### PR TITLE
Simplify the schema publishing logic

### DIFF
--- a/.changeset/strong-pandas-brake.md
+++ b/.changeset/strong-pandas-brake.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': minor
+---
+
+Support SchemaPublishMissingUrlError type

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       - 'stack'
 
   zookeeper:
-    image: confluentinc/cp-zookeeper:6.2.2-3-ubi8
+    image: confluentinc/cp-zookeeper:7.1.1-1-ubi8.amd64
     hostname: zookeeper
     networks:
       - 'stack'
@@ -48,17 +48,17 @@ services:
         soft: 20000
         hard: 40000
     healthcheck:
-      test: ['CMD', 'cub', 'zk-ready', '127.0.0.1:2181', '10']
-      interval: 5s
-      timeout: 10s
-      retries: 6
-      start_period: 15s
+      test: ['CMD', 'cub', 'zk-ready', '127.0.0.1:2181', '1']
+      interval: 2s
+      timeout: 1s
+      retries: 10
+      start_period: 5s
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
 
   broker:
-    image: confluentinc/cp-kafka:6.2.2-3-ubi8
+    image: confluentinc/cp-kafka:7.1.1-1-ubi8.amd64
     hostname: borker
     depends_on:
       zookeeper:

--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -51,8 +51,8 @@ services:
       test: ['CMD', 'cub', 'zk-ready', '127.0.0.1:2181', '1']
       interval: 2s
       timeout: 1s
-      retries: 10
-      start_period: 5s
+      retries: 20
+      start_period: 10s
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000

--- a/integration-tests/dockest.ts
+++ b/integration-tests/dockest.ts
@@ -14,7 +14,7 @@ async function main() {
         transform: {
           '^.+\\.ts$': 'ts-jest',
         },
-        testTimeout: 45_000,
+        testTimeout: 60_000,
         maxConcurrency: 1,
         setupFiles: ['dotenv/config'],
         setupFilesAfterEnv: ['./jest-setup.ts'],

--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -400,6 +400,7 @@ export function fetchLatestSchema(token: string) {
             nodes {
               source
               commit
+              url
             }
             total
           }

--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -414,7 +414,7 @@ test('should allow to update the URL of a Federated service without changing the
 
   expect(updateResult.body.errors).not.toBeDefined();
   expect(updateResult.body.data!.schemaPublish.__typename).toBe('SchemaPublishSuccess');
-  expect(updateResult.body.data!.schemaPublish['message']).toBe(
+  expect((updateResult.body.data!.schemaPublish as any).message).toBe(
     'Updated: New service url: http://localhost:3000/test/graphql (previously: empty)'
   );
 });

--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -412,6 +412,8 @@ test('should allow to update the URL of a Federated service without changing the
     writeToken
   );
 
+  console.log(updateResult.body);
+
   expect(updateResult.body.errors).not.toBeDefined();
 });
 

--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -412,9 +412,101 @@ test('should allow to update the URL of a Federated service without changing the
     writeToken
   );
 
