### PR TITLE
Small changes to the version card

### DIFF
--- a/packages/web/app/pages/[orgId]/[projectId]/[targetId]/schema.tsx
+++ b/packages/web/app/pages/[orgId]/[projectId]/[targetId]/schema.tsx
@@ -132,8 +132,10 @@ const SchemaPage: FC = () => {
     >
       <a
         className={clsx(
-          'flex flex-col rounded-[10px] p-2.5 hover:bg-gray-800',
-          router.versionId && router.versionId === version.id && 'bg-gray-800'
+          'flex flex-col rounded-[10px] p-2.5 hover:bg-gray-800/40',
+          router.versionId && 
+            router.versionId === version.id &&
+            'bg-gray-800/40'
         )}
       >
         <h3 className="truncate font-bold">{version.commit.commit}</h3>


### PR DESCRIPTION
Removed unnecessary text and used only data we get from graphql api.

Before:
![Zrzut ekranu 2022-05-18 o 16 43 49](https://user-images.githubusercontent.com/8167190/169070955-bca8ced1-a110-4876-ab0b-ea13bd0ed62f.png)

After:
![Zrzut ekranu 2022-05-18 o 16 48 16](https://user-images.githubusercontent.com/8167190/169070966-c28fc1f6-d81a-4568-9bc5-ce7d7a8d8321.png)
