### PR TITLE
New pricing

### DIFF
--- a/packages/services/api/src/modules/billing/module.graphql.ts
+++ b/packages/services/api/src/modules/billing/module.graphql.ts
@@ -50,9 +50,7 @@ export default gql`
     description: String
     basePrice: Float
     includedOperationsLimit: SafeInt
-    includedSchemaPushLimit: SafeInt
     pricePerOperationsUnit: Float
-    pricePerSchemaPushUnit: Float
     rateLimit: UsageRateLimitType!
     retentionInDays: Int!
   }

--- a/packages/services/api/src/modules/billing/resolvers.ts
+++ b/packages/services/api/src/modules/billing/resolvers.ts
@@ -7,24 +7,18 @@ import { IdTranslator } from '../shared/providers/id-translator';
 import { BillingProvider } from './providers/billing.provider';
 import { BillingModule } from './__generated__/types';
 
-const USAGE_DEFAULT_LIMITATIONS: Record<
-  'HOBBY' | 'PRO' | 'ENTERPRISE',
-  { operations: number; schemaPushes: number; retention: number }
-> = {
+const USAGE_DEFAULT_LIMITATIONS: Record<'HOBBY' | 'PRO' | 'ENTERPRISE', { operations: number; retention: number }> = {
   HOBBY: {
     operations: 1_000_000,
-    schemaPushes: 50,
-    retention: 3,
+    retention: 7,
   },
   PRO: {
-    operations: 5_000_000,
-    schemaPushes: 500,
-    retention: 180,
+    operations: 0,
+    retention: 90,
   },
   ENTERPRISE: {
     operations: 0, // unlimited
-    schemaPushes: 0, // unlimited
-    retention: 360,
+    retention: 365,
   },
 };
 
@@ -116,10 +110,8 @@ export const resolvers: BillingModule.Resolvers = {
           name: 'Hobby',
           description: 'Free for non-commercial use, startups, side-projects and just experiments.',
           includedOperationsLimit: USAGE_DEFAULT_LIMITATIONS.HOBBY.operations,
-          includedSchemaPushLimit: USAGE_DEFAULT_LIMITATIONS.HOBBY.schemaPushes,
           rateLimit: 'MONTHLY_LIMITED',
           pricePerOperationsUnit: 0,
-          pricePerSchemaPushUnit: 0,
           retentionInDays: USAGE_DEFAULT_LIMITATIONS.HOBBY.retention,
         },
         {
@@ -127,12 +119,9 @@ export const resolvers: BillingModule.Resolvers = {
           planType: 'PRO',
           basePrice: availablePrices.basePrice.unit_amount! / 100,
           name: 'Pro',
-          description:
-            'For production-ready applications that requires long retention, high ingestion capacity and unlimited access to all Hive features.',
+          description: 'For production-ready applications that requires long retention, high ingestion capacity.',
           includedOperationsLimit: USAGE_DEFAULT_LIMITATIONS.PRO.operations,
-          includedSchemaPushLimit: USAGE_DEFAULT_LIMITATIONS.PRO.schemaPushes,
           pricePerOperationsUnit: availablePrices.operationsPrice.tiers![1].unit_amount! / 100,
-          pricePerSchemaPushUnit: availablePrices.schemaPushesPrice.tiers![1].unit_amount! / 100,
           retentionInDays: USAGE_DEFAULT_LIMITATIONS.PRO.retention,
           rateLimit: 'MONTHLY_QUOTA',
         },
@@ -140,9 +129,8 @@ export const resolvers: BillingModule.Resolvers = {
           id: 'ENTERPRISE',
           planType: 'ENTERPRISE',
           name: 'Enterprise',
-          description: 'For enterprise and organization that requires custom setup and custn data ingestion rates.',
+          description: 'For enterprise and organization that requires custom setup and custom data ingestion rates.',
           includedOperationsLimit: USAGE_DEFAULT_LIMITATIONS.ENTERPRISE.operations,
-          includedSchemaPushLimit: USAGE_DEFAULT_LIMITATIONS.ENTERPRISE.schemaPushes,
           retentionInDays: USAGE_DEFAULT_LIMITATIONS.ENTERPRISE.retention,
           rateLimit: 'UNLIMITED',
         },
@@ -160,7 +148,6 @@ export const resolvers: BillingModule.Resolvers = {
         monthlyRateLimit: {
           retentionInDays: USAGE_DEFAULT_LIMITATIONS.PRO.retention,
           operations: args.monthlyLimits.operations,
-          schemaPush: args.monthlyLimits.schemaPushes,
         },
       });
     },
@@ -194,7 +181,6 @@ export const resolvers: BillingModule.Resolvers = {
           monthlyRateLimit: {
             retentionInDays: USAGE_DEFAULT_LIMITATIONS.HOBBY.retention,
             operations: USAGE_DEFAULT_LIMITATIONS.HOBBY.operations,
-            schemaPush: USAGE_DEFAULT_LIMITATIONS.HOBBY.schemaPushes,
           },
         });
 
@@ -227,7 +213,6 @@ export const resolvers: BillingModule.Resolvers = {
           paymentMethodId: args.input.paymentMethodId,
           reserved: {
             operations: Math.floor(args.input.monthlyLimits.operations / 1_000_000),
-            schemaPushes: args.input.monthlyLimits.schemaPushes,
           },
         });
 
@@ -242,7 +227,6 @@ export const resolvers: BillingModule.Resolvers = {
           monthlyRateLimit: {
             retentionInDays: USAGE_DEFAULT_LIMITATIONS.PRO.retention,
             operations: args.input.monthlyLimits.operations || USAGE_DEFAULT_LIMITATIONS.PRO.operations,
-            schemaPush: args.input.monthlyLimits.schemaPushes || USAGE_DEFAULT_LIMITATIONS.PRO.schemaPushes,
           },
         });
 

--- a/packages/services/api/src/modules/organization/providers/organization-manager.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-manager.ts
@@ -287,7 +287,6 @@ export class OrganizationManager {
         organizationId: organization.id,
         reserved: {
           operations: Math.floor(input.monthlyRateLimit.operations / 1_000_000),
-          schemaPushes: input.monthlyRateLimit.schemaPush,
         },
       });
     }

--- a/packages/services/api/src/modules/rate-limit/module.graphql.ts
+++ b/packages/services/api/src/modules/rate-limit/module.graphql.ts
@@ -3,15 +3,12 @@ import { gql } from 'graphql-modules';
 export default gql`
   type RateLimit {
     limitedForOperations: Boolean!
-    limitedForSchemaPushes: Boolean!
     operations: SafeInt!
-    schemaPushes: SafeInt!
     retentionInDays: Int!
   }
 
   input RateLimitInput {
     operations: SafeInt!
-    schemaPushes: SafeInt!
   }
 
   extend type Organization {

--- a/packages/services/api/src/modules/rate-limit/resolvers.ts
+++ b/packages/services/api/src/modules/rate-limit/resolvers.ts
@@ -5,34 +5,23 @@ export const resolvers: RateLimitModule.Resolvers = {
   Organization: {
     rateLimit: async (org, args, { injector }) => {
       let limitedForOperations = false;
-      let limitedForSchemaPushes = false;
 
       try {
-        const [operationsRateLimit, schemaPushLimit] = await Promise.all([
-          injector.get(RateLimitProvider).checkRateLimit({
-            entityType: 'organization',
-            id: org.id,
-            type: 'operations-reporting',
-          }),
-          injector.get(RateLimitProvider).checkRateLimit({
-            entityType: 'organization',
-            id: org.id,
-            type: 'schema-push',
-          }),
-        ]);
+        const operationsRateLimit = await injector.get(RateLimitProvider).checkRateLimit({
+          entityType: 'organization',
+          id: org.id,
+          type: 'operations-reporting',
+        });
 
-        console.info('Fetched rate-limit info:', { orgId: org.id, operationsRateLimit, schemaPushLimit });
+        console.info('Fetched rate-limit info:', { orgId: org.id, operationsRateLimit });
         limitedForOperations = operationsRateLimit.limited;
-        limitedForSchemaPushes = schemaPushLimit.limited;
       } catch (e) {
         console.warn('Failed to fetch rate-limit info:', org.id, e);
       }
 
       return {
         limitedForOperations,
-        limitedForSchemaPushes,
         operations: org.monthlyRateLimit.operations,
-        schemaPushes: org.monthlyRateLimit.schemaPush,
         retentionInDays: org.monthlyRateLimit.retentionInDays,
       };
     },

--- a/packages/services/api/src/modules/schema/resolvers.ts
+++ b/packages/services/api/src/modules/schema/resolvers.ts
@@ -12,7 +12,6 @@ import { SchemaBuildError } from './providers/orchestrators/errors';
 import { TargetManager } from '../target/providers/target-manager';
 import { AuthManager } from '../auth/providers/auth-manager';
 import { parseResolveInfo } from 'graphql-parse-resolve-info';
-import { RateLimitProvider } from '../rate-limit/providers/rate-limit.provider';
 import { z } from 'zod';
 import { SchemaHelper } from './providers/schema-helper';
 
@@ -43,13 +42,6 @@ export const resolvers: SchemaModule.Resolvers = {
         injector.get(TargetManager).getTargetIdByToken(),
       ]);
       const token = injector.get(AuthManager).ensureApiToken();
-
-      await injector.get(RateLimitProvider).assertRateLimit({
-        entityType: 'target',
-        id: target,
-        type: 'schema-push',
-        token,
-      });
 
       const checksum = createHash('md5').update(JSON.stringify(input)).update(token).digest('base64');
 

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -289,7 +289,6 @@ export interface Storage {
       org_name: string;
       target: string;
       limit_operations_monthly: number;
-      limit_schema_push_monthly: number;
       limit_retention_days: number;
     }>
   >;

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -200,15 +200,6 @@ export interface Storage {
 
   getSchema(_: { commit: string; target: string }): Promise<Schema | never>;
 
-  getSchemaPushCount(_: { targetIds: string[]; startTime: Date; endTime: Date }): Promise<number>;
-
-  getAllSchemaPushesGrouped(_: { startTime: Date; endTime: Date }): Promise<
-    {
-      total: number;
-      target: string;
-    }[]
-  >;
-
   createActivity(
     _: {
       user: string;

--- a/packages/services/api/src/modules/usage-estimation/module.graphql.ts
+++ b/packages/services/api/src/modules/usage-estimation/module.graphql.ts
@@ -11,7 +11,6 @@ export default gql`
   }
 
   type UsageEstimation {
-    schemaPushes: SafeInt!
     operations: SafeInt!
   }
 `;

--- a/packages/services/api/src/modules/usage-estimation/providers/usage-estimation.provider.ts
+++ b/packages/services/api/src/modules/usage-estimation/providers/usage-estimation.provider.ts
@@ -46,23 +46,4 @@ export class UsageEstimationProvider {
 
     return result.totalOperations;
   }
-
-  @sentry('UsageEstimation.estimateSchemaPushes')
-  async estimateSchemaPushes(input: UsageEstimatorQueryInput<'estimateSchemaPushesForTarget'>): Promise<null | number> {
-    this.logger.debug('Estimation schema pushes, input: %o', input);
-
-    if (input.targetIds.length === 0) {
-      return 0;
-    }
-
-    if (!this.usageEstimator) {
-      this.logger.warn('Usage estimator is not available due to missing configuration');
-
-      return null;
-    }
-
-    const result = await this.usageEstimator.query('estimateSchemaPushesForTarget', input);
-
-    return result.totalSchemaPushes;
-  }
 }

--- a/packages/services/api/src/modules/usage-estimation/resolvers.ts
+++ b/packages/services/api/src/modules/usage-estimation/resolvers.ts
@@ -76,18 +76,5 @@ export const resolvers: UsageEstimationModule.Resolvers = {
 
       return result;
     },
-    schemaPushes: async (params, args, { injector }) => {
-      const result = await injector.get(UsageEstimationProvider).estimateSchemaPushes({
-        targetIds: params.targets,
-        endTime: params.endTime.toString(),
-        startTime: params.startTime.toString(),
-      });
-
-      if (!result && result !== 0) {
-        throw new EnvelopError(`Failed to estimate usage, please try again later.`);
-      }
-
-      return result;
-    },
   },
 };

--- a/packages/services/api/src/shared/entities.ts
+++ b/packages/services/api/src/shared/entities.ts
@@ -113,7 +113,6 @@ export interface Organization {
   monthlyRateLimit: {
     retentionInDays: number;
     operations: number;
-    schemaPush: number;
   };
   getStarted: OrganizationGetStarted;
 }

--- a/packages/services/rate-limit/src/api.ts
+++ b/packages/services/rate-limit/src/api.ts
@@ -9,7 +9,7 @@ const VALIDATION = z
   .object({
     id: z.string().nonempty(),
     entityType: z.enum(['organization', 'target']),
-    type: z.enum(['schema-push', 'operations-reporting']),
+    type: z.enum(['operations-reporting']),
     /**
      * Token is optional, and used only when an additional blocking (WAF) process is needed.
      */

--- a/packages/services/rate-limit/src/metrics.ts
+++ b/packages/services/rate-limit/src/metrics.ts
@@ -1,11 +1,5 @@
 import { metrics } from '@hive/service-common';
 
-export const rateLimitSchemaEventOrg = new metrics.Counter({
-  name: 'rate_limited_schema_events_count',
-  help: 'Rate limit events per org id, for schema pushses.',
-  labelNames: ['orgId', 'orgName'],
-});
-
 export const rateLimitOperationsEventOrg = new metrics.Counter({
   name: 'rate_limited_operations_events_count',
   help: 'Rate limit events per org id, for operations.',

--- a/packages/services/storage/migrations/actions/2022.07.07T12.15.10.no-schema-pushes-limit.sql
+++ b/packages/services/storage/migrations/actions/2022.07.07T12.15.10.no-schema-pushes-limit.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.organizations DROP COLUMN limit_schema_push_monthly;

--- a/packages/services/storage/migrations/actions/down/2022.07.07T12.15.10.no-schema-pushes-limit.sql
+++ b/packages/services/storage/migrations/actions/down/2022.07.07T12.15.10.no-schema-pushes-limit.sql
@@ -1,0 +1,1 @@
+ALTER table public.organizations ADD COLUMN limit_schema_push_monthly BIGINT NOT NULL DEFAULT 50; -- HOBBY plan is default

--- a/packages/services/storage/src/db/types.ts
+++ b/packages/services/storage/src/db/types.ts
@@ -83,7 +83,6 @@ export interface organizations {
   invite_code: string;
   limit_operations_monthly: string;
   limit_retention_days: string;
-  limit_schema_push_monthly: string;
   name: string;
   plan_name: string;
   slack_token: string | null;

--- a/packages/services/stripe-billing/src/api.ts
+++ b/packages/services/stripe-billing/src/api.ts
@@ -9,7 +9,6 @@ export type Context = {
   storage$: ReturnType<typeof createStorage>;
   stripe: Stripe;
   stripeData$: Promise<{
-    schemaPushesPrice: Stripe.Price;
     operationsPrice: Stripe.Price;
     basePrice: Stripe.Price;
   }>;
@@ -120,7 +119,6 @@ export const stripeBillingApiRouter = trpc
         .object({
           /** in millions, value 1 is actually 1_000_000 */
           operations: z.number().nonnegative(),
-          schemaPushes: z.number().nonnegative(),
         })
         .required(),
     }),
@@ -148,11 +146,6 @@ export const stripeBillingApiRouter = trpc
             if (item.plan.id === stripePrices.operationsPrice.id) {
               await ctx.stripe.subscriptionItems.update(item.id, {
                 quantity: input.reserved.operations,
-              });
-            }
-            if (item.plan.id === stripePrices.schemaPushesPrice.id) {
-              await ctx.stripe.subscriptionItems.update(item.id, {
-                quantity: input.reserved.schemaPushes,
               });
             }
           }
@@ -213,7 +206,6 @@ export const stripeBillingApiRouter = trpc
         .object({
           /** in millions, value 1 is actually 1_000_000 */
           operations: z.number().nonnegative(),
-          schemaPushes: z.number().nonnegative(),
         })
         .required(),
     }),
@@ -298,10 +290,6 @@ export const stripeBillingApiRouter = trpc
           {
             price: stripePrices.operationsPrice.id,
             quantity: input.reserved.operations,
-          },
-          {
-            price: stripePrices.schemaPushesPrice.id,
-            quantity: input.reserved.schemaPushes,
           },
         ],
       });