+  expect(updateResult.body.errors).not.toBeDefined();
+  expect(updateResult.body.data!.schemaPublish.__typename).toBe('SchemaPublishSuccess');
+  expect(updateResult.body.data!.schemaPublish['message']).toBe(
+    'Updated: New service url: http://localhost:3000/test/graphql (previously: empty)'
+  );
+});
+
+test('should allow to update the URL of a Federated service while also changing the schema', async () => {
+  const { access_token: owner_access_token } = await authenticate('main');
+  const orgResult = await createOrganization(
+    {
+      name: 'foo',
+    },
+    owner_access_token
+  );
+  const org = orgResult.body.data!.createOrganization.ok!.createdOrganizationPayload.organization;
+
+  const projectResult = await createProject(
+    {
+      organization: org.cleanId,
+      type: ProjectType.Federation,
+      name: 'foo',
+    },
+    owner_access_token
+  );
+
+  const project = projectResult.body.data!.createProject.ok!.createdProject;
+  const target = projectResult.body.data!.createProject.ok!.createdTarget;
+
+  // Create a token with write rights
+  const writeTokenResult = await createToken(
+    {
+      name: 'test',
+      organization: org.cleanId,
+      project: project.cleanId,
+      target: target.cleanId,
+      organizationScopes: [],
+      projectScopes: [],
+      targetScopes: [TargetAccessScope.RegistryRead, TargetAccessScope.RegistryWrite],
+    },
+    owner_access_token
+  );
+  expect(writeTokenResult.body.errors).not.toBeDefined();
+  const writeToken = writeTokenResult.body.data!.createToken.ok!.secret;
+
+  const basePublishParams = {
+    service: 'test',
+    author: 'Kamil',
+    commit: 'abc123',
+    sdl: `type Query { me: User } type User @key(fields: "id") { id: ID! name: String }`,
+  };
+
+  const publishResult = await publishSchema(basePublishParams, writeToken);
+
+  // Schema publish should be successful
+  expect(publishResult.body.errors).not.toBeDefined();
+  expect(publishResult.body.data!.schemaPublish.__typename).toBe('SchemaPublishSuccess');
+
+  const versionsResult = await fetchVersions(
+    {
+      organization: org.cleanId,
+      project: project.cleanId,
+      target: target.cleanId,
+    },
+    5,
+    writeToken
+  );
+
+  expect(versionsResult.body.errors).not.toBeDefined();
+  expect(versionsResult.body.data!.schemaVersions.nodes).toHaveLength(1);
+
+  const latestResult = await fetchLatestSchema(writeToken);
+  expect(latestResult.body.errors).not.toBeDefined();
+  expect(latestResult.body.data!.latestVersion.schemas.total).toBe(1);
+  expect(latestResult.body.data!.latestVersion.schemas.nodes[0].commit).toBe('abc123');
+  expect(latestResult.body.data!.latestVersion.schemas.nodes[0].source).toMatch(
+    `type Query { me: User } type User @key(fields: "id") { id: ID! name: String }`
+  );
+
+  // try to update the schema again, with force and url set
+  const updateResult = await publishSchema(
+    {
+      ...basePublishParams,
+      force: true,
+      url: `http://localhost:3000/test/graphql`,
+      // here, we also add something minor to the schema, just to trigger the publish flow and not just the URL update flow
+      sdl: `type Query { me: User } type User @key(fields: "id") { id: ID! name: String age: Int }`,
+    },
+    writeToken
+  );
+
   console.log(updateResult.body);
 
   expect(updateResult.body.errors).not.toBeDefined();
+  expect(updateResult.body.data!.schemaPublish.__typename).toBe('SchemaPublishSuccess');
 });
 
 test('directives should not be removed (stitching)', async () => {

--- a/integration-tests/tests/api/target/usage.spec.ts
+++ b/integration-tests/tests/api/target/usage.spec.ts
@@ -16,7 +16,7 @@ import {
 import { authenticate } from '../../../testkit/auth';
 import { collect, CollectedOperation } from '../../../testkit/usage';
 import { clickHouseQuery } from '../../../testkit/clickhouse';
-// eslint-disable-next-line import/no-extraneous-dependencies
+// eslint-disable-next-line import/no-extraneous-dependencies, hive/enforce-deps-in-dev
 import { normalizeOperation } from '@graphql-hive/core';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { parse, print } from 'graphql';
@@ -372,7 +372,7 @@ test('normalize and collect operation without breaking its syntax', async () => 
   expect(op.percentage).toBeGreaterThan(99);
 });
 
-test('number of produced and collected operations should match', async () => {
+test('number of produced and collected operations should match (no errors)', async () => {
   const { access_token: owner_access_token } = await authenticate('main');
   const orgResult = await createOrganization(
     {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "jest": "28.1.0",
     "lint-staged": "11.2.6",
     "patch-package": "6.4.7",
-    "prettier": "2.4.1",
+    "prettier": "2.7.1",
     "prettier-plugin-tailwindcss": "0.1.10",
     "pretty-quick": "3.1.3",
     "rimraf": "3.0.2",

--- a/packages/libraries/cli/src/commands/schema/publish.graphql
+++ b/packages/libraries/cli/src/commands/schema/publish.graphql
@@ -32,6 +32,9 @@ mutation schemaPublish($input: SchemaPublishInput!, $usesGitHubApp: Boolean!) {
     ... on SchemaPublishMissingServiceError @skip(if: $usesGitHubApp) {
       missingServiceError: message
     }
+    ... on SchemaPublishMissingUrlError @skip(if: $usesGitHubApp) {
+      missingUrlError: message
+    }
     ... on GitHubSchemaPublishSuccess @include(if: $usesGitHubApp) {
       message
     }

--- a/packages/libraries/cli/src/commands/schema/publish.ts
+++ b/packages/libraries/cli/src/commands/schema/publish.ts
@@ -175,6 +175,9 @@ export default class SchemaPublish extends Command {
       } else if (result.schemaPublish.__typename === 'SchemaPublishMissingServiceError') {
         this.fail(`${result.schemaPublish.missingServiceError} Please use the '--service <name>' parameter.`);
         this.exit(1);
+      } else if (result.schemaPublish.__typename === 'SchemaPublishMissingUrlError') {
+        this.fail(`${result.schemaPublish.missingUrlError} Please use the '--url <url>' parameter.`);
+        this.exit(1);
       } else if (result.schemaPublish.__typename === 'SchemaPublishError') {
         const changes = result.schemaPublish.changes;
         const errors = result.schemaPublish.errors;

--- a/packages/libraries/client/src/version.ts
+++ b/packages/libraries/client/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.15.2';
+export const version = '0.15.4';

--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -83,6 +83,7 @@ export default gql`
       SchemaPublishSuccess
     | SchemaPublishError
     | SchemaPublishMissingServiceError
+    | SchemaPublishMissingUrlError
     | GitHubSchemaPublishSuccess
     | GitHubSchemaPublishError
 
@@ -170,6 +171,10 @@ export default gql`
   }
 
   type SchemaPublishMissingServiceError {
+    message: String!
+  }
+
+  type SchemaPublishMissingUrlError {
     message: String!
   }
 

--- a/packages/services/api/src/modules/schema/providers/schema-manager.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-manager.ts
@@ -286,23 +286,6 @@ export class SchemaManager {
       service = service.toLowerCase();
     }
 
-    // if schema exists
-    const existingSchema = await this.storage.getMaybeSchema({
-      commit,
-      service,
-      organization,
-      project,
-      target,
-    });
-
-    if (existingSchema) {
-      if (service) {
-        throw new HiveError(`Only one service schema per commit per target is allowed`);
-      }
-
-      throw new HiveError(`Only one schema per commit per target is allowed`);
-    }
-
     // insert new schema
     const insertedSchema = await this.insertSchema({
       organization,

--- a/packages/services/api/src/modules/schema/resolvers.ts
+++ b/packages/services/api/src/modules/schema/resolvers.ts
@@ -58,6 +58,10 @@ export const resolvers: SchemaModule.Resolvers = {
       // NOTE: This should be removed once the usage of cli versions that don't request on 'SchemaPublishMissingServiceError' is becomes pretty low.
       const isSchemaPublishMissingServiceErrorSelected =
         !!parsedResolveInfoFragment?.fieldsByTypeName['SchemaPublishMissingServiceError'];
+      // We only want to resolve to SchemaPublishMissingUrlError if it is selected by the operation.
+      // NOTE: This should be removed once the usage of cli versions that don't request on 'SchemaPublishMissingUrlError' is becomes pretty low.
+      const isSchemaPublishMissingUrlErrorSelected =
+        !!parsedResolveInfoFragment?.fieldsByTypeName['SchemaPublishMissingUrlError'];
 
       return injector.get(SchemaPublisher).publish({
         ...input,
@@ -66,6 +70,7 @@ export const resolvers: SchemaModule.Resolvers = {
         project,
         target,
         isSchemaPublishMissingServiceErrorSelected,
+        isSchemaPublishMissingUrlErrorSelected,
       });
     },
     async updateSchemaVersionStatus(_, { input }, { injector }) {

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -206,13 +206,6 @@ export interface Storage {
     }[]
   >;
 
-  getMaybeSchema(
-    _: {
-      commit: string;
-      service?: string | null;
-    } & TargetSelector
-  ): Promise<Schema | null>;
-
   createActivity(
     _: {
       user: string;

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -1267,25 +1267,6 @@ export async function createStorage(connection: string): Promise<Storage> {
         return Promise.reject(new Error(`Schema not found (commit=${selector.commit}, target=${selector.target})`));
       });
     }),
-
-    async getMaybeSchema({ commit, service, project, target }) {
-      const result = await pool.maybeOne<Slonik<WithUrl<commits>>>(
-        sql`
-          SELECT c.* FROM public.commits as c
-          LEFT JOIN public.projects as p ON (p.id = c.project_id)
-          WHERE 
-            c.commit = ${commit}
-            AND c.project_id = ${project}
-            AND c.target_id = ${target}
-            AND c.service = ${service ?? null}`
-      );
-
-      if (!result) {
-        return null;
-      }
-
-      return transformSchema(result);
-    },
     async createActivity({ organization, project, target, user, type, meta }) {
       const { identifiers, values } = objectToParams<Omit<activities, 'id' | 'created_at'>>({
         activity_metadata: meta,

--- a/yarn.lock
+++ b/yarn.lock
@@ -14597,10 +14597,10 @@ prettier-plugin-tailwindcss@0.1.10:
   resolved "https://registry.yarnpkg.com/prettier-plugin-tailwindcss/-/prettier-plugin-tailwindcss-0.1.10.tgz#437bd0757819c8393fc780e17e50e8a7518e2a6b"
   integrity sha512-ooDGNuXUjgCXfShliVYQ6+0iXqUFXn+zdNInPe0WZN9qINt9srbLGFGY5jeVL4MXtY20/4S8JaBcd8l6N6NfCQ==
 
-prettier@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.4.1.tgz#671e11c89c14a4cfc876ce564106c4a6726c9f5c"
-  integrity sha512-9fbDAXSBcc6Bs1mZrDYb3XKzDLm4EXXL9sC1LqKP5rZkT6KRr/rf9amVUcODVXgguK/isJz0d0hP72WeaKWsvA==
+prettier@2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 prettier@^1.19.1:
   version "1.19.1"


### PR DESCRIPTION
- Removes the uniqueness requirement of commit it
- Makes the logic of schema publishing simpler and more readable
- Updating the service url results in a new version (previously na update of existing version)
- Introduces a requirement of defining service url in federated projects (new `SchemaPublishMissingUrlError` type)