### PR TITLE
Expose link to website when publishing schema in GraphQL API

### DIFF
--- a/integration-tests/docker-compose.yml
+++ b/integration-tests/docker-compose.yml
@@ -202,7 +202,8 @@ services:
       AUTH0_CLIENT_SECRET: ${AUTH0_CLIENT_SECRET}
       AUTH0_SCOPE: 'openid profile offline_access'
       AUTH0_AUDIENCE: ${AUTH0_AUDIENCE}
-      AUTH0_CONNECTION: ${AUTH0_CONNECTION}
+      AUTH0_CONNECTION: ${AUTH0_CONNECTION}\
+      WEB_APP_URL: https://app.graphql-hive.com
       PORT: 3001
 
   schema:

--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -196,6 +196,7 @@ export function publishSchema(input: SchemaPublishInput, token: string) {
             initial
             valid
             message
+            linkToWebsite
             changes {
               nodes {
                 message
@@ -206,6 +207,7 @@ export function publishSchema(input: SchemaPublishInput, token: string) {
           }
           ... on SchemaPublishError {
             valid
+            linkToWebsite
             changes {
               nodes {
                 message

--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -1335,5 +1335,5 @@ test('linkToWebsite should be available', async () => {
       : null;
 
   expect(linkToWebsite).toMatch('https://app.graphql-hive.com/foo/foo/experiment/history/');
-  expect(linkToWebsite).toMatch(/history\/[a-z0-9-]+/$);
+  expect(linkToWebsite).toMatch(/history\/[a-z0-9-]+$/);
 });

--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -1335,7 +1335,6 @@ test('linkToWebsite should be available when publishing initial schema', async (
       : null;
 
   expect(linkToWebsite).toEqual('https://app.graphql-hive.com/foo/foo/development');
-  expect(linkToWebsite).toMatch(/history\/[a-z0-9-]+$/);
 });
 
 test('linkToWebsite should be available when publishing non-initial schema', async () => {

--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -1272,7 +1272,7 @@ test('CDN data can be fetched with an valid access token', async () => {
   expect(cdnResult.status).toEqual(200);
 });
 
-test('linkToWebsite should be available', async () => {
+test('linkToWebsite should be available when publishing initial schema', async () => {
   const { access_token: owner_access_token } = await authenticate('main');
   const orgResult = await createOrganization(
     {
@@ -1334,6 +1334,72 @@ test('linkToWebsite should be available', async () => {
       ? result.body.data!.schemaPublish.linkToWebsite
       : null;
 
-  expect(linkToWebsite).toMatch('https://app.graphql-hive.com/foo/foo/experiment/history/');
+  expect(linkToWebsite).toEqual('https://app.graphql-hive.com/foo/foo/development');
+  expect(linkToWebsite).toMatch(/history\/[a-z0-9-]+$/);
+});
+
+test('linkToWebsite should be available when publishing non-initial schema', async () => {
+  const { access_token: owner_access_token } = await authenticate('main');
+  const orgResult = await createOrganization(
+    {
+      name: 'foo',
+    },
+    owner_access_token
+  );
+
+  // Join
+  const { access_token: member_access_token } = await authenticate('extra');
+  const org = orgResult.body.data!.createOrganization.ok!.createdOrganizationPayload.organization;
+  const code = org.inviteCode;
+  await joinOrganization(code, member_access_token);
+
+  const projectResult = await createProject(
+    {
+      organization: org.cleanId,
+      type: ProjectType.Single,
+      name: 'foo',
+    },
+    owner_access_token
+  );
+
+  const project = projectResult.body.data!.createProject.ok!.createdProject;
+  const targets = projectResult.body.data!.createProject.ok!.createdTargets;
+  const target = targets.find(t => t.name === 'development')!;
+
+  const tokenResult = await createToken(
+    {
+      name: 'test',
+      organization: org.cleanId,
+      project: project.cleanId,
+      target: target.cleanId,
+      organizationScopes: [],
+      projectScopes: [],
+      targetScopes: [TargetAccessScope.RegistryRead, TargetAccessScope.RegistryWrite],
+    },
+    owner_access_token
+  );
+
+  expect(tokenResult.body.errors).not.toBeDefined();
+
+  const token = tokenResult.body.data!.createToken.ok!.secret;
+
+  const result = await publishSchema(
+    {
+      author: 'Kamil',
+      commit: 'abc123',
+      sdl: `type Query { ping: String }`,
+    },
+    token
+  );
+
+  expect(result.body.errors).not.toBeDefined();
+  expect(result.body.data!.schemaPublish.__typename).toBe('SchemaPublishSuccess');
+
+  const linkToWebsite =
+    result.body.data!.schemaPublish.__typename === 'SchemaPublishSuccess'
+      ? result.body.data!.schemaPublish.linkToWebsite
+      : null;
+
+  expect(linkToWebsite).toMatch('https://app.graphql-hive.com/foo/foo/development/history/');
   expect(linkToWebsite).toMatch(/history\/[a-z0-9-]+$/);
 });

--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -1382,11 +1382,23 @@ test('linkToWebsite should be available when publishing non-initial schema', asy
 
   const token = tokenResult.body.data!.createToken.ok!.secret;
 
-  const result = await publishSchema(
+  let result = await publishSchema(
     {
       author: 'Kamil',
       commit: 'abc123',
       sdl: `type Query { ping: String }`,
+    },
+    token
+  );
+
+  expect(result.body.errors).not.toBeDefined();
+  expect(result.body.data!.schemaPublish.__typename).toBe('SchemaPublishSuccess');
+
+  result = await publishSchema(
+    {
+      author: 'Kamil',
+      commit: 'abc123',
+      sdl: `type Query { ping: String pong: String }`,
     },
     token
   );

--- a/integration-tests/tests/cli/schema.spec.ts
+++ b/integration-tests/tests/cli/schema.spec.ts
@@ -196,6 +196,55 @@ test('service url should be required in Federation', async () => {
   ).rejects.toThrowError(/url/);
 });
 
+test('schema:publish should print a link to the website', async () => {
+  const { access_token: owner_access_token } = await authenticate('main');
+  const orgResult = await createOrganization(
+    {
+      name: 'foo',
+    },
+    owner_access_token
+  );
+  const org = orgResult.body.data!.createOrganization.ok!.createdOrganizationPayload.organization;
+  const code = org.inviteCode;
+
+  // Join
+  const { access_token: member_access_token } = await authenticate('extra');
+  await joinOrganization(code, member_access_token);
+
+  const projectResult = await createProject(
+    {
+      organization: org.cleanId,
+      type: ProjectType.Single,
+      name: 'foo',
+    },
+    owner_access_token
+  );
+
+  const project = projectResult.body.data!.createProject.ok!.createdProject;
+  const targets = projectResult.body.data!.createProject.ok!.createdTargets;
+  const target = targets.find(t => t.name === 'development')!;
+
+  // Create a token with write rights
+  const writeTokenResult = await createToken(
+    {
+      name: 'test',
+      organization: org.cleanId,
+      project: project.cleanId,
+      target: target.cleanId,
+      organizationScopes: [],
+      projectScopes: [],
+      targetScopes: [TargetAccessScope.RegistryRead, TargetAccessScope.RegistryWrite],
+    },
+    owner_access_token
+  );
+  expect(writeTokenResult.body.errors).not.toBeDefined();
+  const writeToken = writeTokenResult.body.data!.createToken.ok!.secret;
+
+  await expect(schemaCheck(['--token', writeToken, 'fixtures/init-schema.graphql'])).resolves.toMatch(
+    'Available at https://app.graphql-hive.com/foo/foo/development/history/'
+  );
+});
+
 test('schema:check should notify user when registry is empty', async () => {
   const { access_token: owner_access_token } = await authenticate('main');
   const orgResult = await createOrganization(

--- a/integration-tests/tests/cli/schema.spec.ts
+++ b/integration-tests/tests/cli/schema.spec.ts
@@ -240,7 +240,11 @@ test('schema:publish should print a link to the website', async () => {
   expect(writeTokenResult.body.errors).not.toBeDefined();
   const writeToken = writeTokenResult.body.data!.createToken.ok!.secret;
 
-  await expect(schemaCheck(['--token', writeToken, 'fixtures/init-schema.graphql'])).resolves.toMatch(
+  await expect(schemaPublish(['--token', writeToken, 'fixtures/init-schema.graphql'])).resolves.toMatch(
+    'Available at https://app.graphql-hive.com/foo/foo/development'
+  );
+
+  await expect(schemaPublish(['--token', writeToken, 'fixtures/nonbreaking-schema.graphql'])).resolves.toMatch(
     'Available at https://app.graphql-hive.com/foo/foo/development/history/'
   );
 });

--- a/packages/libraries/cli/src/commands/schema/publish.graphql
+++ b/packages/libraries/cli/src/commands/schema/publish.graphql
@@ -5,6 +5,7 @@ mutation schemaPublish($input: SchemaPublishInput!, $usesGitHubApp: Boolean!) {
       initial
       valid
       successMessage: message
+      linkToWebsite
       changes {
         nodes {
           message
@@ -15,6 +16,7 @@ mutation schemaPublish($input: SchemaPublishInput!, $usesGitHubApp: Boolean!) {
     }
     ... on SchemaPublishError @skip(if: $usesGitHubApp) {
       valid
+      linkToWebsite
       changes {
         nodes {
           message

--- a/packages/libraries/cli/src/commands/schema/publish.ts
+++ b/packages/libraries/cli/src/commands/schema/publish.ts
@@ -172,6 +172,10 @@ export default class SchemaPublish extends Command {
           renderChanges.call(this, changes);
           this.success('Schema published');
         }
+
+        if (result.schemaPublish.linkToWebsite) {
+          this.info(`Available at ${result.schemaPublish.linkToWebsite}`);
+        }
       } else if (result.schemaPublish.__typename === 'SchemaPublishMissingServiceError') {
         this.fail(`${result.schemaPublish.missingServiceError} Please use the '--service <name>' parameter.`);
         this.exit(1);
@@ -194,6 +198,10 @@ export default class SchemaPublish extends Command {
           this.exit(1);
         } else {
           this.success('Schema published (forced)');
+        }
+
+        if (result.schemaPublish.linkToWebsite) {
+          this.info(`Available at ${result.schemaPublish.linkToWebsite}`);
         }
       } else if (result.schemaPublish.__typename === 'GitHubSchemaPublishSuccess') {
         this.success(result.schemaPublish.message);

--- a/packages/services/api/src/create.ts
+++ b/packages/services/api/src/create.ts
@@ -30,6 +30,7 @@ import { feedbackModule } from './modules/feedback';
 import { TokensConfig, TOKENS_CONFIG } from './modules/token/providers/tokens';
 import { WebhooksConfig, WEBHOOKS_CONFIG } from './modules/alerts/providers/tokens';
 import { SchemaServiceConfig, SCHEMA_SERVICE_CONFIG } from './modules/schema/providers/orchestrators/tokens';
+import { provideSchemaModuleConfig, SchemaModuleConfig } from './modules/schema/providers/config';
 import { CDN_CONFIG, CDNConfig } from './modules/cdn/providers/tokens';
 import { cdnModule } from './modules/cdn';
 import { adminModule } from './modules/admin';
@@ -91,6 +92,7 @@ export function createRegistry({
   encryptionSecret,
   feedback,
   billing,
+  schemaConfig,
 }: {
   logger: Logger;
   storage: Storage;
@@ -109,6 +111,7 @@ export function createRegistry({
     channel: string;
   };
   billing: BillingConfig;
+  schemaConfig: SchemaModuleConfig;
 }) {
   return createApplication({
     modules,
@@ -184,6 +187,7 @@ export function createRegistry({
         scope: Scope.Singleton,
       },
       encryptionSecretProvider(encryptionSecret),
+      provideSchemaModuleConfig(schemaConfig),
     ]),
   });
 }

--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -161,12 +161,14 @@ export default gql`
   type SchemaPublishSuccess {
     initial: Boolean!
     valid: Boolean!
+    linkToWebsite: String
     message: String
     changes: SchemaChangeConnection
   }
 
   type SchemaPublishError {
     valid: Boolean!
+    linkToWebsite: String
     changes: SchemaChangeConnection
     errors: SchemaErrorConnection!
   }

--- a/packages/services/api/src/modules/schema/providers/config.ts
+++ b/packages/services/api/src/modules/schema/providers/config.ts
@@ -11,7 +11,7 @@ export interface SchemaModuleConfig {
     target: {
       cleanId: string;
     };
-    version: {
+    version?: {
       id: string;
     };
   }): string;

--- a/packages/services/api/src/modules/schema/providers/config.ts
+++ b/packages/services/api/src/modules/schema/providers/config.ts
@@ -1,0 +1,28 @@
+import { InjectionToken, Provider, Scope } from 'graphql-modules';
+
+export interface SchemaModuleConfig {
+  schemaPublishLink?(input: {
+    organization: {
+      cleanId: string;
+    };
+    project: {
+      cleanId: string;
+    };
+    target: {
+      cleanId: string;
+    };
+    version: {
+      id: string;
+    };
+  }): string;
+}
+
+export const SCHEMA_MODULE_CONFIG = new InjectionToken<SchemaModuleConfig>('SchemaModuleConfig');
+
+export function provideSchemaModuleConfig(config: SchemaModuleConfig): Provider {
+  return {
+    provide: SCHEMA_MODULE_CONFIG,
+    useValue: config,
+    scope: Scope.Singleton,
+  };
+}

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -559,7 +559,8 @@ export class SchemaPublisher {
       changes,
       message: updates.length ? updates.join('\n') : null,
       linkToWebsite:
-        typeof this.schemaModuleConfig.schemaPublishLink === 'function' && typeof newVersionId === 'string'
+        typeof this.schemaModuleConfig.schemaPublishLink === 'function' &&
+        (typeof newVersionId === 'string' || isInitialSchema)
           ? this.schemaModuleConfig.schemaPublishLink({
               organization: {
                 cleanId: project.cleanId,
@@ -570,9 +571,11 @@ export class SchemaPublisher {
               target: {
                 cleanId: target.cleanId,
               },
-              version: {
-                id: newVersionId,
-              },
+              version: newVersionId
+                ? {
+                    id: newVersionId,
+                  }
+                : undefined,
             })
           : null,
     };

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -572,11 +572,11 @@ export class SchemaPublisher {
                 cleanId: target.cleanId,
               },
               version:
-                !isInitialSchema && !!newVersionId
-                  ? {
+                isInitialSchema || !newVersionId
+                  ? undefined
+                  : {
                       id: newVersionId,
-                    }
-                  : undefined,
+                    },
             })
           : null,
     };

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -571,11 +571,12 @@ export class SchemaPublisher {
               target: {
                 cleanId: target.cleanId,
               },
-              version: newVersionId
-                ? {
-                    id: newVersionId,
-                  }
-                : undefined,
+              version:
+                !isInitialSchema && !!newVersionId
+                  ? {
+                      id: newVersionId,
+                    }
+                  : undefined,
             })
           : null,
     };

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -1,4 +1,4 @@
-import { Injectable, Scope } from 'graphql-modules';
+import { Injectable, Inject, Scope } from 'graphql-modules';
 import lodash from 'lodash';
 import type { Span } from '@sentry/types';
 import { Schema, Target, Project, ProjectType, createSchemaObject, Orchestrator } from '../../../shared/entities';
@@ -20,6 +20,7 @@ import { OrganizationManager } from '../../organization/providers/organization-m
 import { AuthManager } from '../../auth/providers/auth-manager';
 import { TargetAccessScope } from '../../auth/providers/target-access';
 import { GitHubIntegrationManager } from '../../integrations/providers/github-integration-manager';
+import { SchemaModuleConfig, SCHEMA_MODULE_CONFIG } from './config';
 
 type CheckInput = Omit<Types.SchemaCheckInput, 'project' | 'organization' | 'target'> & TargetSelector;
 
@@ -52,7 +53,8 @@ export class SchemaPublisher {
     private cdn: CdnProvider,
     private tracking: Tracking,
     private gitHubIntegrationManager: GitHubIntegrationManager,
-    private idempotentRunner: IdempotentRunner
+    private idempotentRunner: IdempotentRunner,
+    @Inject(SCHEMA_MODULE_CONFIG) private schemaModuleConfig: SchemaModuleConfig
   ) {
     this.logger = logger.child({ service: 'SchemaPublisher' });
   }
@@ -498,10 +500,12 @@ export class SchemaPublisher {
       };
     }
 
+    let newVersionId: string | null = null;
+
     // if the schema is valid or the user is forcing the publish, we can go ahead and publish
     if (!hasErrors || isForced) {
       this.logger.debug('Publishing new version');
-      await this.publishNewVersion({
+      const newVersion = await this.publishNewVersion({
         input,
         valid,
         schemas: newSchemas,
@@ -513,6 +517,9 @@ export class SchemaPublisher {
         errors,
         initial: isInitialSchema,
       });
+
+      newVersionId = newVersion.id;
+
       await this.publishToCDN({
         valid,
         target,
@@ -550,6 +557,23 @@ export class SchemaPublisher {
       errors,
       changes,
       message: updates.length ? updates.join('\n') : null,
+      linkToWebsite:
+        typeof this.schemaModuleConfig.schemaPublishLink === 'function' && typeof newVersionId === 'string'
+          ? this.schemaModuleConfig.schemaPublishLink({
+              organization: {
+                cleanId: project.cleanId,
+              },
+              project: {
+                cleanId: project.cleanId,
+              },
+              target: {
+                cleanId: target.cleanId,
+              },
+              version: {
+                id: newVersionId,
+              },
+            })
+          : null,
     };
   }
 
@@ -607,7 +631,7 @@ export class SchemaPublisher {
       }),
     ]);
 
-    this.alertsManager
+    void this.alertsManager
       .triggerSchemaChangeNotifications({
         organization,
         project,
@@ -620,6 +644,8 @@ export class SchemaPublisher {
       .catch(err => {
         this.logger.error('Failed to trigger schema change notifications', err);
       });
+
+    return schemaVersion;
   }
 
   @sentry('SchemaPublisher.publishToCDN')

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -551,6 +551,26 @@ export class SchemaPublisher {
       });
     }
 
+    const linkToWebsite =
+      typeof this.schemaModuleConfig.schemaPublishLink === 'function' && typeof newVersionId === 'string'
+        ? this.schemaModuleConfig.schemaPublishLink({
+            organization: {
+              cleanId: project.cleanId,
+            },
+            project: {
+              cleanId: project.cleanId,
+            },
+            target: {
+              cleanId: target.cleanId,
+            },
+            version: isInitialSchema
+              ? undefined
+              : {
+                  id: newVersionId,
+                },
+          })
+        : null;
+
     return {
       __typename: valid ? ('SchemaPublishSuccess' as const) : ('SchemaPublishError' as const),
       initial: isInitialSchema,
@@ -558,27 +578,7 @@ export class SchemaPublisher {
       errors,
       changes,
       message: updates.length ? updates.join('\n') : null,
-      linkToWebsite:
-        typeof this.schemaModuleConfig.schemaPublishLink === 'function' &&
-        (typeof newVersionId === 'string' || isInitialSchema)
-          ? this.schemaModuleConfig.schemaPublishLink({
-              organization: {
-                cleanId: project.cleanId,
-              },
-              project: {
-                cleanId: project.cleanId,
-              },
-              target: {
-                cleanId: target.cleanId,
-              },
-              version:
-                isInitialSchema || !newVersionId
-                  ? undefined
-                  : {
-                      id: newVersionId,
-                    },
-            })
-          : null,
+      linkToWebsite,
     };
   }
 

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -20,7 +20,8 @@ import { OrganizationManager } from '../../organization/providers/organization-m
 import { AuthManager } from '../../auth/providers/auth-manager';
 import { TargetAccessScope } from '../../auth/providers/target-access';
 import { GitHubIntegrationManager } from '../../integrations/providers/github-integration-manager';
-import { SchemaModuleConfig, SCHEMA_MODULE_CONFIG } from './config';
+import type { SchemaModuleConfig } from './config';
+import { SCHEMA_MODULE_CONFIG } from './config';
 
 type CheckInput = Omit<Types.SchemaCheckInput, 'project' | 'organization' | 'target'> & TargetSelector;
 

--- a/packages/services/server/src/index.ts
+++ b/packages/services/server/src/index.ts
@@ -176,7 +176,7 @@ export async function main() {
                 let url = `${process.env.WEB_APP_URL}/${input.organization.cleanId}/${input.project.cleanId}/${input.target.cleanId}`;
 
                 if (input.version) {
-                  url += `/history/${input.version}`;
+                  url += `/history/${input.version.id}`;
                 }
 
                 return url;

--- a/packages/services/server/src/index.ts
+++ b/packages/services/server/src/index.ts
@@ -173,14 +173,13 @@ export async function main() {
         typeof process.env.WEB_APP_URL === 'string'
           ? {
               schemaPublishLink(input) {
-                return [
-                  process.env.WEB_APP_URL,
-                  input.organization.cleanId,
-                  input.project.cleanId,
-                  input.target.cleanId,
-                  'history',
-                  input.version.id,
-                ].join('/');
+                let url = `${process.env.WEB_APP_URL}/${input.organization.cleanId}/${input.project.cleanId}/${input.target.cleanId}`;
+
+                if (input.version) {
+                  url += `/history/${input.version}`;
+                }
+
+                return url;
               },
             }
           : {},

--- a/packages/services/server/src/index.ts
+++ b/packages/services/server/src/index.ts
@@ -169,6 +169,21 @@ export async function main() {
         token: ensureEnv('FEEDBACK_SLACK_TOKEN'),
         channel: ensureEnv('FEEDBACK_SLACK_CHANNEL'),
       },
+      schemaConfig:
+        typeof process.env.WEB_APP_URL === 'string'
+          ? {
+              schemaPublishLink(input) {
+                return [
+                  process.env.WEB_APP_URL,
+                  input.organization.cleanId,
+                  input.project.cleanId,
+                  input.target.cleanId,
+                  'history',
+                  input.version.id,
+                ].join('/');
+              },
+            }
+          : {},
     });
     const graphqlPath = '/graphql';
     const port = process.env.PORT || 4000;


### PR DESCRIPTION
Related #185

When using CLI and publishing the first schema, the user will see:
> Available at https://app.graphql-hive.com/org/proj/tar

When publishing the second schema, the user will see:
> Available at https://app.graphql-hive.com/org/proj/tar/history/new-version-id