### PR TITLE
Client exclusions in breaking change detection

### DIFF
--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -412,6 +412,7 @@ export function setTargetValidation(
           enabled
           period
           percentage
+          excludedClients
         }
       }
     `),
@@ -445,6 +446,7 @@ export function updateTargetValidationSettings(
               targets {
                 id
               }
+              excludedClients
             }
           }
           error {

--- a/integration-tests/tests/api/target/usage.spec.ts
+++ b/integration-tests/tests/api/target/usage.spec.ts
@@ -16,7 +16,7 @@ import {
 import { authenticate } from '../../../testkit/auth';
 import { collect, CollectedOperation } from '../../../testkit/usage';
 import { clickHouseQuery } from '../../../testkit/clickhouse';
-// eslint-disable-next-line hive/enforce-deps-in-dev
+// eslint-disable-next-line hive/enforce-deps-in-dev, import/no-extraneous-dependencies
 import { normalizeOperation } from '@graphql-hive/core';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { parse, print } from 'graphql';
@@ -654,6 +654,199 @@ test('check usage from two selected targets', async () => {
       sdl: `type Query { me: String }`, // ping is used on production and we do check production now
     },
     tokenForStaging
+  );
+
+  if (usedCheckResult.body.data!.schemaCheck.__typename !== 'SchemaCheckSuccess') {
+    throw new Error(`Expected SchemaCheckSuccess, got ${usedCheckResult.body.data!.schemaCheck.__typename}`);
+  }
+
+  expect(usedCheckResult.body.data!.schemaCheck.valid).toEqual(true);
+  expect(usedCheckResult.body.errors).not.toBeDefined();
+});
+
+test('check usage not from excluded client names', async () => {
+  const { access_token: owner_access_token } = await authenticate('main');
+  const orgResult = await createOrganization(
+    {
+      name: 'foo',
+    },
+    owner_access_token
+  );
+
+  const org = orgResult.body.data!.createOrganization.ok!.createdOrganizationPayload.organization;
+
+  const projectResult = await createProject(
+    {
+      organization: org.cleanId,
+      type: ProjectType.Single,
+      name: 'foo',
+    },
+    owner_access_token
+  );
+
+  const project = projectResult.body.data!.createProject.ok!.createdProject;
+  const staging = projectResult.body.data!.createProject.ok!.createdTargets[0];
+
+  const productionTargetResult = await createTarget(
+    {
+      name: 'production',
+      organization: org.cleanId,
+      project: project.cleanId,
+    },
+    owner_access_token
+  );
+
+  const production = productionTargetResult.body.data!.createTarget.ok!.createdTarget;
+
+  const productionTokenResult = await createToken(
+    {
+      name: 'test',
+      organization: org.cleanId,
+      project: project.cleanId,
+      target: production.cleanId,
+      organizationScopes: [OrganizationAccessScope.Read],
+      projectScopes: [ProjectAccessScope.Read],
+      targetScopes: [TargetAccessScope.Read, TargetAccessScope.RegistryRead, TargetAccessScope.RegistryWrite],
+    },
+    owner_access_token
+  );
+
+  expect(productionTokenResult.body.errors).not.toBeDefined();
+
+  const tokenForProduction = productionTokenResult.body.data!.createToken.ok!.secret;
+
+  const schemaPublishResult = await publishSchema(
+    {
+      author: 'Kamil',
+      commit: 'usage-check-2',
+      sdl: `type Query { ping: String me: String }`,
+    },
+    tokenForProduction
+  );
+
+  expect(schemaPublishResult.body.errors).not.toBeDefined();
+  expect((schemaPublishResult.body.data!.schemaPublish as any).valid).toEqual(true);
+
+  const targetValidationResult = await setTargetValidation(
+    {
+      enabled: true,
+      organization: org.cleanId,
+      project: project.cleanId,
+      target: staging.cleanId,
+    },
+    {
+      authToken: owner_access_token,
+    }
+  );
+
+  expect(targetValidationResult.body.errors).not.toBeDefined();
+  expect(targetValidationResult.body.data!.setTargetValidation.enabled).toEqual(true);
+  expect(targetValidationResult.body.data!.setTargetValidation.percentage).toEqual(0);
+  expect(targetValidationResult.body.data!.setTargetValidation.period).toEqual(30);
+
+  const collectResult = await collect({
+    operations: [
+      {
+        timestamp: Date.now(),
+        operation: 'query ping { ping }',
+        operationName: 'ping',
+        fields: ['Query', 'Query.ping'],
+        execution: {
+          ok: true,
+          duration: 200000000,
+          errorsTotal: 0,
+        },
+        metadata: {
+          client: {
+            name: 'cli',
+            version: '2.0.0',
+          },
+        },
+      },
+      {
+        timestamp: Date.now(),
+        operation: 'query me { me }',
+        operationName: 'me',
+        fields: ['Query', 'Query.me'],
+        execution: {
+          ok: true,
+          duration: 200000000,
+          errorsTotal: 0,
+        },
+        metadata: {
+          client: {
+            name: 'app',
+            version: '1.0.0',
+          },
+        },
+      },
+      {
+        timestamp: Date.now(),
+        operation: 'query me { me }',
+        operationName: 'me',
+        fields: ['Query', 'Query.me'],
+        execution: {
+          ok: true,
+          duration: 200000000,
+          errorsTotal: 0,
+        },
+        metadata: {
+          client: {
+            name: 'app',
+            version: '1.0.1',
+          },
+        },
+      },
+    ],
+    token: tokenForProduction,
+  });
+
+  expect(collectResult.status).toEqual(200);
+
+  await waitFor(22_000);
+
+  // should be breaking because the field is used
+  const unusedCheckResult = await checkSchema(
+    {
+      sdl: `type Query { me: String }`, // ping is used
+    },
+    tokenForProduction
+  );
+  expect(unusedCheckResult.body.errors).not.toBeDefined();
+  expect(unusedCheckResult.body.data!.schemaCheck.__typename).toEqual('SchemaCheckSuccess');
+
+  // Exclude app from the check
+
+  const updateValidationResult = await updateTargetValidationSettings(
+    {
+      organization: org.cleanId,
+      project: project.cleanId,
+      target: staging.cleanId,
+      percentage: 0,
+      period: 2,
+      targets: [production.id],
+      excludedClients: ['app'],
+    },
+    {
+      authToken: owner_access_token,
+    }
+  );
+
+  expect(updateValidationResult.body.errors).not.toBeDefined();
+  expect(updateValidationResult.body.data!.updateTargetValidationSettings.error).toBeNull();
+  expect(
+    updateValidationResult.body.data!.updateTargetValidationSettings.ok!.updatedTargetValidationSettings.excludedClients
+  ).toHaveLength(1);
+  expect(
+    updateValidationResult.body.data!.updateTargetValidationSettings.ok!.updatedTargetValidationSettings.excludedClients
+  ).toContainEqual('app');
+
+  // should be safe because the field was not used by the non-excluded clients (cli never requested `Query.me`, but app did)
+  const usedCheckResult = await checkSchema(
+    {
+      sdl: `type Query { me: String }`,
+    },
+    tokenForProduction
   );
 
   if (usedCheckResult.body.data!.schemaCheck.__typename !== 'SchemaCheckSuccess') {

--- a/packages/services/api/src/modules/operations/module.graphql.ts
+++ b/packages/services/api/src/modules/operations/module.graphql.ts
@@ -71,6 +71,7 @@ export default gql`
     duration: DurationStats!
     operations: OperationStatsConnection!
     clients: ClientStatsConnection!