--- a/packages/services/stripe-billing/src/api.ts
+++ b/packages/services/stripe-billing/src/api.ts
@@ -280,7 +280,7 @@ export const stripeBillingApiRouter = trpc
         coupon: input.couponCode || undefined,
         customer: customerId,
         default_payment_method: paymentMethodId,
-        trial_end: Math.floor(addDays(new Date(), 14).getTime() / 1000),
+        trial_end: Math.floor(addDays(new Date(), 30).getTime() / 1000),
         backdate_start_date: Math.floor(startOfMonth(new Date()).getTime() / 1000),
         items: [
           {

--- a/packages/services/stripe-billing/src/billing-sync.ts
+++ b/packages/services/stripe-billing/src/billing-sync.ts
@@ -30,7 +30,6 @@ export function createStripeBilling(config: {
   const loadStripeData$ = ensureStripeProducts();
 
   async function ensureStripeProducts(): Promise<{
-    schemaPushesPrice: Stripe.Price;
     operationsPrice: Stripe.Price;
     basePrice: Stripe.Price;
   }> {
@@ -51,12 +50,6 @@ export function createStripeBilling(config: {
       expand: ['data.tiers'],
     })) as Stripe.Response<Stripe.ApiList<Stripe.Price & { tiers: Stripe.Price.Tier[] }>>;
 
-    const schemaPushesPrice = prices.data.find(v => v.metadata?.hive_usage === 'schema_pushes');
-
-    if (!schemaPushesPrice) {
-      throw new Error(`Failed to find Stripe price ID with Hive metadata for schema-pushses`);
-    }
-
     const operationsPrice = prices.data.find(v => v.metadata?.hive_usage === 'operations');
 
     if (!operationsPrice) {
@@ -71,7 +64,6 @@ export function createStripeBilling(config: {
 
     return {
       operationsPrice,
-      schemaPushesPrice,
       basePrice,
     };
   }

--- a/packages/services/stripe-billing/src/billing-sync.ts
+++ b/packages/services/stripe-billing/src/billing-sync.ts
@@ -38,7 +38,7 @@ export function createStripeBilling(config: {
         active: true,
         type: 'service',
       })
-      .then(r => r.data.filter(v => v.metadata?.hive_plan));
+      .then(r => r.data.filter(v => v.metadata?.hive_plan && v.active === true));
 
     if (relevantProducts.length !== 1) {
       throw new Error(`Invalid count of Hive products configured in Stripe: ${relevantProducts.length}`);

--- a/packages/services/usage-estimator/package.json
+++ b/packages/services/usage-estimator/package.json
@@ -23,7 +23,6 @@
   "devDependencies": {
     "@hive/api": "0.0.1",
     "@hive/service-common": "0.0.0",
-    "@hive/storage": "0.0.0",
     "pino-pretty": "6.0.0"
   },
   "buildOptions": {

--- a/packages/services/usage-estimator/src/api.ts
+++ b/packages/services/usage-estimator/src/api.ts
@@ -14,36 +14,6 @@ const TARGET_BASED_FILTER = {
 
 export const usageEstimatorApiRouter = trpc
   .router<Estimator>()
-  .query('estimateSchemaPushesForTarget', {
-    input: z
-      .object({
-        ...DATE_RANGE_VALIDATION,
-        ...TARGET_BASED_FILTER,
-      })
-      .required(),
-    async resolve({ ctx, input }) {
-      const estimationResponse = await ctx.estimateSchemaPushesForTargets({
-        targets: input.targetIds,
-        startTime: new Date(input.startTime),
-        endTime: new Date(input.endTime),
-      });
-
-      return {
-        totalSchemaPushes: estimationResponse.count,
-      };
-    },
-  })
-  .query('estiamteSchemaPushesForAllTargets', {
-    input: z.object(DATE_RANGE_VALIDATION).required(),
-    async resolve({ ctx, input }) {
-      const estimationResponse = await ctx.estimateSchemaPushesForAllTargets({
-        startTime: new Date(input.startTime),
-        endTime: new Date(input.endTime),
-      });
-
-      return Object.fromEntries(estimationResponse.map(item => [item.target, item.total]));
-    },
-  })
   .query('estimateOperationsForTarget', {
     input: z
       .object({

--- a/packages/services/usage-estimator/src/index.ts
+++ b/packages/services/usage-estimator/src/index.ts
@@ -3,7 +3,6 @@ import 'reflect-metadata';
 import * as Sentry from '@sentry/node';
 import { createServer, startMetrics, ensureEnv, registerShutdown, reportReadiness } from '@hive/service-common';
 import { createEstimator } from './estimator';
-import { createConnectionString } from '@hive/storage';
 import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify/dist/trpc-server-adapters-fastify.cjs.js';
 import { usageEstimatorApiRouter } from './api';
 import { clickHouseElapsedDuration, clickHouseReadDuration } from './metrics';
@@ -35,9 +34,6 @@ async function main() {
           clickHouseReadDuration.labels({ query }).observe(timings.totalSeconds);
           clickHouseElapsedDuration.labels({ query }).observe(timings.elapsedSeconds);
         },
-      },
-      storage: {
-        connectionString: createConnectionString(process.env as any),
       },
     });
 

--- a/packages/web/app/pages/[orgId]/subscription/index.tsx
+++ b/packages/web/app/pages/[orgId]/subscription/index.tsx
@@ -66,7 +66,9 @@ const Page = ({
                   <StatNumber>
                     {CurrencyFormatter.format(organization.billingConfiguration.upcomingInvoice.amount)}
                   </StatNumber>
-                  <StatHelpText>{organization.billingConfiguration.upcomingInvoice.date}</StatHelpText>
+                  <StatHelpText>
+                    {DateFormatter.format(new Date(organization.billingConfiguration.upcomingInvoice.date))}
+                  </StatHelpText>
                 </Stat>
               )}
             </BillingView>

--- a/packages/web/app/pages/[orgId]/subscription/index.tsx
+++ b/packages/web/app/pages/[orgId]/subscription/index.tsx
@@ -84,9 +84,9 @@ const Page = ({
           </div>
         </Card>
         {organization.billingConfiguration?.invoices?.length && (
-          <Card>
-            <Heading className="mb-2">Invoices</Heading>
-            <div>
+          <Card className="mt-8">
+            <Heading>Invoices</Heading>
+            <div className="mt-4">
               <InvoicesList organization={organization} />
             </div>
           </Card>

--- a/packages/web/app/src/components/get-started/wizard.tsx
+++ b/packages/web/app/src/components/get-started/wizard.tsx
@@ -57,7 +57,7 @@ export function GetStartedProgress({
   return (
     <>
       <button onClick={onOpen} className="cursor-pointer rounded px-4 py-2 text-left hover:opacity-80" ref={triggerRef}>
-        <div className="font-medium">Get Started</div>
+        <div className="text-sm font-medium">Get Started</div>
         <div className="text-xs text-gray-500">
           {remaining} remaining task{remaining > 1 ? 's' : ''}
         </div>

--- a/packages/web/app/src/components/organization/Usage.tsx
+++ b/packages/web/app/src/components/organization/Usage.tsx
@@ -53,19 +53,6 @@ export const OrganizationUsageEstimationView: React.FC<{
                       />
                     </Td>
                   </Tr>
-                  <Tr>
-                    <Td>Schema Pushes</Td>
-                    <Td isNumeric>{NumericFormatter.format(result.data.usageEstimation.org.schemaPushes)}</Td>
-                    <Td isNumeric>{NumericFormatter.format(organization.rateLimit.schemaPushes)}</Td>
-                    <Td isNumeric>
-                      <Scale
-                        value={result.data.usageEstimation.org.schemaPushes}
-                        size={10}
-                        max={organization.rateLimit.schemaPushes}
-                        tw="justify-end"
-                      />
-                    </Td>
-                  </Tr>
                 </Tbody>
               </Table>
             </TableContainer>

--- a/packages/web/app/src/components/organization/billing/Billing.tsx
+++ b/packages/web/app/src/components/organization/billing/Billing.tsx
@@ -25,7 +25,6 @@ export const BillingView: React.FC<{
           <PlanSummary
             retentionInDays={organization.rateLimit.retentionInDays}
             operationsRateLimit={Math.floor(organization.rateLimit.operations / 1_000_000)}
-            schemaPushesRateLimit={organization.rateLimit.schemaPushes}
             plan={plan}
           >
             {children}

--- a/packages/web/app/src/components/organization/billing/BillingPlanPicker.tsx
+++ b/packages/web/app/src/components/organization/billing/BillingPlanPicker.tsx
@@ -5,8 +5,6 @@ import { BillingPlanType, BillingPlansQuery } from '@/graphql';
 import { Label, Section } from '@/components/common';
 import { Link, RadioGroup, Radio } from '@/components/v2';
 
-const comingSoon = <span className="text-xs">(coming soon)</span>;
-
 const planCollection: {
   [key in BillingPlanType]: {
     description: string;
@@ -18,32 +16,22 @@ const planCollection: {
     description: 'For personal or small projects',
     features: [
       'Unlimited seats',
-      '1M operations',
-      '50 schema pushes',
-      'Schema Registry',
-      'Detection of breaking changes based on usage reports',
-      'GitHub and Slack integrations',
-      '3 days of usage data retention',
+      'Unlimited schema pushes',
+      'Limit of 1M operations',
+      '7 days of usage data retention',
     ],
   },
   [BillingPlanType.Pro]: {
-    description: 'For growing teams',
+    description: 'For scaling API',
     features: [
       'Unlimited seats',
-      '5M operations',
-      '500 schema pushes',
-      'Schema Registry',
-      'Detection of breaking changes based on usage reports',
-      'GitHub and Slack integrations',
-      '180 days of usage data retention',
-      <div>Schema Policy Checks {comingSoon}</div>,
-      <div>ESLint integration {comingSoon}</div>,
+      'Unlimited schema pushes',
+      '$10 per 1M operations',
+      '90 days of usage data retention',
     ],
     footer: (
       <>
-        <div className="mb-2 text-sm font-bold">Free 14-day trial period</div>
-        <div>$15 for additional 1M operations</div>
-        <div>$1 for additional 10 schema pushes</div>
+        <div className="mb-2 text-sm font-bold">Free 30 days trial period</div>
       </>
     ),
   },
@@ -53,13 +41,7 @@ const planCollection: {
       'Unlimited seats',
       'Unlimited operations',
       'Unlimited schema pushes',
-      'Schema Registry',
-      'Detection of breaking changes based on usage reports',
-      'GitHub and Slack integrations',
-      '360 days of usage data retention',
-      <div>Schema Policy Checks {comingSoon}</div>,
-      <div>ESLint integration {comingSoon}</div>,
-      <div>SAML {comingSoon}</div>,
+      '12 months of usage data retention',
       <span className="flex gap-1">
         Support from
         <Link variant="primary" href="https://the-guild.dev" target="_blank" rel="noreferrer">

--- a/packages/web/app/src/components/organization/billing/InvoicesList.tsx
+++ b/packages/web/app/src/components/organization/billing/InvoicesList.tsx
@@ -2,7 +2,7 @@ import { OrganizationFieldsFragment, OrgBillingInfoFieldsFragment } from '@/grap
 import { Table, TableContainer, Tbody, Td, Th, Thead, Tr, Link } from '@chakra-ui/react';
 import React from 'react';
 import { VscCloudDownload } from 'react-icons/vsc';
-import { CurrencyFormatter } from './helpers';
+import { CurrencyFormatter, DateFormatter } from './helpers';
 
 export const InvoicesList: React.FC<{
   organization: OrganizationFieldsFragment & OrgBillingInfoFieldsFragment;
@@ -26,10 +26,10 @@ export const InvoicesList: React.FC<{
         <Tbody>
           {organization.billingConfiguration.invoices.map(invoice => (
             <Tr>
-              <Td>{invoice.date}</Td>
+              <Td>{DateFormatter.format(new Date(invoice.date))}</Td>
               <Td>{CurrencyFormatter.format(invoice.amount)}</Td>
-              <Td>{invoice.periodStart}</Td>
-              <Td>{invoice.periodEnd}</Td>
+              <Td>{DateFormatter.format(new Date(invoice.periodStart))}</Td>
+              <Td>{DateFormatter.format(new Date(invoice.periodEnd))}</Td>
               <Td>
                 {invoice.pdfLink ? (
                   <Link href={invoice.pdfLink}>

--- a/packages/web/app/src/components/organization/billing/PlanSummary.tsx
+++ b/packages/web/app/src/components/organization/billing/PlanSummary.tsx
@@ -19,18 +19,14 @@ import { CurrencyFormatter } from './helpers';
 const PriceEstimationTable = ({
   plan,
   operationsRateLimit,
-  schemaPushesRateLimit,
 }: {
   plan: BillingPlansQuery['billingPlans'][number];
   operationsRateLimit: number;
-  schemaPushesRateLimit: number;
 }): ReactElement => {
   const includedOperationsInMillions = (plan.includedOperationsLimit ?? 0) / 1_000_000;
   const additionalOperations = Math.max(0, operationsRateLimit - includedOperationsInMillions);
   const operationsTotal = (plan.pricePerOperationsUnit ?? 0) * additionalOperations;
-  const additionalSchemaPushes = Math.max(0, schemaPushesRateLimit - (plan.includedSchemaPushLimit ?? 0));
-  const schemaTotal = (plan.pricePerSchemaPushUnit ?? 0) * additionalSchemaPushes;
-  const total = (plan.basePrice ?? 0) + operationsTotal + schemaTotal;
+  const total = (plan.basePrice ?? 0) + operationsTotal;
 
   return (
     <Table size="sm">
@@ -51,36 +47,22 @@ const PriceEstimationTable = ({
           <Td isNumeric>{CurrencyFormatter.format(plan.basePrice ?? 0)}</Td>
           <Td isNumeric>{CurrencyFormatter.format(plan.basePrice ?? 0)}</Td>
         </Tr>
-        <Tr>
-          <Td>
-            Included Operations <span className="text-gray-500">(free)</span>
-          </Td>
-          <Td isNumeric>{includedOperationsInMillions}M</Td>
-          <Td isNumeric>{CurrencyFormatter.format(0)}</Td>
-          <Td isNumeric>{CurrencyFormatter.format(0)}</Td>
-        </Tr>
-        <Tr>
-          <Td>
-            Included Schema Pushes <span className="text-gray-500">(free)</span>
-          </Td>
-          <Td isNumeric>{plan.includedSchemaPushLimit}</Td>
-          <Td isNumeric>{CurrencyFormatter.format(0)}</Td>
-          <Td isNumeric>{CurrencyFormatter.format(0)}</Td>
-        </Tr>
+        {includedOperationsInMillions > 0 ? (
+          <Tr>
+            <Td>
+              Included Operations <span className="text-gray-500">(free)</span>
+            </Td>
+            <Td isNumeric>{includedOperationsInMillions}M</Td>
+            <Td isNumeric>{CurrencyFormatter.format(0)}</Td>
+            <Td isNumeric>{CurrencyFormatter.format(0)}</Td>
+          </Tr>
+        ) : null}
         {plan.planType === BillingPlanType.Pro && (
           <Tr>
-            <Td>Additional Operations</Td>
+            <Td>Operations</Td>
             <Td isNumeric>{additionalOperations}M</Td>
             <Td isNumeric>{CurrencyFormatter.format(plan.pricePerOperationsUnit ?? 0)}</Td>
             <Td isNumeric>{CurrencyFormatter.format(operationsTotal)}</Td>
-          </Tr>
-        )}
-        {plan.planType === BillingPlanType.Pro && (
-          <Tr>
-            <Td>Additional Schema Pushes</Td>
-            <Td isNumeric>{additionalSchemaPushes}</Td>
-            <Td isNumeric>{CurrencyFormatter.format(plan.pricePerSchemaPushUnit ?? 0)}</Td>
-            <Td isNumeric>{CurrencyFormatter.format(schemaTotal)}</Td>
           </Tr>
         )}
       </Tbody>
@@ -99,13 +81,11 @@ const PriceEstimationTable = ({
 export const PlanSummary = ({
   plan,
   operationsRateLimit,
-  schemaPushesRateLimit,
   retentionInDays,
   children,
 }: {
   plan: BillingPlansQuery['billingPlans'][number];
   operationsRateLimit: number;
-  schemaPushesRateLimit: number;
   retentionInDays: number;
   children: ReactNode;
 }): ReactElement => {
@@ -141,22 +121,12 @@ export const PlanSummary = ({
           <StatHelpText>per month</StatHelpText>
         </Stat>
         <Stat className="mb-8">
-          <StatLabel>Schema Pushes Limit</StatLabel>
-          <StatHelpText>up to</StatHelpText>
-          <StatNumber>{schemaPushesRateLimit}</StatNumber>
-          <StatHelpText>per month</StatHelpText>
-        </Stat>
-        <Stat className="mb-8">
           <StatLabel>Retention</StatLabel>
           <StatHelpText>usage reports</StatHelpText>
           <StatNumber>{retentionInDays} days</StatNumber>
         </Stat>
       </StatGroup>
-      <PriceEstimationTable
-        plan={plan}
-        operationsRateLimit={operationsRateLimit}
-        schemaPushesRateLimit={schemaPushesRateLimit}
-      />
+      <PriceEstimationTable plan={plan} operationsRateLimit={operationsRateLimit} />
     </>
   );
 };

--- a/packages/web/app/src/components/organization/billing/RateLimitWarn.tsx
+++ b/packages/web/app/src/components/organization/billing/RateLimitWarn.tsx
@@ -5,17 +5,12 @@ import React from 'react';
 export const RateLimitWarn: React.FC<{
   organization: OrgRateLimitFieldsFragment;
 }> = ({ organization }) => {
-  if (organization.rateLimit.limitedForOperations || organization.rateLimit.limitedForSchemaPushes) {
-    const limitedFor = [
-      organization.rateLimit.limitedForOperations ? 'operations' : undefined,
-      organization.rateLimit.limitedForSchemaPushes ? 'schema pushses' : undefined,
-    ].filter(Boolean);
-
+  if (organization.rateLimit.limitedForOperations) {
     return (
       <Alert status="warning" width="50%" m="5">
         <AlertIcon />
         <Box flex="1">
-          <AlertTitle>Your organization is being rate-limited for {limitedFor.join(' and ')}.</AlertTitle>
+          <AlertTitle>Your organization is being rate-limited for operations.</AlertTitle>
           <AlertDescription display="block">
             Since you reached your organization rate-limit and data ingestion limitation, your organization{' '}
             <strong>{organization.name}</strong> is currently unable to ingest data.

--- a/packages/web/app/src/components/organization/billing/helpers.tsx
+++ b/packages/web/app/src/components/organization/billing/helpers.tsx
@@ -3,3 +3,9 @@ export const CurrencyFormatter = Intl.NumberFormat('en', {
   currency: 'USD',
   style: 'currency',
 });
+
+export const DateFormatter = Intl.DateTimeFormat('en', {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+});

--- a/packages/web/app/src/graphql/fragments.graphql
+++ b/packages/web/app/src/graphql/fragments.graphql
@@ -402,9 +402,7 @@ fragment OrgRateLimitFields on Organization {
   name
   rateLimit {
     limitedForOperations
-    limitedForSchemaPushes
     operations
-    schemaPushes
     retentionInDays
   }
 }

--- a/packages/web/app/src/graphql/query.billing-plans.graphql
+++ b/packages/web/app/src/graphql/query.billing-plans.graphql
@@ -6,9 +6,7 @@ query billingPlans {
     basePrice
     description
     includedOperationsLimit
-    includedSchemaPushLimit
     pricePerOperationsUnit
-    pricePerSchemaPushUnit
     rateLimit
     retentionInDays
   }

--- a/packages/web/app/src/graphql/query.org-usage-estimation.graphql
+++ b/packages/web/app/src/graphql/query.org-usage-estimation.graphql
@@ -2,7 +2,6 @@ query usageEstimation($range: DateRangeInput!, $organization: ID!) {
   usageEstimation(range: $range) {
     org(selector: { organization: $organization }) {
       operations
-      schemaPushes
     }
   }
 }

--- a/packages/web/app/tsconfig.json
+++ b/packages/web/app/tsconfig.json
@@ -22,6 +22,6 @@
     },
     "incremental": true
   },
-  "include": ["next-env.d.ts", "twin.d.ts", "modules.d.ts", "**/*.ts", "**/*.tsx", "pages/stack/[stackId]/2"],
+  "include": ["next-env.d.ts", "modules.d.ts", "twin.d.ts", "src", "pages"],
   "exclude": ["node_modules"]
 }

--- a/packages/web/landing-page/components/pricing.tsx
+++ b/packages/web/landing-page/components/pricing.tsx
@@ -1,10 +1,27 @@
 import React from 'react';
 import 'twin.macro';
+import * as RadixTooltip from '@radix-ui/react-tooltip';
+
+function Tooltip(
+  props: React.PropsWithChildren<{
+    content: string;
+  }>
+) {
+  return (
+    <RadixTooltip.Root>
+      <RadixTooltip.Trigger>{props.children}</RadixTooltip.Trigger>
+      <RadixTooltip.Content sideOffset={5} tw="p-2 text-xs rounded-sm bg-white shadow">
+        {props.content}
+        <RadixTooltip.Arrow tw="fill-current text-white" />
+      </RadixTooltip.Content>
+    </RadixTooltip.Root>
+  );
+}
 
 function Plan(plan: {
   name: string;
   description: string;
-  price: number | string;
+  price: React.ReactNode | string;
   features: Array<React.ReactNode | string>;
   footer?: React.ReactNode;
 }) {
@@ -13,18 +30,8 @@ function Plan(plan: {
       <div tw="flex h-full flex-col justify-between">
         <div>
           <h2 tw="text-base text-white font-bold flex items-center justify-between">{plan.name}</h2>
-          <div tw="text-3xl font-bold text-white">
-            {typeof plan.price === 'string' ? (
-              plan.price
-            ) : (
-              <>
-                {'$'}
-                {plan.price}
-                <span tw="text-sm text-gray-500">/mo</span>
-              </>
-            )}
-          </div>
-          <div tw="text-sm text-gray-500">{plan.description}</div>
+          <div tw="text-3xl font-bold text-white">{plan.price}</div>
+          <div tw="text-sm text-gray-500 mt-3">{plan.description}</div>
           <div>
             <ul tw="mt-6 list-disc px-5 text-gray-500">
               {plan.features.map((feature, i) => {
@@ -48,12 +55,15 @@ function Plan(plan: {
   );
 }
 
+const usageDataRetentionExplainer = 'How long to store GraphQL requests reported to GraphQL Hive';
+const operationsExplainer = 'GraphQL requests reported to GraphQL Hive';
+
 export function Pricing() {
   return (
     <div style={{ backgroundColor: 'rgb(23, 23, 23)' }} tw="w-full">
       <div tw="max-width[1024px] w-full px-6 box-border mx-auto my-12">
         <h2 tw="md:text-3xl text-2xl text-white font-bold">Pricing</h2>
-        <p tw="text-gray-400">Available in the application</p>
+        <p tw="text-gray-400">All features for every plan</p>
         <div tw="flex flex-col md:flex-row content-start items-stretch justify-start justify-items-start gap-4 mt-6">
           <Plan
             name="Hobby"
@@ -61,60 +71,51 @@ export function Pricing() {
             price="Free"
             features={[
               'Unlimited seats',
-              '1M operations',
-              '50 schema pushes',
-              'Schema Registry',
-              'Detection of breaking changes based on usage reports',
-              'GitHub and Slack integrations',
-              '3 days of usage data retention',
+              'Unlimited schema pushes',
+              <Tooltip content={operationsExplainer}>Limit of 1M operations monthly</Tooltip>,
+              <Tooltip content={usageDataRetentionExplainer}>7 days of usage data retention</Tooltip>,
             ]}
           />
           <Plan
             name="Pro"
-            description="For growing teams"
-            price={50}
+            description="For scaling API"
+            price={
+              <Tooltip content="Base price charged monthly">
+                $10<span tw="text-sm text-gray-500">/mo</span>
+              </Tooltip>
+            }
             features={[
               'Unlimited seats',
-              '5M operations',
-              '500 schema pushes',
-              'Schema Registry',
-              'Detection of breaking changes based on usage reports',
-              'GitHub and Slack integrations',
-              '180 days of usage data retention',
-              <div>
-                Schema Policy Checks <span tw="text-xs">(coming soon)</span>
-              </div>,
-              <div>
-                ESLint integration <span tw="text-xs">(coming soon)</span>
-              </div>,
+              'Unlimited schema pushes',
+              <Tooltip content={operationsExplainer}>$10 per 1M operations monthly</Tooltip>,
+              <Tooltip content={usageDataRetentionExplainer}>90 days of usage data retention</Tooltip>,
             ]}
             footer={
               <>
-                <div tw="mb-2 text-sm font-bold">Free 14-day trial period</div>
-                <div>$15 for additional 1M operations</div>
-                <div>$1 for additional 10 schema pushes</div>
+                <div tw="mb-2 text-sm font-bold">Free 30 days trial period</div>
               </>
             }
           />
           <Plan
             name="Enterprise"
             description="Custom plan for large companies"
-            price="Contact us"
+            price={
+              <span
+                tw="cursor-pointer"
+                onClick={() => {
+                  if (typeof window !== 'undefined' && (window as any).$crisp) {
+                    (window as any).$crisp.push(['do', 'chat:open']);
+                  }
+                }}
+              >
+                Contact us
+              </span>
+            }
             features={[
               'Unlimited seats',
-              'Unlimited operations',
               'Unlimited schema pushes',
-              'Schema Registry',
-              'Detection of breaking changes based on usage reports',
-              'GitHub and Slack integrations',
-              '360 days of usage data retention',
-              <div>
-                Schema Policy Checks <span tw="text-xs">(coming soon)</span>
-              </div>,
-              <div>
-                ESLint integration <span tw="text-xs">(coming soon)</span>
-              </div>,
-              'SAML (coming soon)',
+              <Tooltip content={operationsExplainer}>Unlimited operations</Tooltip>,
+              <Tooltip content={usageDataRetentionExplainer}>12 months of usage data retention</Tooltip>,
               <span tw="flex gap-1">
                 Support from
                 <a

--- a/packages/web/landing-page/package.json
+++ b/packages/web/landing-page/package.json
@@ -7,9 +7,10 @@
     "build": "bob runify --single"
   },
   "dependencies": {
-    "next": "12.1.6",
+    "@radix-ui/react-tooltip": "0.1.7",
     "@theguild/components": "1.12.0-alpha-f2032ea.0",
     "framer-motion": "^6.3.3",
+    "next": "12.1.6",
     "react": "17.0.2",
     "react-dom": "17.0.2",
     "react-use": "^17.3.2",

--- a/packages/web/landing-page/pages/index.tsx
+++ b/packages/web/landing-page/pages/index.tsx
@@ -4,6 +4,7 @@ import Head from 'next/head';
 import { GlobalStyles } from 'twin.macro';
 import { css } from 'twin.macro';
 import { Header, FooterExtended, GlobalStyles as TGCStyles, ThemeProvider } from '@theguild/components';
+import * as Tooltip from '@radix-ui/react-tooltip';
 import { Pricing } from '../components/pricing';
 
 const CookiesConsent: React.FC = () => {
@@ -123,98 +124,100 @@ export default function Index() {
         <link rel="canonical" href="https://graphql-hive.com" />
       </Head>
 
-      <div tw="flex flex-col h-full">
-        <style global jsx>{`
-          * {
-            font-family: Inter;
-          }
-          .dark {
-            background-color: #0b0d11;
-          }
-          html,
-          body,
-          #__next {
-            height: 100vh;
-          }
-          body {
-            margin: 0;
-          }
-        `}</style>
-        <GlobalStyles />
-        <TGCStyles includeFonts={false} />
-        <Header accentColor="#D49605" activeLink="" disableSearch />
-        <div css={heroWrapper}>
-          <HeroGradient
-            title="Manage your GraphQL API workflow"
-            description={description}
-            colors={['#FFB21D']}
-            image={{
-              src: '/manage.svg',
-              alt: 'Manage workflows',
-            }}
-            link={[
+      <Tooltip.Provider>
+        <div tw="flex flex-col h-full">
+          <style global jsx>{`
+            * {
+              font-family: Inter;
+            }
+            .dark {
+              background-color: #0b0d11;
+            }
+            html,
+            body,
+            #__next {
+              height: 100vh;
+            }
+            body {
+              margin: 0;
+            }
+          `}</style>
+          <GlobalStyles />
+          <TGCStyles includeFonts={false} />
+          <Header accentColor="#D49605" activeLink="" disableSearch />
+          <div css={heroWrapper}>
+            <HeroGradient
+              title="Manage your GraphQL API workflow"
+              description={description}
+              colors={['#FFB21D']}
+              image={{
+                src: '/manage.svg',
+                alt: 'Manage workflows',
+              }}
+              link={[
+                {
+                  target: '_blank',
+                  href: 'https://app.graphql-hive.com',
+                  title: 'Go to app',
+                  children: 'Go to app',
+                },
+                {
+                  target: '_blank',
+                  href: 'https://docs.graphql-hive.com',
+                  title: 'Documentation',
+                  children: 'Documentation',
+                  style: {
+                    color: '#fff',
+                    border: '1px solid #fff',
+                    background: 'transparent',
+                  },
+                },
+                {
+                  target: '_blank',
+                  href: 'https://github.com/kamilkisiela/graphql-hive',
+                  title: 'GitHub',
+                  children: 'GitHub',
+                  style: {
+                    color: '#fff',
+                    border: '1px solid #fff',
+                    background: 'transparent',
+                  },
+                },
+              ]}
+            />
+          </div>
+          {ITEMS.map((option, i) => {
+            return (
+              <HeroIllustration
+                key={option.title}
+                title={option.title}
+                description={option.description}
+                image={{
+                  src: option.imageSrc,
+                  alt: option.imageAlt,
+                }}
+                flipped={i % 2 !== 0}
+              />
+            );
+          })}
+          <Pricing />
+          <FooterExtended
+            resources={[
               {
-                target: '_blank',
-                href: 'https://app.graphql-hive.com',
-                title: 'Go to app',
-                children: 'Go to app',
+                title: 'Privacy Policy',
+                href: '/privacy-policy.pdf',
+                children: 'Privacy Policy',
               },
               {
-                target: '_blank',
-                href: 'https://docs.graphql-hive.com',
-                title: 'Documentation',
-                children: 'Documentation',
-                style: {
-                  color: '#fff',
-                  border: '1px solid #fff',
-                  background: 'transparent',
-                },
-              },
-              {
-                target: '_blank',
-                href: 'https://github.com/kamilkisiela/graphql-hive',
-                title: 'GitHub',
-                children: 'GitHub',
-                style: {
-                  color: '#fff',
-                  border: '1px solid #fff',
-                  background: 'transparent',
-                },
+                title: 'Terms of Use',
+                href: '/terms-of-use.pdf',
+                children: 'Terms of Use',
               },
             ]}
           />
         </div>
-        {ITEMS.map((option, i) => {
-          return (
-            <HeroIllustration
-              key={option.title}
-              title={option.title}
-              description={option.description}
-              image={{
-                src: option.imageSrc,
-                alt: option.imageAlt,
-              }}
-              flipped={i % 2 !== 0}
-            />
-          );
-        })}
-        <Pricing />
-        <FooterExtended
-          resources={[
-            {
-              title: 'Privacy Policy',
-              href: '/privacy-policy.pdf',
-              children: 'Privacy Policy',
-            },
-            {
-              title: 'Terms of Use',
-              href: '/terms-of-use.pdf',
-              children: 'Terms of Use',
-            },
-          ]}
-        />
-      </div>
-      <CookiesConsent />
+        <CookiesConsent />
+      </Tooltip.Provider>
     </ThemeProvider>
   );
 }

--- a/packages/web/landing-page/tsconfig.json
+++ b/packages/web/landing-page/tsconfig.json
@@ -15,6 +15,6 @@
     "jsx": "preserve",
     "incremental": true
   },
-  "include": ["next-env.d.ts", "twin.d.ts", "**/*.ts", "**/*.tsx", "pages/stack/[stackId]/2"],
+  "include": ["next-env.d.ts", "twin.d.ts", "pages", "components"],
   "exclude": ["node_modules"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4027,6 +4027,27 @@
     "@radix-ui/react-separator" "0.1.3"
     "@radix-ui/react-toggle-group" "0.1.4"
 
+"@radix-ui/react-tooltip@0.1.7":
+  version "0.1.7"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-tooltip/-/react-tooltip-0.1.7.tgz#6f8c00d6e489565d14abf209ce0fb8853c8c8ee3"
+  integrity sha512-eiBUsVOHenZ0JR16tl970bB0DafJBz6mFgSGfIGIVpflFj0LIsIDiLMsYyvYdx1KwwsIUDTEZtxcPm/sWjPzqA==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@radix-ui/primitive" "0.1.0"
+    "@radix-ui/react-compose-refs" "0.1.0"
+    "@radix-ui/react-context" "0.1.1"
+    "@radix-ui/react-id" "0.1.5"
+    "@radix-ui/react-popper" "0.1.4"
+    "@radix-ui/react-portal" "0.1.4"
+    "@radix-ui/react-presence" "0.1.2"
+    "@radix-ui/react-primitive" "0.1.4"
+    "@radix-ui/react-slot" "0.1.2"
+    "@radix-ui/react-use-controllable-state" "0.1.0"
+    "@radix-ui/react-use-escape-keydown" "0.1.0"
+    "@radix-ui/react-use-previous" "0.1.1"
+    "@radix-ui/react-use-rect" "0.1.1"
+    "@radix-ui/react-visually-hidden" "0.1.4"
+
 "@radix-ui/react-use-body-pointer-events@0.1.1":
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-use-body-pointer-events/-/react-use-body-pointer-events-0.1.1.tgz#63e7fd81ca7ffd30841deb584cd2b7f460df2597"


### PR DESCRIPTION
**What has changed?**
- unlimited schema pushes for everyone
- lowered the base price of the Pro plan, it's now $10 (previously $50).
- increased usage data retention for Hobby plan from 3 to 7 days
- decreased usage data retention for Hobby plan from 180 to 90 days
- a longer trial period, it's now 30 days (previously 14 days)

For example, a Pro plan with 50M operations and 500 schema pushes costs now **~30%** less than before.


**Migration plan for Stripe:**
1. Archive the old product
1. Copy the new product to live
1. Cancel the old subscriptions and add the new subscriptions
