### PR TITLE
fix postgres container healthcheck

### DIFF
--- a/packages/services/storage/docker-compose.yml
+++ b/packages/services/storage/docker-compose.yml
@@ -12,6 +12,7 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: registry
       PGDATA: /var/lib/postgresql/data
     volumes:
       - ./volumes/postgresql/db:/var/lib/postgresql/data


### PR DESCRIPTION
Currently the `postgres` container fails its docker healthcheck because the `POSTGRES_DB` isn't set, so the `pg_isready ...` command fails.

```bash
$ yarn workspace @hive/storage run db:start
...

$ docker ps --format "table {{.ID}}\t{{.Image}}\t{{.Status}}"
CONTAINER ID   IMAGE                                          STATUS
127d3df6ceac   confluentinc/cp-kafka:7.1.1-1-ubi8.amd64       Up 6 minutes (healthy)
b4605846c7fd   clickhouse/clickhouse-server:22.3.5.5-alpine   Up 6 minutes (healthy)
fe839cb9d5a4   confluentinc/cp-zookeeper:7.1.1-1-ubi8.amd64   Up 6 minutes
43af8004ae9e   postgres:13.4-alpine                           Up 6 minutes (unhealthy)
1b7e56e86242   bitnami/redis:6.2                              Up 6 minutes (healthy)

```