+    clientNames: [ClientNameStats!]
   }
 
   type OperationStatsConnection {
@@ -119,6 +120,11 @@ export default gql`
     version: String!
     count: Int!
     percentage: Float!
+  }
+
+  type ClientNameStats {
+    name: String!
+    count: Int!
   }
 
   type RequestsOverTime {

--- a/packages/services/api/src/modules/operations/module.graphql.ts
+++ b/packages/services/api/src/modules/operations/module.graphql.ts
@@ -6,6 +6,7 @@ export default gql`
     fieldListStats(selector: FieldListStatsInput!): [FieldStats!]!
     operationsStats(selector: OperationsStatsSelectorInput!): OperationsStats!
     hasCollectedOperations(selector: TargetSelectorInput!): Boolean!
+    clientStatsByTargets(selector: ClientStatsByTargetsInput!): ClientStatsConnection!
   }
 
   input OperationsStatsSelectorInput {
@@ -14,6 +15,13 @@ export default gql`
     target: ID!
     period: DateRangeInput!
     operations: [ID!]
+  }
+
+  input ClientStatsByTargetsInput {
+    organization: ID!
+    project: ID!
+    targetIds: [ID!]!
+    period: DateRangeInput!
   }
 
   input DateRangeInput {
@@ -71,7 +79,6 @@ export default gql`
     duration: DurationStats!
     operations: OperationStatsConnection!
     clients: ClientStatsConnection!
-    clientNames: [ClientNameStats!]
   }
 
   type OperationStatsConnection {

--- a/packages/services/api/src/modules/operations/providers/operations-manager.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-manager.ts
@@ -194,6 +194,7 @@ export class OperationsManager {
     project,
     target,
     unsafe__itIsMeInspector,
+    excludedClients,
   }: {
     fields: ReadonlyArray<{
       type: string;
@@ -208,6 +209,7 @@ export class OperationsManager {
      * TODO: let's think how to solve it well, soon.
      */
     unsafe__itIsMeInspector?: boolean;
+    excludedClients?: readonly string[];
   } & Listify<TargetSelector, 'target'>) {
     this.logger.info('Counting fields (period=%o, target=%s)', period, target);
 
@@ -225,6 +227,7 @@ export class OperationsManager {
         fields,
         target,
         period,
+        excludedClients,
       }),
       this.reader.countOperations({ target, period }).then(r => r.total),
     ]);

