### PR TITLE
Refactor rate-limit to support multi-targets orgs

### DIFF
--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -299,6 +299,7 @@ export interface Storage {
   getGetOrganizationsAndTargetPairsWithLimitInfo(): Promise<
     ReadonlyArray<{
       organization: string;
+      org_name: string;
       target: string;
       limit_operations_monthly: number;
       limit_schema_push_monthly: number;

--- a/packages/services/rate-limit/src/api.ts
+++ b/packages/services/rate-limit/src/api.ts
@@ -32,11 +32,7 @@ export const rateLimitApiRouter = trpc
   .query('checkRateLimit', {
     input: VALIDATION,
     async resolve({ ctx, input }) {
-      ctx.logger.info(`checkRateLimit called, input is: %o`, input);
-      const result = await ctx.checkLimit(input);
-      ctx.logger.info(`checkRateLimit done, result is: %o`, input);
-
-      return result;
+      return ctx.checkLimit(input);
     },
   });
 

--- a/packages/services/rate-limit/src/metrics.ts
+++ b/packages/services/rate-limit/src/metrics.ts
@@ -3,11 +3,11 @@ import { metrics } from '@hive/service-common';
 export const rateLimitSchemaEventOrg = new metrics.Counter({
   name: 'rate_limited_schema_events_count',
   help: 'Rate limit events per org id, for schema pushses.',
-  labelNames: ['orgId'],
+  labelNames: ['orgId', 'orgName'],
 });
 
 export const rateLimitOperationsEventOrg = new metrics.Counter({
   name: 'rate_limited_operations_events_count',
   help: 'Rate limit events per org id, for operations.',
-  labelNames: ['orgId'],
+  labelNames: ['orgId', 'orgName'],
 });

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -1590,6 +1590,7 @@ export async function createStorage(connection: string): Promise<Storage> {
       const results = await pool.query<
         Slonik<{
           organization: string;
+          org_name: string;
           target: string;
           limit_operations_monthly: number;
           limit_schema_push_monthly: number;
@@ -1599,6 +1600,7 @@ export async function createStorage(connection: string): Promise<Storage> {
         sql`
           SELECT 
             o.id as organization,
+            o.name as org_name,
             o.limit_operations_monthly,
             o.limit_schema_push_monthly,
             o.limit_retention_days,

--- a/packages/services/usage/src/index.ts
+++ b/packages/services/usage/src/index.ts
@@ -9,6 +9,7 @@ import {
   httpRequestsWithNonExistingToken,
   httpRequestsWithNoAccess,
   collectLatency,
+  droppedReports,
 } from './metrics';
 import type { IncomingLegacyReport, IncomingReport } from './types';
 import { createUsageRateLimit } from './rate-limit';
@@ -112,7 +113,7 @@ async function main() {
             entityType: 'target',
           })
         ) {
-          // TODO: We should trigger a call to update the KV in the WAF in case we want to make sure token is being blocked?
+          droppedReports.labels({ targetId: tokenInfo.target }).inc();
           res.status(429).send();
 
           return;

--- a/packages/services/usage/src/metrics.ts
+++ b/packages/services/usage/src/metrics.ts
@@ -40,6 +40,12 @@ export const totalReports = new metrics.Counter({
   help: 'Number of reports received by usage service',
 });
 
+export const droppedReports = new metrics.Counter({
+  name: 'usage_rate_limit_dropped',
+  help: 'Number of reports dropped by usage service due to rate-limit',
+  labelNames: ['targetId'],
+});
+
 export const totalLegacyReports = new metrics.Counter({
   name: 'usage_reports_legacy_format_total',
   help: 'Number of legacy-format reports received by usage service',

--- a/packages/web/app/src/graphql/fragments.graphql
+++ b/packages/web/app/src/graphql/fragments.graphql
@@ -4,11 +4,6 @@ fragment OrganizationFields on Organization {
   name
   type
   plan
-  rateLimit {
-    operations
-    schemaPushes
-    retentionInDays
-  }
   me {
     ...MemberFields
   }


### PR DESCRIPTION
- [x] Add more nice logging (org name)
- [x] Improve metrics and add orgName to metrics reported
- [x] Refactor calculation and simplify service code
- [x] Fix bug where rate-limit was not calculated correctly for an org (i was using a single target, instead of an aggregation of all targets)
- [x] Added metrics for the amount of dropped reports in usage service 
- [x] Change OrganizationFields fragment and don't load rate-limit info for all orgs loaded 