### PR TITLE
Use paginated table in Admin Stats

### DIFF
--- a/packages/services/storage/package.json
+++ b/packages/services/storage/package.json
@@ -14,7 +14,7 @@
     "migration:rollback": "yarn db:migrator down",
     "db:generate": "schemats generate --config schemats.cjs -o src/db/types.ts",
     "db:start": "docker-compose up -d --remove-orphans",
-    "db:dev": "docker compose up --remove-orphans",
+    "db:dev": "docker compose up --remove-orphans --abort-on-container-exit",
     "build": "bob runify --single",
     "postbuild": "copyfiles -f \"migrations/actions/*.sql\" dist/actions && copyfiles -f \"migrations/actions/down/*.sql\" dist/actions/down"
   },

--- a/packages/web/app/src/components/target/operations/List.tsx
+++ b/packages/web/app/src/components/target/operations/List.tsx
@@ -204,7 +204,7 @@ const OperationsTable: React.FC<{
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
-    debugTable: true,
+    debugTable: process.env.NODE_ENV !== 'production',
   });
 
   const firstPage = React.useCallback(() => {


### PR DESCRIPTION
Combining react-window with react-table and chakra-ui is too weird... 
The goal is to improve the performance of the table and pagination works just fine.