### PR TITLE
test: prove error masking works as expected and always do error masking

### DIFF
--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -1414,3 +1414,26 @@ test('linkToWebsite should be available when publishing non-initial schema', asy
   expect(linkToWebsite).toMatch('https://app.graphql-hive.com/foo/foo/development/history/');
   expect(linkToWebsite).toMatch(/history\/[a-z0-9-]+$/);
 });
+
+test('cannot do API request with invalid access token', async () => {
+  const orgResult = await publishSchema(
+    {
+      commit: '1',
+      sdl: 'type Query { smokeBangBang: String }',
+      author: 'Kamil',
+    },
+    'foobars'
+  );
+  expect(orgResult).toEqual({
+    body: {
+      data: null,
+      errors: [
+        {
+          message: 'Invalid token provided!',
+          path: ['schemaPublish'],
+        },
+      ],
+    },
+    status: 200,
+  });
+});

--- a/packages/services/server/src/graphql-handler.ts
+++ b/packages/services/server/src/graphql-handler.ts
@@ -96,7 +96,6 @@ export const graphqlHandler = (options: GraphQLHandlerOptions): RouteHandlerMeth
     headers: Record<string, string | string[] | undefined>;
     requestId?: string | null;
   }>({
-    maskedErrors: process.env.ENVIRONMENT === 'prod' || process.env.ENVIRONMENT === 'staging',
     plugins: [
       ...additionalPlugins,
       useAuth0({


### PR DESCRIPTION
This proves that the allegation made in https://github.com/kamilkisiela/graphql-hive/issues/188 is incorrect. Error masking does not mask `GraphQLYogaError` instances.


_____


Closes https://github.com/kamilkisiela/graphql-hive/issues/188
Closes https://github.com/kamilkisiela/graphql-hive/issues/189