--- a/packages/services/api/src/modules/operations/providers/operations-manager.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-manager.ts
@@ -115,7 +115,7 @@ export class OperationsManager {
     target,
     period,
     operations,
-  }: { period: DateRange; operations?: readonly string[] } & TargetSelector) {
+  }: { period: DateRange; operations?: readonly string[] } & Listify<TargetSelector, 'target'>) {
     this.logger.info('Counting requests (period=%s, target=%s)', period, target);
     await this.authManager.ensureTargetAccess({
       organization,
@@ -456,7 +456,7 @@ export class OperationsManager {
     project,
     target,
     operations,
-  }: { period: DateRange; operations?: readonly string[] } & TargetSelector) {
+  }: { period: DateRange; operations?: readonly string[] } & Listify<TargetSelector, 'target'>) {
     this.logger.info('Read unique client names (period=%o, target=%s)', period, target);
     await this.authManager.ensureTargetAccess({
       organization,

--- a/packages/services/api/src/modules/operations/providers/operations-manager.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-manager.ts
@@ -442,6 +442,28 @@ export class OperationsManager {
     });
   }
 
+  async readUniqueClientNames({
+    period,
+    organization,
+    project,
+    target,
+    operations,
+  }: { period: DateRange; operations?: readonly string[] } & TargetSelector) {
+    this.logger.info('Read unique client names (period=%o, target=%s)', period, target);
+    await this.authManager.ensureTargetAccess({
+      organization,
+      project,
+      target,
+      scope: TargetAccessScope.REGISTRY_READ,
+    });
+
+    return this.reader.readUniqueClientNames({
+      target,
+      period,
+      operations,
+    });
+  }
+
   async hasOperationsForOrganization(selector: OrganizationSelector): Promise<boolean> {
     const targets = await this.storage.getTargetIdsOfOrganization(selector);
 

--- a/packages/services/api/src/modules/operations/providers/operations-manager.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-manager.ts
@@ -211,7 +211,12 @@ export class OperationsManager {
     unsafe__itIsMeInspector?: boolean;
     excludedClients?: readonly string[];
   } & Listify<TargetSelector, 'target'>) {
-    this.logger.info('Counting fields (period=%o, target=%s)', period, target);
+    this.logger.info(
+      'Counting fields (period=%o, target=%s, excludedClients=%s)',
+      period,
+      target,
+      excludedClients?.join(', ') ?? 'none'
+    );
 
     if (!unsafe__itIsMeInspector) {
       await this.authManager.ensureTargetAccess({

--- a/packages/services/api/src/modules/operations/providers/operations-reader.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-reader.ts
@@ -105,7 +105,7 @@ export class OperationsReader {
       target,
       period,
       operations,
-      excludeClientNames,
+      excludedClients,
     }: {
       fields: ReadonlyArray<{
         type: string;
@@ -115,14 +115,14 @@ export class OperationsReader {
       target: string | readonly string[];
       period: DateRange;
       operations?: readonly string[];
-      excludeClientNames?: readonly string[];
+      excludedClients?: readonly string[];
     },
     span?: Span
   ): Promise<Record<string, number>> {
     const coordinates = fields.map(selector => this.makeId(selector));
     const conditions = [`( coordinate IN ('${coordinates.join(`', '`)}') )`];
 
-    if (Array.isArray(excludeClientNames)) {
+    if (Array.isArray(excludedClients) && excludedClients.length > 0) {
       // Eliminate coordinates fetched by excluded clients.
       // We can connect a coordinate to a client by using the hash column.
       // The hash column is basically a unique identifier of a GraphQL operation.
@@ -131,7 +131,7 @@ export class OperationsReader {
           SELECT hash FROM client_names_daily ${this.createFilter({
             target,
             period,
-            extra: [`client_name IN ('${excludeClientNames.join(`', '`)}')`],
+            extra: [`client_name IN ('${excludedClients.join(`', '`)}')`],
           })} GROUP BY hash
         )
       `);

--- a/packages/services/api/src/modules/operations/providers/operations-reader.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-reader.ts
@@ -1,5 +1,5 @@
 import { Injectable } from 'graphql-modules';
-import { format, addMinutes, subDays, parse, isAfter } from 'date-fns';
+import { format, addMinutes, subDays } from 'date-fns';
 import type { Span } from '@sentry/types';
 import { ClickHouse, RowOf } from './clickhouse-client';
 import { calculateTimeWindow, maxResolution } from './helpers';
@@ -71,16 +71,6 @@ function canUseHourlyAggTable({
   return true;
 }
 
-const schemaCoordinatesDailyStartedAt = parse('2022-01-25 00:00:00', 'yyyy-MM-dd HH:mm:ss', new Date());
-
-function canUseSchemaCoordinatesDailyTable(period?: DateRange): boolean {
-  if (period) {
-    return isAfter(period.from, schemaCoordinatesDailyStartedAt);
-  }
-
-  return false;
-}
-
 @Injectable({
   global: true,
 })
@@ -115,6 +105,7 @@ export class OperationsReader {
       target,
       period,
       operations,
+      excludeClientNames,
     }: {
       fields: ReadonlyArray<{
         type: string;
@@ -124,18 +115,33 @@ export class OperationsReader {
       target: string | readonly string[];
       period: DateRange;
       operations?: readonly string[];
+      excludeClientNames?: readonly string[];
     },
     span?: Span
   ): Promise<Record<string, number>> {
-    // Once we collect data from more than 30 days, we can leave on this part of code
-    if (canUseSchemaCoordinatesDailyTable(period)) {
-      const coordinates = fields.map(selector => this.makeId(selector));
+    const coordinates = fields.map(selector => this.makeId(selector));
+    const conditions = [`( coordinate IN ('${coordinates.join(`', '`)}') )`];
 
-      const res = await this.clickHouse.query<{
-        total: string;
-        coordinate: string;
-      }>({
-        query: `
+    if (Array.isArray(excludeClientNames)) {
+      // Eliminate coordinates fetched by excluded clients.
+      // We can connect a coordinate to a client by using the hash column.
+      // The hash column is basically a unique identifier of a GraphQL operation.
+      conditions.push(`
+        hash NOT IN (
+          SELECT hash FROM client_names_daily ${this.createFilter({
+            target,
+            period,
+            extra: [`client_name IN ('${excludeClientNames.join(`', '`)}')`],
+          })} GROUP BY hash
+        )
+      `);
+    }
+
+    const res = await this.clickHouse.query<{
+      total: string;
+      coordinate: string;
+    }>({
+      query: `
           SELECT
             coordinate,
             sum(total) as total
@@ -144,92 +150,19 @@ export class OperationsReader {
             target,
             period,
             operations,
-            extra: [`( coordinate IN ('${coordinates.join(`', '`)}') )`],
+            extra: conditions,
           })}
           GROUP BY coordinate
         `,
-        queryId: 'count_fields_v2',
-        timeout: 30_000,
-        span,
-      });
-
-      const stats: Record<string, number> = {};
-      for (const row of res.data) {
-        stats[row.coordinate] = ensureNumber(row.total);
-      }
-
-      for (const selector of fields) {
-        const key = this.makeId(selector);
-
-        if (typeof stats[key] !== 'number') {
-          stats[key] = 0;
-        }
-      }
-
-      return stats;
-    }
-
-    // TODO: Remove after 2022-02-25
-
-    const sep = `_${Math.random().toString(36).substr(2, 5)}_`;
-
-    function createAlias(selector: { type: string; field?: string | null; argument?: string | null }) {
-      return [selector.type, selector.field, selector.argument].filter(Boolean).join(sep);
-    }
-
-    function extractSelector(alias: string): {
-      type: string;
-      field?: string | null;
-      argument?: string | null;
-    } {
-      const [type, field, argument] = alias.split(sep);
-
-      return {
-        type,
-        field,
-        argument,
-      };
-    }
-
-    const counters: string[] = [];
-    const conditions: string[] = [];
-
-    for (const selector of fields) {
-      const alias = createAlias(selector);
-      const id = this.makeId(selector);
-
-      counters.push(`sum(has(schema, '${id}')) as ${alias}`);
-      conditions.push(`has(schema, '${id}')`);
-    }
-
-    const res = await this.clickHouse.query<{
-      [key: string]: string;
-    }>({
-      query: `
-        SELECT
-          ${counters.join(', ')}
-        FROM operations_new
-        ${this.createFilter({
-          target,
-          period,
-          operations,
-          extra: [`( ${conditions.join(' OR ')} )`],
-        })}
-      `,
-      queryId: 'count_fields',
-      timeout: 60_000,
+      queryId: 'count_fields_v2',
+      timeout: 30_000,
       span,
     });
 
-    const row = res.data[0];
     const stats: Record<string, number> = {};
-
-    Object.keys(row).forEach(alias => {
-      const selector = extractSelector(alias);
-      const total = ensureNumber(row[alias]);
-
-      stats[this.makeId(selector)] = total;
-    });
+    for (const row of res.data) {
+      stats[row.coordinate] = ensureNumber(row.total);
+    }
 
     for (const selector of fields) {
       const key = this.makeId(selector);
@@ -754,6 +687,18 @@ export class OperationsReader {
     });
 
     return collection;
+  }
+
+  async getClientNames({ target, period }: { target: string; period: DateRange }): Promise<string[]> {
+    const result = await this.clickHouse.query<{
+      client_name: string;
+    }>({
+      queryId: 'client_names_per_target',
+      query: `SELECT client_name FROM client_names_daily ${this.createFilter({ target, period })} GROUP BY client_name`,
+      timeout: 10_000,
+    });
+
+    return result.data.map(row => row.client_name);
   }
 
   @sentry('OperationsReader.getDurationAndCountOverTime')

--- a/packages/services/api/src/modules/operations/providers/operations-reader.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-reader.ts
@@ -474,7 +474,7 @@ export class OperationsReader {
       period,
       operations,
     }: {
-      target: string;
+      target: string | readonly string[];
       period: DateRange;
       operations?: readonly string[];
     },

--- a/packages/services/api/src/modules/operations/resolvers.ts
+++ b/packages/services/api/src/modules/operations/resolvers.ts
@@ -72,6 +72,40 @@ export const resolvers: OperationsModule.Resolvers = {
         operations,
       };
     },
+    async clientStatsByTargets(_, { selector }, { injector }) {
+      const translator = injector.get(IdTranslator);
+      const [organization, project] = await Promise.all([
+        translator.translateOrganizationId(selector),
+        translator.translateProjectId(selector),
+      ]);
+
+      const targets = selector.targetIds;
+      const period = parseDateRangeInput(selector.period);
+
+      const [rows, total] = await Promise.all([
+        injector.get(OperationsManager).readUniqueClientNames({
+          target: targets,
+          project,
+          organization,
+          period,
+        }),
+        injector.get(OperationsManager).countRequests({
+          organization,
+          project,
+          target: targets,
+          period,
+        }),
+      ]);
+
+      return rows.map(row => {
+        return {
+          name: row.name,
+          count: row.count,
+          percentage: total === 0 ? 0 : (row.count / total) * 100,
+          versions: [], // TODO: include versions at some point
+        };
+      });
+    },
   },
   OperationsStats: {
     async operations({ organization, project, target, period, operations: operationsFilter }, _, { injector }) {
@@ -180,15 +214,6 @@ export const resolvers: OperationsModule.Resolvers = {
     },
     clients({ organization, project, target, period, operations: operationsFilter }, _, { injector }) {
       return injector.get(OperationsManager).readUniqueClients({
-        target,
-        project,
-        organization,
-        period,
-        operations: operationsFilter,
-      });
-    },
-    clientNames({ organization, project, target, period, operations: operationsFilter }, _, { injector }) {
-      return injector.get(OperationsManager).readUniqueClientNames({
         target,
         project,
         organization,

--- a/packages/services/api/src/modules/operations/resolvers.ts
+++ b/packages/services/api/src/modules/operations/resolvers.ts
@@ -187,6 +187,15 @@ export const resolvers: OperationsModule.Resolvers = {
         operations: operationsFilter,
       });
     },
+    clientNames({ organization, project, target, period, operations: operationsFilter }, _, { injector }) {
+      return injector.get(OperationsManager).readUniqueClientNames({
+        target,
+        project,
+        organization,
+        period,
+        operations: operationsFilter,
+      });
+    },
     duration({ organization, project, target, period, operations: operationsFilter }, _, { injector }) {
       return injector.get(OperationsManager).readGeneralDurationPercentiles({
         organization,

--- a/packages/services/api/src/modules/schema/providers/inspector.ts
+++ b/packages/services/api/src/modules/schema/providers/inspector.ts
@@ -134,6 +134,7 @@ export class Inspector {
         fields,
         period: createPeriod(`${settings.validation.period}d`),
         target: settings.validation.targets,
+        excludedClients: settings.validation.excludedClients,
         project: selector.project,
         organization: selector.organization,
         unsafe__itIsMeInspector: true,

--- a/packages/services/api/src/modules/target/module.graphql.ts
+++ b/packages/services/api/src/modules/target/module.graphql.ts
@@ -66,6 +66,7 @@ export default gql`
     period: Int!
     percentage: Float!
     targets: [ID!]!
+    excludedClients: [String!]
   }
 
   type UpdateTargetValidationSettingsResult {
@@ -126,6 +127,7 @@ export default gql`
     period: Int!
     percentage: Float!
     targets: [Target!]!
+    excludedClients: [String!]!
   }
 
   input CreateTargetInput {

--- a/packages/services/api/src/modules/target/providers/target-manager.ts
+++ b/packages/services/api/src/modules/target/providers/target-manager.ts
@@ -214,7 +214,6 @@ export class TargetManager {
       throw new HiveError(`No targets specified. Required at least one target`);
     }
 
-    // TODO: validation of percentage (0 - 100) and period (1 - 30)
     return this.storage.updateTargetValidationSettings(input);
   }
 

--- a/packages/services/api/src/modules/target/resolvers.ts
+++ b/packages/services/api/src/modules/target/resolvers.ts
@@ -240,6 +240,8 @@ export const resolvers: TargetModule.Resolvers = {
       const UpdateTargetValidationSettingsModel = z.object({
         percentage: PercentageModel,
         period: z.number().min(1).max(org.monthlyRateLimit.retentionInDays).int(),
+        targets: z.array(z.string()).min(1),
+        excludedClients: z.optional(z.array(z.string())),
       });
 
       const result = UpdateTargetValidationSettingsModel.safeParse(input);
@@ -264,7 +266,7 @@ export const resolvers: TargetModule.Resolvers = {
         project,
         organization,
         targets: input.targets,
-        excludedClients: [], // TODO
+        excludedClients: input.excludedClients ?? [],
       });
 
       return {

--- a/packages/services/api/src/modules/target/resolvers.ts
+++ b/packages/services/api/src/modules/target/resolvers.ts
@@ -264,6 +264,7 @@ export const resolvers: TargetModule.Resolvers = {
         project,
         organization,
         targets: input.targets,
+        excludedClients: [], // TODO
       });
 
       return {

--- a/packages/services/api/src/shared/entities.ts
+++ b/packages/services/api/src/shared/entities.ts
@@ -176,6 +176,7 @@ export interface TargetSettings {
     period: number;
     percentage: number;
     targets: readonly string[];
+    excludedClients: readonly string[];
   };
 }
 

--- a/packages/services/storage/migrations/actions/2022.07.18T10.10.44.target-validation-client-exclusion.sql
+++ b/packages/services/storage/migrations/actions/2022.07.18T10.10.44.target-validation-client-exclusion.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.targets ADD COLUMN validation_excluded_clients text[];

--- a/packages/services/storage/migrations/actions/down/2022.07.18T10.10.44.target-validation-client-exclusion.sql
+++ b/packages/services/storage/migrations/actions/down/2022.07.18T10.10.44.target-validation-client-exclusion.sql
@@ -1,0 +1,1 @@
+ALTER TABLE public.targets DROP COLUMN validation_excluded_clients;

--- a/packages/services/storage/src/db/types.ts
+++ b/packages/services/storage/src/db/types.ts
@@ -131,6 +131,7 @@ export interface targets {
   name: string;
   project_id: string;
   validation_enabled: boolean;
+  validation_excluded_clients: Array<string> | null;
   validation_percentage: number;
   validation_period: number;
 }

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -200,7 +200,10 @@ export async function createStorage(connection: string): Promise<Storage> {
   }
 
   function transformTargetSettings(
-    row: Pick<targets, 'validation_enabled' | 'validation_percentage' | 'validation_period'> & {
+    row: Pick<
+      targets,
+      'validation_enabled' | 'validation_percentage' | 'validation_period' | 'validation_excluded_clients'
+    > & {
       targets: target_validation['destination_target_id'][] | null;
     }
   ): TargetSettings {
@@ -210,6 +213,9 @@ export async function createStorage(connection: string): Promise<Storage> {
         percentage: row.validation_percentage,
         period: row.validation_period,
         targets: Array.isArray(row.targets) ? row.targets.filter(isDefined) : [],
+        excludedClients: Array.isArray(row.validation_excluded_clients)
+          ? row.validation_excluded_clients.filter(isDefined)
+          : [],
       },
     };
   }
@@ -741,14 +747,51 @@ export async function createStorage(connection: string): Promise<Storage> {
 
       return result;
     },
-    async getTarget({ organization, project, target }) {
-      return transformTarget(
-        await pool.one<Slonik<targets>>(
-          sql`SELECT * FROM public.targets WHERE id = ${target} AND project_id = ${project} LIMIT 1`
-        ),
-        organization
-      );
-    },
+    getTarget: batch(
+      async (
+        selectors: Array<{
+          organization: string;
+          project: string;
+          target: string;
+        }>
+      ) => {
+        const uniqueSelectorsMap = new Map<string, typeof selectors[0]>();
+
+        for (const selector of selectors) {
+          const key = JSON.stringify({
+            organization: selector.organization,
+            project: selector.project,
+            target: selector.target,
+          });
+
+          uniqueSelectorsMap.set(key, selector);
+        }
+
+        const uniqueSelectors = Array.from(uniqueSelectorsMap.values());
+
+        const rows = await pool.many<Slonik<targets>>(
+          sql`
+            SELECT * FROM public.targets
+            WHERE (id, project_id) IN ((${sql.join(
+              uniqueSelectors.map(s => sql`${s.target}, ${s.project}`),
+              sql`), (`
+            )}))
+          `
+        );
+
+        return selectors.map(selector => {
+          const row = rows.find(row => row.id === selector.target && row.project_id === selector.project);
+
+          if (!row) {
+            return Promise.reject(
+              new Error(`Target not found (target=${selector.target}, project=${selector.project})`)
+            );
+          }
+
+          return Promise.resolve(transformTarget(row, selector.organization));
+        });
+      }
+    ),
     async getTargetByCleanId({ organization, project, cleanId }) {
       const result = await pool.maybeOne<Slonik<targets>>(
         sql`SELECT * FROM public.targets WHERE clean_id = ${cleanId} AND project_id = ${project} LIMIT 1`
@@ -781,7 +824,10 @@ export async function createStorage(connection: string): Promise<Storage> {
     },
     async getTargetSettings({ target, project }) {
       const row = await pool.one<
-        Pick<targets, 'validation_enabled' | 'validation_percentage' | 'validation_period'> & {
+        Pick<
+          targets,
+          'validation_enabled' | 'validation_percentage' | 'validation_period' | 'validation_excluded_clients'
+        > & {
           targets: target_validation['destination_target_id'][];
         }
       >(sql`
@@ -789,6 +835,7 @@ export async function createStorage(connection: string): Promise<Storage> {
           t.validation_enabled,
           t.validation_percentage,
           t.validation_period,
+          t.validation_excluded_clients,
           array_agg(tv.destination_target_id) as targets
         FROM public.targets AS t
         LEFT JOIN public.target_validation AS tv ON (tv.target_id = t.id)
@@ -813,7 +860,10 @@ export async function createStorage(connection: string): Promise<Storage> {
           }
 
           return trx.one<
-            Pick<targets, 'validation_enabled' | 'validation_percentage' | 'validation_period'> & {
+            Pick<
+              targets,
+              'validation_enabled' | 'validation_percentage' | 'validation_period' | 'validation_excluded_clients'
+            > & {
               targets: target_validation['destination_target_id'][];
             }
           >(sql`
@@ -831,7 +881,7 @@ export async function createStorage(connection: string): Promise<Storage> {
               LIMIT 1
             ) ret
           WHERE t.id = ret.id
-          RETURNING ret.id, t.validation_enabled, t.validation_percentage, t.validation_period, ret.targets
+          RETURNING ret.id, t.validation_enabled, t.validation_percentage, t.validation_period, t.validation_excluded_clients, ret.targets
         `);
         })
       ).validation;

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -926,7 +926,7 @@ export async function createStorage(connection: string): Promise<Storage> {
               LIMIT 1
             ) ret
             WHERE t.id = ret.id
-            RETURNING t.id, t.validation_enabled, t.validation_percentage, t.validation_period, ret.targets;
+            RETURNING t.id, t.validation_enabled, t.validation_percentage, t.validation_period, t.validation_excluded_clients, ret.targets;
           `);
         })
       ).validation;

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -886,7 +886,7 @@ export async function createStorage(connection: string): Promise<Storage> {
         })
       ).validation;
     },
-    async updateTargetValidationSettings({ target, project, percentage, period, targets }) {
+    async updateTargetValidationSettings({ target, project, percentage, period, targets, excludedClients }) {
       return transformTargetSettings(
         await pool.transaction(async trx => {
           await trx.query(sql`
@@ -911,7 +911,10 @@ export async function createStorage(connection: string): Promise<Storage> {
 
           return trx.one(sql`
             UPDATE public.targets as t
-            SET validation_percentage = ${percentage}, validation_period = ${period}
+            SET validation_percentage = ${percentage}, validation_period = ${period}, validation_excluded_clients = ${sql.array(
+            excludedClients,
+            'text'
+          )}
             FROM (
               SELECT
                 it.id,

--- a/packages/services/usage-ingestor/__tests__/serializer.spec.ts
+++ b/packages/services/usage-ingestor/__tests__/serializer.spec.ts
@@ -1,8 +1,8 @@
-import { stringifyOperation, stringifyRegistryRecord, joinIntoSingleMessage } from '../src/serializer';
+import { stringifyOperation, stringifyRegistryRecord, joinIntoSingleMessage, formatDate } from '../src/serializer';
 
 const timestamp = {
   asNumber: 1643892203027,
-  asString: '2022-02-03 12:43:23',
+  asString: '2022-02-03 12:43:23', // date as string in UTC timezone
 };
 
 test('stringify operation in correct format and order', () => {
@@ -116,4 +116,8 @@ test('stringify registry records in correct format and order', () => {
       ].join(','),
     ].join('\n')
   );
+});
+
+test('formatDate should return formatted date in UTC timezone', () => {
+  expect(formatDate(timestamp.asNumber)).toEqual(timestamp.asString);
 });

--- a/packages/services/usage-ingestor/package.json
+++ b/packages/services/usage-ingestor/package.json
@@ -14,7 +14,6 @@
     "@sentry/tracing": "7.5.0",
     "agentkeepalive": "4.2.0",
     "date-fns": "2.25.0",
-    "date-fns-tz": "1.2.2",
     "dotenv": "10.0.0",
     "graphql": "16.5.0",
     "got": "12.0.4",

--- a/packages/services/usage-ingestor/src/serializer.ts
+++ b/packages/services/usage-ingestor/src/serializer.ts
@@ -1,13 +1,24 @@
-import * as dateFnsTz from 'date-fns-tz';
 import LRU from 'tiny-lru';
 import { cache } from './helpers';
 import type { ProcessedRegistryRecord, ProcessedOperation } from '@hive/usage-common';
 
 const delimiter = '\n';
-const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+const formatter = Intl.DateTimeFormat('en-GB', {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+  timeZone: 'UTC',
+});
 
-function formatDate(date: number): string {
-  return dateFnsTz.formatInTimeZone(dateFnsTz.zonedTimeToUtc(date, timezone), 'UTC', 'yyyy-MM-dd HH:mm:ss');
+export function formatDate(date: number): string {
+  return formatter
+    .format(date)
+    .replace(',', '')
+    .replace(/(\d+)\/(\d+)\/(\d+)/, (_, d, m, y) => `${y}-${m}-${d}`);
 }
 
 function dateCacheKey(date: number): string {

--- a/packages/web/app/package.json
+++ b/packages/web/app/package.json
@@ -61,6 +61,7 @@
     "react-date-range": "1.4.0",
     "react-dom": "17.0.2",
     "react-icons": "4.3.1",
+    "react-select": "5.4.0",
     "react-string-replace": "0.4.4",
     "react-virtualized-auto-sizer": "1.0.6",
     "react-window": "1.8.7",

--- a/packages/web/app/pages/[orgId]/[projectId]/[targetId]/settings.tsx
+++ b/packages/web/app/pages/[orgId]/[projectId]/[targetId]/settings.tsx
@@ -289,7 +289,15 @@ const ConditionalBreakingChanges = (): ReactElement => {
   const settings = targetSettings.data?.targetSettings.validation;
   const isEnabled = settings?.enabled || false;
   const possibleTargets = targetSettings.data?.targets.nodes;
-  const allClientNames = targetSettings.data?.operationsStats.clientNames ?? [];
+  const clientNamesFromStats = targetSettings.data?.operationsStats.clientNames?.map(c => c.name);
+  const allClientNames =
+    clientNamesFromStats && settings
+      ? clientNamesFromStats.concat(
+          // In case of clients from validation settings being no longer available in usage stats,
+          // add them to the list of options
+          settings.excludedClients.filter(clientName => !clientNamesFromStats.includes(clientName))
+        )
+      : settings?.excludedClients ?? [];
 
   const {
     handleSubmit,
@@ -413,9 +421,9 @@ const ConditionalBreakingChanges = (): ReactElement => {
                   value,
                   label: value,
                 }))}
-                options={allClientNames.map(c => ({
-                  value: c.name,
-                  label: c.name,
+                options={allClientNames.map(name => ({
+                  value: name,
+                  label: name,
                 }))}
                 onBlur={() => setFieldTouched('excludedClients')}
                 onChange={options => {

--- a/packages/web/app/pages/[orgId]/[projectId]/[targetId]/settings.tsx
+++ b/packages/web/app/pages/[orgId]/[projectId]/[targetId]/settings.tsx
@@ -9,6 +9,7 @@ import * as Yup from 'yup';
 
 import { TargetLayout } from '@/components/layouts';
 import { Button, Card, Checkbox, Heading, Input, Switch, Table, Tag, TimeAgo, Title } from '@/components/v2';
+import { Combobox } from '@/components/v2/combobox';
 import { AlertTriangleIcon } from '@/components/v2/icon';
 import { CreateAccessTokenModal, DeleteTargetModal } from '@/components/v2/modals';
 import {
@@ -288,6 +289,7 @@ const ConditionalBreakingChanges = (): ReactElement => {
   const settings = targetSettings.data?.targetSettings.validation;
   const isEnabled = settings?.enabled || false;
   const possibleTargets = targetSettings.data?.targets.nodes;
+  const allClientNames = targetSettings.data?.operationsStats.clientNames ?? [];
 
   const {
     handleSubmit,
@@ -354,7 +356,7 @@ const ConditionalBreakingChanges = (): ReactElement => {
         </Heading>
         <div
           className={clsx(
-            'mb-3 flex flex-col items-start gap-3 font-light text-gray-500',
+            'mb-3 flex flex-col items-start gap-3 font-light text-gray-300',
             !isEnabled && 'pointer-events-none opacity-25'
           )}
         >
@@ -399,6 +401,36 @@ const ConditionalBreakingChanges = (): ReactElement => {
           {mutation.data?.updateTargetValidationSettings.error?.inputErrors.period && (
             <div className="text-red-500">{mutation.data.updateTargetValidationSettings.error.inputErrors.period}</div>
           )}
+          <div className="my-4 flex flex-col gap-2">
+            <div>
+              <div>Exclude these clients:</div>
+              <div className="text-xs">Marks a breaking change as safe when it only affects the following clients.</div>
+            </div>
+            <div>
+              <Combobox
+                name="excludedClients"
+                value={values.excludedClients.map(value => ({
+                  value,
+                  label: value,
+                }))}
+                options={allClientNames.map(c => ({
+                  value: c.name,
+                  label: c.name,
+                }))}
+                onBlur={() => setFieldTouched('excludedClients')}
+                onChange={options => {
+                  setFieldValue(
+                    'excludedClients',
+                    options.map(o => o.value)
+                  );
+                }}
+                disabled={isSubmitting}
+              />
+            </div>
+            {touched.excludedClients && errors.excludedClients && (
+              <div className="text-red-500">{errors.excludedClients}</div>
+            )}
+          </div>
           Check collected usage data from these targets:
           {possibleTargets?.map(pt => (
             <div key={pt.id} className="flex items-center gap-2 pl-5">

--- a/packages/web/app/src/components/v2/combobox.tsx
+++ b/packages/web/app/src/components/v2/combobox.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { StylesConfig } from 'react-select';
+import Select from 'react-select';
+
+interface Option {
+  value: string;
+  label: string;
+}
+
+const styles: StylesConfig = {
+  control: styles => ({
+    ...styles,
+    backgroundColor: '#24272E',
+    borderWidth: 1,
+    borderColor: '#5f6169',
+  }),
+  multiValue: styles => ({
+    ...styles,
+    backgroundColor: '#4B5563',
+    color: '#fff',
+  }),
+  multiValueLabel: styles => ({
+    ...styles,
+    color: '#fff',
+  }),
+  multiValueRemove: styles => ({
+    ...styles,
+    color: '#6B7280',
+    ':hover': {
+      backgroundColor: '#6B7280',
+      color: '#fff',
+    },
+  }),
+  option: styles => ({
+    ...styles,
+    color: '#fff',
+    fontSize: '14px',
+    backgroundColor: '#24272E',
+    ':hover': {
+      backgroundColor: '#5f6169',
+    },
+  }),
+  menu: styles => ({
+    ...styles,
+    backgroundColor: '#24272E',
+  }),
+};
+
+export function Combobox(
+  props: React.PropsWithoutRef<{
+    name: string;
+    options: readonly Option[];
+    value?: readonly Option[];
+    onChange: (value: readonly Option[]) => void;
+    onBlur: (el: unknown) => void;
+    disabled?: boolean;
+  }>
+) {
+  return (
+    <Select
+      name={props.name}
+      closeMenuOnSelect={false}
+      value={props.value}
+      isMulti
+      options={props.options}
+      styles={styles}
+      onChange={props.onChange as any}
+      isDisabled={props.disabled}
+      onBlur={props.onBlur}
+    />
+  );
+}

--- a/packages/web/app/src/components/v2/combobox.tsx
+++ b/packages/web/app/src/components/v2/combobox.tsx
@@ -54,6 +54,7 @@ export function Combobox(
     onChange: (value: readonly Option[]) => void;
     onBlur: (el: unknown) => void;
     disabled?: boolean;
+    loading?: boolean;
   }>
 ) {
   return (
@@ -67,6 +68,7 @@ export function Combobox(
       onChange={props.onChange as any}
       isDisabled={props.disabled}
       onBlur={props.onBlur}
+      isLoading={props.loading}
     />
   );
 }

--- a/packages/web/app/src/graphql/fragments.graphql
+++ b/packages/web/app/src/graphql/fragments.graphql
@@ -357,6 +357,7 @@ fragment TargetValidationSettingsFields on TargetValidationSettings {
   targets {
     ...TargetEssentials
   }
+  excludedClients
 }
 
 fragment AlertSlackChannelFields on AlertSlackChannel {

--- a/yarn.lock
+++ b/yarn.lock
@@ -832,6 +832,13 @@
   dependencies:
     regenerator-runtime "^0.13.4"
 
+"@babel/runtime@^7.12.0", "@babel/runtime@^7.8.7":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.18.9.tgz#b4fcfce55db3d2e5e080d2490f608a3b9f407f4a"
+  integrity sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@babel/template@^7.14.5", "@babel/template@^7.15.4", "@babel/template@^7.16.7", "@babel/template@^7.3.3":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -1705,6 +1712,17 @@
     source-map "^0.5.7"
     stylis "4.0.13"
 
+"@emotion/cache@^11.4.0", "@emotion/cache@^11.9.3":
+  version "11.9.3"
+  resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.9.3.tgz#96638449f6929fd18062cfe04d79b29b44c0d6cb"
+  integrity sha512-0dgkI/JKlCXa+lEXviaMtGBL0ynpx4osh7rjOXE71q9bIF8G+XhJgvi+wDu0B0IdCVx37BffiwXlN9I3UuzFvg==
+  dependencies:
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/sheet" "^1.1.1"
+    "@emotion/utils" "^1.0.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    stylis "4.0.13"
+
 "@emotion/cache@^11.5.0", "@emotion/cache@^11.7.1":
   version "11.7.1"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-11.7.1.tgz#08d080e396a42e0037848214e8aa7bf879065539"
@@ -1782,10 +1800,34 @@
     "@emotion/weak-memoize" "^0.2.5"
     hoist-non-react-statics "^3.3.1"
 
+"@emotion/react@^11.8.1":
+  version "11.9.3"
+  resolved "https://registry.yarnpkg.com/@emotion/react/-/react-11.9.3.tgz#f4f4f34444f6654a2e550f5dab4f2d360c101df9"
+  integrity sha512-g9Q1GcTOlzOEjqwuLF/Zd9LC+4FljjPjDfxSM7KmEakm+hsHXk+bYZ2q+/hTJzr0OUNkujo72pXLQvXj6H+GJQ==
+  dependencies:
+    "@babel/runtime" "^7.13.10"
+    "@emotion/babel-plugin" "^11.7.1"
+    "@emotion/cache" "^11.9.3"
+    "@emotion/serialize" "^1.0.4"
+    "@emotion/utils" "^1.1.0"
+    "@emotion/weak-memoize" "^0.2.5"
+    hoist-non-react-statics "^3.3.1"
+
 "@emotion/serialize@^1.0.0", "@emotion/serialize@^1.0.2", "@emotion/serialize@^1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.3.tgz#99e2060c26c6292469fb30db41f4690e1c8fea63"
   integrity sha512-2mSSvgLfyV3q+iVh3YWgNlUc2a9ZlDU7DjuP5MjK3AXRR0dYigCrP99aeFtaB2L/hjfEZdSThn5dsZ0ufqbvsA==
+  dependencies:
+    "@emotion/hash" "^0.8.0"
+    "@emotion/memoize" "^0.7.4"
+    "@emotion/unitless" "^0.7.5"
+    "@emotion/utils" "^1.0.0"
+    csstype "^3.0.2"
+
+"@emotion/serialize@^1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@emotion/serialize/-/serialize-1.0.4.tgz#ff31fd11bb07999611199c2229e152faadc21a3c"
+  integrity sha512-1JHamSpH8PIfFwAMryO2bNka+y8+KA5yga5Ocf2d7ZEiJjb7xlLW7aknBGZqJLajuLOvJ+72vN+IBSwPlXD1Pg==
   dependencies:
     "@emotion/hash" "^0.8.0"
     "@emotion/memoize" "^0.7.4"
@@ -1807,6 +1849,11 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.0.tgz#56d99c41f0a1cda2726a05aa6a20afd4c63e58d2"
   integrity sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g==
+
+"@emotion/sheet@^1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@emotion/sheet/-/sheet-1.1.1.tgz#015756e2a9a3c7c5f11d8ec22966a8dbfbfac787"
+  integrity sha512-J3YPccVRMiTZxYAY0IOq3kd+hUP8idY8Kz6B/Cyo+JuXq52Ek+zbPbSQUrVQp95aJ+lsAW7DPL1P2Z+U1jGkKA==
 
 "@emotion/styled@11.6.0":
   version "11.6.0"
@@ -5171,6 +5218,13 @@
   dependencies:
     "@types/react" "^17"
 
+"@types/react-transition-group@^4.4.0":
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.4.5.tgz#aae20dcf773c5aa275d5b9f7cdbca638abc5e416"
+  integrity sha512-juKD/eiSM3/xZYzjuzH6ZwpP+/lejltmiS3QEzV/vmb/Q8+HfDmxu+Baga8UEMGBqV88Nbg4l2hY/K2DkyaLLA==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-virtualized-auto-sizer@1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.1.tgz#b3187dae1dfc4c15880c9cfc5b45f2719ea6ebd4"
@@ -7993,6 +8047,14 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
+
+dom-helpers@^5.0.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
+  integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
+  dependencies:
+    "@babel/runtime" "^7.8.7"
+    csstype "^3.0.2"
 
 dot-case@^1.1.0:
   version "1.1.2"
@@ -12682,7 +12744,7 @@ mdurl@^1.0.0, mdurl@^1.0.1:
     vinyl "^2.0.1"
     vinyl-file "^3.0.0"
 
-"memoize-one@>=3.1.1 <6", memoize-one@^5.1.1:
+"memoize-one@>=3.1.1 <6", memoize-one@^5.0.0, memoize-one@^5.1.1:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/memoize-one/-/memoize-one-5.2.1.tgz#8337aa3c4335581839ec01c3d594090cebe8f00e"
   integrity sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==
@@ -15331,6 +15393,19 @@ react-remove-scroll@^2.4.0:
     use-callback-ref "^1.3.0"
     use-sidecar "^1.1.2"
 
+react-select@5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/react-select/-/react-select-5.4.0.tgz#81f6ac73906126706f104751ee14437bd16798f4"
+  integrity sha512-CjE9RFLUvChd5SdlfG4vqxZd55AZJRrLrHzkQyTYeHlpOztqcgnyftYAolJ0SGsBev6zAs6qFrjm6KU3eo2hzg==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
+    "@emotion/cache" "^11.4.0"
+    "@emotion/react" "^11.8.1"
+    "@types/react-transition-group" "^4.4.0"
+    memoize-one "^5.0.0"
+    prop-types "^15.6.0"
+    react-transition-group "^4.3.0"
+
 react-string-replace@0.4.4:
   version "0.4.4"
   resolved "https://registry.yarnpkg.com/react-string-replace/-/react-string-replace-0.4.4.tgz#24006fbe0db573d5be583133df38b1a735cb4225"
@@ -15346,6 +15421,16 @@ react-style-singleton@^2.1.0, react-style-singleton@^2.2.0:
     get-nonce "^1.0.0"
     invariant "^2.2.4"
     tslib "^2.0.0"
+
+react-transition-group@^4.3.0:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.2.tgz#8b59a56f09ced7b55cbd53c36768b922890d5470"
+  integrity sha512-/RNYfRAMlZwDSr6z4zNKV6xu53/e2BuaBbGhbyYIXTrmgu/bGHzmqOs7mJSJBHy9Ud+ApHx3QjrkKSp1pxvlFg==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react-universal-interface@^0.6.2:
   version "0.6.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7612,11 +7612,6 @@ dataloader@2.1.0:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.1.0.tgz#c69c538235e85e7ac6c6c444bae8ecabf5de9df7"
   integrity sha512-qTcEYLen3r7ojZNgVUaRggOI+KM7jrKxXeSHhogh/TWxYMeONEMqY+hmkobiYQozsGIyg9OYVzO4ZIfoB4I0pQ==
 
-date-fns-tz@1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.2.2.tgz#89432b54ce3fa7d050a2039e997e5b6a96df35dd"
-  integrity sha512-vWtn44eEqnLbkACb7T5G5gPgKR4nY8NkNMOCyoY49NsRGHrcDmY2aysCyzDeA+u+vcDBn/w6nQqEDyouRs4m8w==
-
 date-fns@2.25.0:
   version "2.25.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.25.0.tgz#8c5c8f1d958be3809a9a03f4b742eba894fc5680"


### PR DESCRIPTION
What it is, and what it does?

Let's take GraphQL Hive as an example. 
Whenever we make breaking changes in GraphQL API, Hive detects them and prevent the PR from being merged.
That's fine but sometimes we do a breaking change that does not affect anyone because a removed/modified field is requested only by `@hive/app` (app.graphql-hive.com). We know it's not breaking but Hive does not.

This PR lets us define a list of GraphQL consumers (clients) like app.graphql-hive.com so that Hive knows they won't be affected by any breaking changes (`@hive/server` is deployed together with `@hive/app`).

Perfect example: https://github.com/kamilkisiela/graphql-hive/pull/241/checks?check_run_id=7340193063

This should be useful for many users.


Todo
- [x] Implement client exclusion related methods in OperationsReader
- [x] Add UI to pick excluded clients
- [x] Persist excluded clients in Postgres
- [x] Fetch excluded clients from Postgres
- [x] Connect it to Inspector
- [x] Tests