### PR TITLE
fix: text overflow issue in the organization switcher dropdown

### DIFF
--- a/packages/web/app/src/components/v2/header.tsx
+++ b/packages/web/app/src/components/v2/header.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement, useCallback, useState } from 'react';
+import { ReactElement, useCallback, useState } from 'react';
 import NextLink from 'next/link';
 import { useQuery } from 'urql';
 
@@ -24,7 +24,7 @@ import {
 type DropdownOrganization = OrganizationsQuery['organizations']['nodes'];
 
 const OrganizationLink = (props: {
-  children: React.ReactChild;
+  children: string;
   href: string;
 }): ReactElement => {
   return (


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/14338007/169060205-5d13d21c-bd40-4e37-b71c-722a2120bece.png)

After:

<img width="331" alt="image" src="https://user-images.githubusercontent.com/14338007/169060250-24ed1de4-15ad-419d-b7ca-065729cbd3cd.png">
