### PR TITLE
feat: always log unexpected errors

### DIFF
--- a/.changeset/little-dingos-exercise.md
+++ b/.changeset/little-dingos-exercise.md
@@ -1,0 +1,5 @@
+---
+'@hive/api': patch
+---
+
+Stop masking GraphQL syntax errors within `Mutation.schemaPublish`.

--- a/.changeset/quiet-dogs-flow.md
+++ b/.changeset/quiet-dogs-flow.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': patch
+---
+
+Better error messages for SDL syntax errors.

--- a/.prettierignore
+++ b/.prettierignore
@@ -12,3 +12,6 @@ __generated__/
 /packages/web/app/src/gql/gql.d.ts
 /packages/web/app/src/gql/graphql.ts
 /packages/web/app/src/graphql/index.ts
+
+# test fixtures
+integration-tests/fixtures/init-invalid-schema.graphql

--- a/integration-tests/dockest.ts
+++ b/integration-tests/dockest.ts
@@ -9,9 +9,7 @@ async function main() {
     logLevel: logLevel.DEBUG,
     jestOpts: {
       runInBand: true,
-      testMatch: process.env.TEST_FILTER
-        ? [`**/${process.env.TEST_FILTER}?(*.)+(spec|test).[jt]s?(x)`]
-        : undefined,
+      testMatch: process.env.TEST_FILTER ? [`**/${process.env.TEST_FILTER}?(*.)+(spec|test).[jt]s?(x)`] : undefined,
       config: JSON.stringify({
         roots: ['<rootDir>/tests'],
         transform: {

--- a/integration-tests/dockest.ts
+++ b/integration-tests/dockest.ts
@@ -9,6 +9,9 @@ async function main() {
     logLevel: logLevel.DEBUG,
     jestOpts: {
       runInBand: true,
+      testMatch: process.env.TEST_FILTER
+        ? [`**/${process.env.TEST_FILTER}?(*.)+(spec|test).[jt]s?(x)`]
+        : undefined,
       config: JSON.stringify({
         roots: ['<rootDir>/tests'],
         transform: {

--- a/integration-tests/fixtures/init-invalid-schema.graphql
+++ b/integration-tests/fixtures/init-invalid-schema.graphql
@@ -1,0 +1,1 @@
+iliketurtles.mp4

--- a/integration-tests/tests/cli/schema.spec.ts
+++ b/integration-tests/tests/cli/schema.spec.ts
@@ -70,6 +70,69 @@ test('can publish and check a schema with target:registry:read access', async ()
   );
 });
 
+test('publishing invalid schema SDL provides meaningful feedback for the user.', async () => {
+  const { access_token: owner_access_token } = await authenticate('main');
+  const orgResult = await createOrganization(
+    {
+      name: 'foo',
+    },
+    owner_access_token
+  );
+  const org = orgResult.body.data!.createOrganization.ok!.createdOrganizationPayload.organization;
+  const code = org.inviteCode;
+
+  // Join
+  const { access_token: member_access_token } = await authenticate('extra');
+  await joinOrganization(code, member_access_token);
+
+  const projectResult = await createProject(
+    {
+      organization: org.cleanId,
+      type: ProjectType.Single,
+      name: 'foo',
+    },
+    owner_access_token
+  );
+
+  const project = projectResult.body.data!.createProject.ok!.createdProject;
+  const target = projectResult.body.data!.createProject.ok!.createdTargets[0];
+
+  // Create a token with write rights
+  const writeTokenResult = await createToken(
+    {
+      name: 'test',
+      organization: org.cleanId,
+      project: project.cleanId,
+      target: target.cleanId,
+      organizationScopes: [],
+      projectScopes: [],
+      targetScopes: [TargetAccessScope.RegistryRead, TargetAccessScope.RegistryWrite],
+    },
+    owner_access_token
+  );
+  expect(writeTokenResult.body.errors).not.toBeDefined();
+  const writeToken = writeTokenResult.body.data!.createToken.ok!.secret;
+
+  const allocatedError = new Error('Should have thrown.');
+  try {
+    await schemaPublish([
+      '--token',
+      writeToken,
+      '--author',
+      'Kamil',
+      '--commit',
+      'abc123',
+      'fixtures/init-invalid-schema.graphql',
+    ]);
+    throw allocatedError;
+  } catch (err) {
+    if (err === allocatedError) {
+      throw err;
+    }
+    expect(String(err)).toContain(`The SDL is not valid at line 1, column 1:\nSyntax Error: Unexpected Name "iliketurtles"`);
+  }
+});
+
 test('service url should be available in supergraph', async () => {
   const { access_token: owner_access_token } = await authenticate('main');
   const orgResult = await createOrganization(

--- a/integration-tests/tests/cli/schema.spec.ts
+++ b/integration-tests/tests/cli/schema.spec.ts
@@ -129,7 +129,8 @@ test('publishing invalid schema SDL provides meaningful feedback for the user.',
     if (err === allocatedError) {
       throw err;
     }
-    expect(String(err)).toContain(`The SDL is not valid at line 1, column 1:\nSyntax Error: Unexpected Name "iliketurtles"`);
+    expect(String(err)).toMatch(`The SDL is not valid at line 1, column 1:`);
+    expect(String(err)).toMatch(`Syntax Error: Unexpected Name "iliketurtles"`);
   }
 });
 

--- a/packages/libraries/cli/src/commands/schema/publish.ts
+++ b/packages/libraries/cli/src/commands/schema/publish.ts
@@ -137,8 +137,8 @@ export default class SchemaPublish extends Command {
       if (!commit) {
         throw new Errors.CLIError(`Missing "commit"`);
       }
-      
-      let sdl: string
+
+      let sdl: string;
       try {
         const rawSdl = await loadSchema(file);
         invariant(typeof rawSdl === 'string' && rawSdl.length > 0, 'Schema seems empty');
@@ -147,10 +147,10 @@ export default class SchemaPublish extends Command {
       } catch (err) {
         if (err instanceof GraphQLError) {
           const location = err.locations?.[0];
-          const locationString = location ? ` at line ${location.line}, column ${location.column}` : ''
-          throw new Error(`The SDL is not valid${locationString}:\n ${err.message}`)
+          const locationString = location ? ` at line ${location.line}, column ${location.column}` : '';
+          throw new Error(`The SDL is not valid${locationString}:\n ${err.message}`);
         }
-        throw err
+        throw err;
       }
 
       const result = await this.registryApi(registry, token).schemaPublish({

--- a/packages/libraries/cli/src/commands/schema/publish.ts
+++ b/packages/libraries/cli/src/commands/schema/publish.ts
@@ -1,6 +1,6 @@
 import { transformCommentsToDescriptions } from '@graphql-tools/utils';
 import { Flags, Errors } from '@oclif/core';
-import { print } from 'graphql';
+import { GraphQLError, print } from 'graphql';
 import Command from '../../base-command';
 import { gitInfo } from '../../helpers/git';
 import { invariant } from '../../helpers/validation';
@@ -137,13 +137,21 @@ export default class SchemaPublish extends Command {
       if (!commit) {
         throw new Errors.CLIError(`Missing "commit"`);
       }
-
-      const sdl = await loadSchema(file);
-
-      invariant(typeof sdl === 'string' && sdl.length > 0, 'Schema seems empty');
-
-      const transformedSDL = print(transformCommentsToDescriptions(sdl));
-      const minifiedSDL = minifySchema(transformedSDL);
+      
+      let sdl: string
+      try {
+        const rawSdl = await loadSchema(file);
+        invariant(typeof rawSdl === 'string' && rawSdl.length > 0, 'Schema seems empty');
+        const transformedSDL = print(transformCommentsToDescriptions(rawSdl));
+        sdl = minifySchema(transformedSDL);
+      } catch (err) {
+        if (err instanceof GraphQLError) {
+          const location = err.locations?.[0];
+          const locationString = location ? ` at line ${location.line}, column ${location.column}` : ''
+          throw new Error(`The SDL is not valid${locationString}:\n ${err.message}`)
+        }
+        throw err
+      }
 
       const result = await this.registryApi(registry, token).schemaPublish({
         input: {
@@ -151,7 +159,7 @@ export default class SchemaPublish extends Command {
           url,
           author,
           commit,
-          sdl: minifiedSDL,
+          sdl,
           force,
           metadata,
           github: usesGitHubApp,

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -1,7 +1,15 @@
 import { Injectable, Inject, Scope } from 'graphql-modules';
 import lodash from 'lodash';
 import type { Span } from '@sentry/types';
-import { Schema, Target, Project, ProjectType, createSchemaObject, Orchestrator, GraphQLDocumentStringInvalidError } from '../../../shared/entities';
+import {
+  Schema,
+  Target,
+  Project,
+  ProjectType,
+  createSchemaObject,
+  Orchestrator,
+  GraphQLDocumentStringInvalidError,
+} from '../../../shared/entities';
 import * as Types from '../../../__generated__/types';
 import { ProjectManager } from '../../project/providers/project-manager';
 import { Logger } from '../../shared/providers/logger';
@@ -451,8 +459,8 @@ export class SchemaPublisher {
 
     const isInitialSchema = schemas.length === 0;
 
-    let result: ValidationResult 
-    
+    let result: ValidationResult;
+
     try {
       result = await this.schemaValidator.validate({
         orchestrator,
@@ -470,7 +478,7 @@ export class SchemaPublisher {
       if (err instanceof GraphQLDocumentStringInvalidError) {
         throw new HiveError(err.message);
       }
-      throw err
+      throw err;
     }
 
     const { changes, errors, valid } = result;

--- a/packages/services/api/src/modules/schema/providers/schema-validator.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-validator.ts
@@ -6,6 +6,11 @@ import { Logger } from '../../shared/providers/logger';
 import { sentry } from '../../../shared/sentry';
 import { Inspector } from './inspector';
 
+export type ValidationResult = {
+  valid: boolean;
+  errors: Array<Types.SchemaError>;
+  changes: Array<Types.SchemaChange>;
+}
 @Injectable({
   scope: Scope.Operation,
 })
@@ -31,7 +36,7 @@ export class SchemaValidator {
     after: readonly Schema[];
     selector: Types.TargetSelector;
     baseSchema: string | null;
-  }) {
+  }): Promise<ValidationResult> {
     this.logger.debug('Validating Schema');
     const existing = findSchema(before, incoming);
     const afterWithBase = after.map((schema, index) => {

--- a/packages/services/api/src/modules/schema/providers/schema-validator.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-validator.ts
@@ -10,7 +10,7 @@ export type ValidationResult = {
   valid: boolean;
   errors: Array<Types.SchemaError>;
   changes: Array<Types.SchemaChange>;
-}
+};
 @Injectable({
   scope: Scope.Operation,
 })

--- a/packages/services/api/src/shared/entities.ts
+++ b/packages/services/api/src/shared/entities.ts
@@ -56,21 +56,21 @@ export const emptySource = '*';
 
 export class GraphQLDocumentStringInvalidError extends Error {
   constructor(message: string, location?: SourceLocation) {
-    const locationString = location ? ` at line ${location.line}, column ${location.column}` : ''
+    const locationString = location ? ` at line ${location.line}, column ${location.column}` : '';
     super(`The provided SDL is not valid${locationString}\n: ${message}`);
   }
 }
 
 export function createSchemaObject(schema: Schema): SchemaObject {
   let document: DocumentNode;
-  
+
   try {
-    document = parse(schema.source)
-  }  catch (err) {
+    document = parse(schema.source);
+  } catch (err) {
     if (err instanceof GraphQLError) {
-      throw new GraphQLDocumentStringInvalidError(err.message,  err.locations?.[0])
+      throw new GraphQLDocumentStringInvalidError(err.message, err.locations?.[0]);
     }
-    throw err
+    throw err;
   }
 
   return {


### PR DESCRIPTION
In persuit of figuring out what causes https://github.com/kamilkisiela/graphql-hive/issues/188 I realized that the actual issue [for my test here](https://github.com/kamilkisiela/graphql-hive/pull/201#issuecomment-1169651610) is that the `GraphQLError` thrown from `parse` within our business logic causes the `unexpected error.`. This PR resolves that by wrapping the logic and rethrowing the error.

Note that this is probably still not a fix for the error mentioned in https://github.com/kamilkisiela/graphql-hive/issues/187, as the CLI would have failed before doing any API requests, because it is also using `parse` and `print`.

- Always log unexpected errors to the console, even in dev mode
- Catch `GraphQLError` raised by `parse` and format it into a more obvious error message for both the CLI and API

