### PR TITLE
chore: enable TypeScript flags noImplicitThis, strictBindCallApply and alwaysStrict for @hive/app

### DIFF
--- a/packages/web/app/tsconfig.json
+++ b/packages/web/app/tsconfig.json
@@ -8,6 +8,9 @@
 
     "strict": false,
     "useUnknownInCatchVariables": true,
+    "noImplicitThis": true,
+    "strictBindCallApply": true,
+    "alwaysStrict": true,
 
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,


### PR DESCRIPTION
Enables the TypeScript strict mode rules that require no additional code adjustments.

Please first merge https://github.com/kamilkisiela/graphql-hive/pull/82 - then rebase this branch upon origin/main and change the target branch to main.