### PR TITLE
Fix validation of git repository identifier

### DIFF
--- a/packages/services/api/src/modules/project/resolvers.ts
+++ b/packages/services/api/src/modules/project/resolvers.ts
@@ -8,6 +8,10 @@ import { z } from 'zod';
 
 const ProjectNameModel = z.string().min(2).max(40);
 const URLModel = z.string().url().max(200);
+const RepoOwnerWithNameModel = z
+  .string()
+  .regex(/^[^/]+\/[^/]+$/, 'Expected owner/name format')
+  .max(200);
 const MaybeModel = <T extends z.ZodType>(value: T) => z.union([z.null(), z.undefined(), value]);
 
 export const resolvers: ProjectModule.Resolvers & { ProjectType: any } = {
@@ -137,7 +141,7 @@ export const resolvers: ProjectModule.Resolvers & { ProjectType: any } = {
     },
     async updateProjectGitRepository(_, { input }, { injector }) {
       const UpdateProjectGitRepositoryModel = z.object({
-        gitRepository: MaybeModel(URLModel),
+        gitRepository: MaybeModel(RepoOwnerWithNameModel),
       });
 
       const result = UpdateProjectGitRepositoryModel.safeParse(input);


### PR DESCRIPTION
Validation logic of the git repository field in the project's settings expected an URL instead of the `owner/name` format