### PR TITLE
Pass x-request-id to tRPC

### DIFF
--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@hive/schema": "0.0.0",
     "@hive/tokens": "0.0.0",
+    "@hive/webhooks": "0.0.0",
     "@graphql-hive/core": "0.2.2",
     "@types/auth0": "2.34.2",
     "@types/ioredis": "4.28.7",

--- a/packages/services/api/src/modules/alerts/providers/adapters/common.ts
+++ b/packages/services/api/src/modules/alerts/providers/adapters/common.ts
@@ -7,8 +7,8 @@ export interface SchemaChangeNotificationInput {
     project: Pick<Project, 'id' | 'cleanId' | 'name'>;
     target: Pick<Target, 'id' | 'cleanId' | 'name'>;
     schema: Pick<SchemaVersion, 'id' | 'commit' | 'valid'>;
-    changes: readonly Types.SchemaChange[];
-    errors: readonly Types.SchemaError[];
+    changes: Types.SchemaChange[];
+    errors: Types.SchemaError[];
     initial: boolean;
   };
   alert: Alert;

--- a/packages/services/api/src/modules/alerts/providers/adapters/webhook.ts
+++ b/packages/services/api/src/modules/alerts/providers/adapters/webhook.ts
@@ -1,16 +1,34 @@
-import { Injectable, Inject } from 'graphql-modules';
+import { Injectable, Inject, Scope, CONTEXT } from 'graphql-modules';
+import type { WebhooksApi } from '@hive/webhooks';
+import { createTRPCClient } from '@trpc/client';
+import { fetch } from 'cross-undici-fetch';
 import type { CommunicationAdapter, SchemaChangeNotificationInput } from './common';
 import { Logger } from '../../../shared/providers/logger';
 import { HttpClient } from '../../../shared/providers/http-client';
 import { WEBHOOKS_CONFIG } from '../tokens';
 import type { WebhooksConfig } from '../tokens';
 
