### PR TITLE
fix copy to clipboard and tabs styles in Safari

### DIFF
--- a/packages/web/app/pages/_document.tsx
+++ b/packages/web/app/pages/_document.tsx
@@ -36,8 +36,8 @@ export default class MyDocument extends Document {
             id="force-dark-mode"
             dangerouslySetInnerHTML={{
               __html: `
-              localStorage['chakra-ui-color-mode'] = 'dark';
-              document.documentElement.classList.add('dark');
+                localStorage['chakra-ui-color-mode'] = 'dark';
+                document.documentElement.classList.add('dark');
               `,
             }}
           />

--- a/packages/web/app/src/components/v2/tabs.tsx
+++ b/packages/web/app/src/components/v2/tabs.tsx
@@ -41,6 +41,7 @@ Tabs.Trigger = forwardRef(
     <Trigger
       ref={forwardedRef as any}
       className={clsx(
+        '!appearance-none', // unset button styles in Safari
         `
   radix-state-active:text-white
   font-bold

--- a/packages/web/app/src/lib/hooks/use-clipboard.ts
+++ b/packages/web/app/src/lib/hooks/use-clipboard.ts
@@ -6,33 +6,17 @@ export function useClipboard() {
 
   return useCallback(
     async (text: string): Promise<void> => {
-      const result = await navigator.permissions.query({
-        name: 'clipboard-write' as any,
-      });
-
-      if (result.state === 'denied') {
+      if (!navigator?.clipboard) {
         notify('Access to clipboard rejected!', 'error');
         return;
       }
-      // TODO: toast throws when used in Modal and modal's Portal is document.body
-      const isV2 = window.location.pathname.startsWith('/v2');
       try {
         await navigator.clipboard.writeText(text);
-        if (!isV2) {
-          notify('Copied to clipboard!', 'info');
-        }
-      } catch (e) {
-        if (!isV2) {
-          notify('Failed to copy!', 'error');
-        }
+        notify('Copied to clipboard!', 'info');
+      } catch {
+        notify('Failed to copy!', 'error');
       }
     },
     [notify]
   );
 }
-
-// navigator.permissions.query({name: "clipboard-write"}).then(result => {
-//   if (result.state == "granted" || result.state == "prompt") {
-//     /* write to the clipboard now */
-//   }
-// });


### PR DESCRIPTION
fixes https://github.com/kamilkisiela/graphql-hive/issues/64
could reproduce and fix in Safari
1. 
![image](https://user-images.githubusercontent.com/7361780/170064100-508ba910-6432-4918-980c-d963ebdc21a8.png)
2.
![image](https://user-images.githubusercontent.com/7361780/170064244-29238319-17fd-46be-ba16-c64ea03c70e2.png)