-@Injectable()
+@Injectable({
+  scope: Scope.Operation,
+})
 export class WebhookCommunicationAdapter implements CommunicationAdapter {
   private logger: Logger;
+  private webhooksService;
 
-  constructor(logger: Logger, private http: HttpClient, @Inject(WEBHOOKS_CONFIG) private config: WebhooksConfig) {
+  constructor(
+    logger: Logger,
+    private http: HttpClient,
+    @Inject(WEBHOOKS_CONFIG) private config: WebhooksConfig,
+    @Inject(CONTEXT) context: GraphQLModules.ModuleContext
+  ) {
     this.logger = logger.child({ service: 'WebhookCommunicationAdapter' });
+    this.webhooksService = createTRPCClient<WebhooksApi>({
+      url: `${config.endpoint}/trpc`,
+      fetch,
+      headers: {
+        'x-request-id': context.requestId,
+      },
+    });
   }
 
   async sendSchemaChangeNotification(input: SchemaChangeNotificationInput) {
@@ -21,22 +39,9 @@ export class WebhookCommunicationAdapter implements CommunicationAdapter {
       input.event.target.id
     );
     try {
-      await this.http.post(this.config.endpoint + '/schedule', {
-        headers: {
-          'Accept-Encoding': 'gzip, deflate, br',
-          'Content-Type': 'application/json',
-        },
-        retry: { limit: 3 },
-        timeout: {
-          socket: 1000,
-          connect: 1000,
-          secureConnect: 1000,
-          request: 10_000,
-        },
-        json: {
-          endpoint: input.channel.webhookEndpoint,
-          event: input.event,
-        },
+      await this.webhooksService.mutation('schedule', {
+        endpoint: input.channel.webhookEndpoint!,
+        event: input.event,
       });
     } catch (error) {
       this.logger.error(`Failed to send Webhook notification`, error);

--- a/packages/services/api/src/modules/feedback/resolvers.ts
+++ b/packages/services/api/src/modules/feedback/resolvers.ts
@@ -26,7 +26,6 @@ export const resolvers: FeedbackModule.Resolvers = {
           text: [`Got a feedback from \`${user.email}\``, `> ${feedback}`].join('\n'),
         }),
       ]).catch(error => {
-        console.log('Feedback.sendFeedback error', error);
         Sentry.captureException(error, {
           extra: {
             feedback,

--- a/packages/services/api/src/modules/schema/providers/orchestrators/stitching.ts
+++ b/packages/services/api/src/modules/schema/providers/orchestrators/stitching.ts
@@ -1,4 +1,4 @@
-import { Injectable, Inject } from 'graphql-modules';
+import { Injectable, Inject, Scope, CONTEXT } from 'graphql-modules';
 import { parse } from 'graphql';
 import { Logger } from '../../../shared/providers/logger';
 import { Orchestrator, ProjectType, SchemaObject } from '../../../../shared/entities';
@@ -10,17 +10,26 @@ import { createTRPCClient } from '@trpc/client';
 import { fetch } from 'cross-undici-fetch';
 import type { SchemaBuilderApi } from '@hive/schema';
 
-@Injectable()
+@Injectable({
+  scope: Scope.Operation,
+})
 export class StitchingOrchestrator implements Orchestrator {
   type = ProjectType.STITCHING;
   private logger: Logger;
   private schemaService;
 
-  constructor(logger: Logger, @Inject(SCHEMA_SERVICE_CONFIG) private serviceConfig: SchemaServiceConfig) {
+  constructor(
+    logger: Logger,
+    @Inject(SCHEMA_SERVICE_CONFIG) serviceConfig: SchemaServiceConfig,
+    @Inject(CONTEXT) context: GraphQLModules.ModuleContext
+  ) {
     this.logger = logger.child({ service: 'StitchingOrchestrator' });
     this.schemaService = createTRPCClient<SchemaBuilderApi>({
       url: `${serviceConfig.endpoint}/trpc`,
       fetch,
+      headers: {
+        'x-request-id': context.requestId,
+      },
     });
   }
 

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -573,8 +573,8 @@ export class SchemaPublisher {
     organizationId: string;
     newSchema: Schema;
     schemas: readonly Schema[];
-    changes: readonly Types.SchemaChange[];
-    errors: readonly Types.SchemaError[];
+    changes: Types.SchemaChange[];
+    errors: Types.SchemaError[];
     initial: boolean;
   }) {
     const commits = schemas

--- a/packages/services/api/src/modules/shared/providers/http-client.ts
+++ b/packages/services/api/src/modules/shared/providers/http-client.ts
@@ -56,7 +56,6 @@ export class HttpClient {
         return Promise.resolve(response.body);
       },
       error => {
-        console.log('HttpClient.request error', error);
         console.error(error);
         Sentry.captureException(error);
 

--- a/packages/services/api/src/modules/shared/providers/tracking.ts
+++ b/packages/services/api/src/modules/shared/providers/tracking.ts
@@ -24,7 +24,6 @@ export class Tracking {
         data: event.data,
       });
     } catch (error) {
-      console.log('Tracking.track error', error);
       Sentry.captureException(error);
     }
   }

--- a/packages/services/api/src/modules/token/providers/token-storage.ts
+++ b/packages/services/api/src/modules/token/providers/token-storage.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, Scope } from 'graphql-modules';
+import { Inject, Injectable, Scope, CONTEXT } from 'graphql-modules';
 import { atomic } from '../../../shared/helpers';
 import { HiveError } from '../../../shared/errors';
 import type { Token } from '../../../shared/entities';
@@ -38,11 +38,18 @@ export class TokenStorage {
   private logger: Logger;
   private tokensService;
 
-  constructor(logger: Logger, @Inject(TOKENS_CONFIG) tokensConfig: TokensConfig) {
+  constructor(
+    logger: Logger,
+    @Inject(TOKENS_CONFIG) tokensConfig: TokensConfig,
+    @Inject(CONTEXT) context: GraphQLModules.ModuleContext
+  ) {
     this.logger = logger.child({ source: 'TokenStorage' });
     this.tokensService = createTRPCClient<TokensApi>({
       url: `${tokensConfig.endpoint}/trpc`,
       fetch,
+      headers: {
+        'x-request-id': context.requestId,
+      },
     });
   }
 

--- a/packages/services/api/src/shared/sentry.ts
+++ b/packages/services/api/src/shared/sentry.ts
@@ -45,7 +45,6 @@ export function sentry(name: string, addToContext?: (...args: any[]) => SentryCo
           return Promise.resolve(result);
         },
         error => {
-          console.log('sentry decorator error', error);
           Sentry.captureException(error);
           span.setStatus('internal_error');
           span.finish();

--- a/packages/services/schema/src/index.ts
+++ b/packages/services/schema/src/index.ts
@@ -9,7 +9,8 @@ import {
 } from '@hive/service-common';
 import * as Sentry from '@sentry/node';
 import Redis from 'ioredis';
-import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify/dist/trpc-server-adapters-fastify.cjs.js';
+import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
+import type { CreateFastifyContextOptions } from '@trpc/server/adapters/fastify';
 import { schemaBuilderApiRouter } from './api';
 
 async function main() {
@@ -74,17 +75,14 @@ async function main() {
     });
 
     const port = process.env.PORT || 6500;
-    const context = {
-      redis,
-      logger: server.log,
-      errorHandler,
-    };
 
     await server.register(fastifyTRPCPlugin, {
       prefix: '/trpc',
       trpcOptions: {
         router: schemaBuilderApiRouter,
-        createContext: () => context,
+        createContext({ req }: CreateFastifyContextOptions) {
+          return { redis, logger: req.log, errorHandler };
+        },
       },
     });
 

--- a/packages/services/schema/src/orchestrators.ts
+++ b/packages/services/schema/src/orchestrators.ts
@@ -232,13 +232,10 @@ function validateStitchedSchema(doc: DocumentNode) {
 export function pickOrchestrator(type: SchemaType, redis: RedisInstance, logger: FastifyLoggerInstance) {
   switch (type) {
     case 'federation':
-      logger.debug('Using federation orchestrator');
       return createFederation(redis, logger);
     case 'single':
-      logger.debug('Using single orchestrator');
       return single;
     case 'stitching':
-      logger.debug('Using stitching orchestrator');
       return createStitching(redis, logger);
     default:
       throw new Error(`Unknown schema type: ${type}`);

--- a/packages/services/server/package.json
+++ b/packages/services/server/package.json
@@ -22,6 +22,7 @@
     "dotenv": "10.0.0",
     "got": "12.0.4",
     "graphql": "16.5.0",
+    "hyperid": "2.3.1",
     "reflect-metadata": "0.1.13"
   },
   "devDependencies": {

--- a/packages/services/server/src/graphql-handler.ts
+++ b/packages/services/server/src/graphql-handler.ts
@@ -10,6 +10,9 @@ import { asyncStorage } from './async-storage';
 import { useSentryUser, extractUserId } from './use-sentry-user';
 import { useHive } from '@graphql-hive/client';
 import { useErrorHandler, Plugin } from '@graphql-yoga/node';
+import hyperid from 'hyperid';
+
+const reqIdGenerate = hyperid({ fixedLength: true });
 
 export interface GraphQLHandlerOptions {
   graphiqlEndpoint: string;
@@ -144,7 +147,7 @@ export const graphqlHandler = (options: GraphQLHandlerOptions): RouteHandlerMeth
   });
 
   return async (req, reply) => {
-    const requestIdHeader = req.headers['x-request-id'];
+    const requestIdHeader = req.headers['x-request-id'] ?? reqIdGenerate();
     const requestId = cleanRequestId(requestIdHeader);
 
     await asyncStorage.run(

--- a/packages/services/server/src/graphql-handler.ts
+++ b/packages/services/server/src/graphql-handler.ts
@@ -14,7 +14,6 @@ import { useErrorHandler, Plugin } from '@graphql-yoga/node';
 export interface GraphQLHandlerOptions {
   graphiqlEndpoint: string;
   registry: Registry;
-  onError: (e: Error) => void;
   signature: string;
 }
 
@@ -84,10 +83,6 @@ export const graphqlHandler = (options: GraphQLHandlerOptions): RouteHandlerMeth
       useSentryUser(),
       useErrorHandler(errors => {
         errors?.map(e => server.logger.error(e));
-
-        for (const error of errors) {
-          options.onError(error);
-        }
       })
     );
   }
@@ -96,6 +91,7 @@ export const graphqlHandler = (options: GraphQLHandlerOptions): RouteHandlerMeth
     req: FastifyRequest;
     reply: FastifyReply;
     headers: Record<string, string | string[] | undefined>;
+    requestId?: string | null;
   }>({
     maskedErrors: process.env.ENVIRONMENT === 'prod' || process.env.ENVIRONMENT === 'staging',
     plugins: [
@@ -160,6 +156,7 @@ export const graphqlHandler = (options: GraphQLHandlerOptions): RouteHandlerMeth
           req,
           reply,
           headers: req.headers,
+          requestId,
         });
 
         response.headers.forEach((value, key) => {

--- a/packages/services/server/src/index.ts
+++ b/packages/services/server/src/index.ts
@@ -56,7 +56,6 @@ export async function main() {
       const errorObj = error instanceof Error ? error : errorLike instanceof Error ? errorLike : null;
 
       if (errorObj instanceof Error) {
-        console.log('createErrorHandler', errorObj);
         Sentry.captureException(errorObj, {
           level,
           extra: {
@@ -178,18 +177,6 @@ export async function main() {
       graphiqlEndpoint: graphqlPath,
       registry,
       signature,
-      onError(error) {
-        console.log('graphqlHandler.onError', error);
-        Sentry.captureException(error, {
-          extra: {
-            error,
-            originalError: (error as any).originalError,
-          },
-          level: Sentry.Severity.Error,
-        });
-        graphqlLogger.error(error.message);
-        return graphqlLogger.error(`GraphQL execution failed`, error);
-      },
     });
 
     server.route({

--- a/packages/services/service-common/src/errors.ts
+++ b/packages/services/service-common/src/errors.ts
@@ -3,7 +3,6 @@ import * as Sentry from '@sentry/node';
 
 export function createErrorHandler(server: FastifyInstance) {
   return function errorHandler(message: string, error: Error, logger?: FastifyLoggerInstance) {
-    console.log('createErrorHandler', message, error);
     Sentry.captureException(error);
     if (logger) {
       logger.error(message + '  (error=%s)', error);

--- a/packages/services/service-common/src/fastify.ts
+++ b/packages/services/service-common/src/fastify.ts
@@ -23,12 +23,10 @@ export async function createServer(options: { tracing: boolean; name: string }) 
 
   process
     .on('unhandledRejection', (reason, p) => {
-      console.log('unhandledRejection', reason);
       Sentry.captureException(reason);
       server.log.error(reason as any, 'Unhandled Rejection at Promise', p);
     })
     .on('uncaughtException', err => {
-      console.log('uncaughtException', err);
       Sentry.captureException(err);
       server.log.error(err as any, 'Uncaught Exception thrown');
     });

--- a/packages/services/service-common/src/metrics.ts
+++ b/packages/services/service-common/src/metrics.ts
@@ -33,7 +33,6 @@ export async function startMetrics() {
 
         res.send(result); // eslint-disable-line @typescript-eslint/no-floating-promises -- false positive, FastifyReply.then returns void
       } catch (error) {
-        console.log('metrics error', error);
         res.status(500).send(error); // eslint-disable-line @typescript-eslint/no-floating-promises -- false positive, FastifyReply.then returns void
       }
     },

--- a/packages/services/storage/src/db/sentry.ts
+++ b/packages/services/storage/src/db/sentry.ts
@@ -56,7 +56,6 @@ export const createSentryInterceptor = (): InterceptorType => {
         return null;
       }
 
-      console.log('Sentry interceptor error', error);
       captureException(error, {
         extra: {
           query: context.originalQuery.sql,

--- a/packages/services/tokens/src/index.ts
+++ b/packages/services/tokens/src/index.ts
@@ -13,7 +13,8 @@ import LRU from 'tiny-lru';
 import ms from 'ms';
 import { createStorage } from './storage';
 import { useCache } from './cache';
-import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify/dist/trpc-server-adapters-fastify.cjs.js';
+import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
+import type { CreateFastifyContextOptions } from '@trpc/server/adapters/fastify';
 import { Context, tokensApiRouter } from './api';
 
 export async function main() {
@@ -62,19 +63,19 @@ export async function main() {
 
     const port = process.env.PORT || 6001;
 
-    const context: Context = {
-      errorCachingInterval,
-      logger: server.log,
-      errorHandler,
-      getStorage,
-      tokenReadFailuresCache,
-    };
-
     await server.register(fastifyTRPCPlugin, {
       prefix: '/trpc',
       trpcOptions: {
         router: tokensApiRouter,
-        createContext: () => context,
+        createContext({ req }: CreateFastifyContextOptions): Context {
+          return {
+            errorCachingInterval,
+            logger: req.log,
+            errorHandler,
+            getStorage,
+            tokenReadFailuresCache,
+          };
+        },
       },
     });
 

--- a/packages/services/webhooks/package.json
+++ b/packages/services/webhooks/package.json
@@ -11,6 +11,8 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "zod": "3.15.1",
+    "@trpc/server": "9.23.2",
     "@sentry/node": "6.19.7",
     "@sentry/tracing": "6.19.7",
     "bullmq": "1.81.4",

--- a/packages/services/webhooks/src/api.ts
+++ b/packages/services/webhooks/src/api.ts
@@ -1,0 +1,67 @@
+import * as trpc from '@trpc/server';
+import { inferProcedureInput } from '@trpc/server';
+import { z } from 'zod';
+import type { Context } from './types';
+
+const webhookInput = z
+  .object({
+    endpoint: z.string().nonempty(),
+    event: z
+      .object({
+        organization: z
+          .object({
+            id: z.string().nonempty(),
+            cleanId: z.string().nonempty(),
+            name: z.string().nonempty(),
+          })
+          .required(),
+        project: z
+          .object({
+            id: z.string().nonempty(),
+            cleanId: z.string().nonempty(),
+            name: z.string().nonempty(),
+          })
+          .required(),
+        target: z
+          .object({
+            id: z.string().nonempty(),
+            cleanId: z.string().nonempty(),
+            name: z.string().nonempty(),
+          })
+          .required(),
+        schema: z
+          .object({
+            id: z.string().nonempty(),
+            valid: z.boolean(),
+            commit: z.string().nonempty(),
+          })
+          .required(),
+        changes: z.array(z.any()),
+        errors: z.array(z.any()),
+      })
+      .required(),
+  })
+  .required();
+
+export const webhooksApiRouter = trpc.router<Context>().mutation('schedule', {
+  input: webhookInput,
+  async resolve({ ctx, input }) {
+    try {
+      const job = await ctx.schedule(input);
+
+      return { job: job.id ?? 'unknown' };
+    } catch (error) {
+      ctx.errorHandler('Failed to schedule a webhook', error as Error, ctx.logger);
+      throw error;
+    }
+  },
+});
+
+export type WebhooksApi = typeof webhooksApiRouter;
+export type WebhooksApiMutate = keyof WebhooksApi['_def']['mutations'];
+
+export type WebhooksMutationInput<TRouteKey extends WebhooksApiMutate> = inferProcedureInput<
+  WebhooksApi['_def']['mutations'][TRouteKey]
+>;
+
+export type WebhookInput = WebhooksMutationInput<'schedule'>;

--- a/packages/services/webhooks/src/jobs.ts
+++ b/packages/services/webhooks/src/jobs.ts
@@ -1,7 +1,8 @@
 import { createHash } from 'crypto';
 import { got } from 'got';
 import type { Queue, Job } from 'bullmq';
-import type { Config, WebhookInput } from './types';
+import type { Config } from './types';
+import type { WebhookInput } from './scheduler';
 
 export async function scheduleWebhook({
   queue,

--- a/packages/services/webhooks/src/scheduler.ts
+++ b/packages/services/webhooks/src/scheduler.ts
@@ -2,8 +2,36 @@ import * as Sentry from '@sentry/node';
 import { Queue, QueueScheduler, Worker, Job } from 'bullmq';
 import Redis, { Redis as RedisInstance } from 'ioredis';
 import pTimeout from 'p-timeout';
-import type { WebhookInput, Config } from './types';
+import type { Config } from './types';
 import { scheduleWebhook, createWebhookJob } from './jobs';
+
+export interface WebhookInput {
+  endpoint: string;
+  event: {
+    organization: {
+      id: string;
+      cleanId: string;
+      name: string;
+    };
+    project: {
+      id: string;
+      cleanId: string;
+      name: string;
+    };
+    target: {
+      id: string;
+      cleanId: string;
+      name: string;
+    };
+    schema: {
+      id: string;
+      valid: boolean;
+      commit: string;
+    };
+    changes: any[];
+    errors: any[];
+  };
+}
 
 export function createScheduler(config: Config) {
   let redisConnection: RedisInstance | null;

--- a/packages/services/webhooks/src/types.ts
+++ b/packages/services/webhooks/src/types.ts
@@ -1,4 +1,6 @@
 import type { FastifyLoggerInstance } from '@hive/service-common';
+import type { Job } from 'bullmq';
+import type { WebhookInput } from './scheduler';
 
 export interface Config {
   logger: FastifyLoggerInstance;
@@ -12,30 +14,8 @@ export interface Config {
   backoffDelay: number;
 }
 
-export interface WebhookInput {
-  endpoint: string;
-  event: {
-    organization: {
-      id: string;
-      cleanId: string;
-      name: string;
-    };
-    project: {
-      id: string;
-      cleanId: string;
-      name: string;
-    };
-    target: {
-      id: string;
-      cleanId: string;
-      name: string;
-    };
-    schema: {
-      id: string;
-      valid: boolean;
-      commit: string;
-    };
-    changes: any[];
-    errors: any[];
-  };
+export interface Context {
+  logger: FastifyLoggerInstance;
+  errorHandler(message: string, error: Error, logger?: FastifyLoggerInstance | undefined): void;
+  schedule(webhook: WebhookInput): Promise<Job<any, any, string>>;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -34,7 +34,7 @@
       "@hive/usage-ingestor": ["./packages/services/usage-ingestor/src/index.ts"],
       "@hive/rate-limit": ["./packages/services/rate-limit/src/api.ts"],
       "@hive/tokens": ["./packages/services/tokens/src/api.ts"],
-      "@hive/webhooks": ["./packages/services/webhooks/src/index.ts"],
+      "@hive/webhooks": ["./packages/services/webhooks/src/api.ts"],
       "@graphql-hive/client": ["./packages/libraries/client/src/index.ts"],
       "@graphql-hive/core": ["./packages/libraries/core/src/index.ts"],
       "@hive/storage": ["./packages/services/storage/src/index.ts"]


### PR DESCRIPTION
- No Sentry reporting for GraphQLErrors
- [No more debugging of that sentry issue](https://github.com/kamilkisiela/graphql-hive/commit/e7122b235310d0b9ca07d02931eafafee30926cc)
- Passes x-request-id to tRPC and uses `fastifyRequest.log` for logging (that extracts x-request-id and shows it in the log message)