### PR TITLE
dockerize dev environment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# Common
+README.md
+CHANGELOG.md
+docker-compose.yml
+Dockerfile
+.DS_STORE
+
+# Docker files
+Dockerfile
+docker-compose.yml
+.dockerignore
+packages/services/storage/volumes
+
+# git
+.git
+.gitattributes
+.gitignore
+
+# Node
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+**/*node_modules
+
+# Secrets
+**/*.env
+.env.template
+
+# Editor
+.vscode
+
+# Generated Files
+**/dist
+integration-tests/testkit/gql
+.turbo/
+target
+temp
+__generated__

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:16.13.2-alpine3.14
+
+ARG POSTGRES_HOST=localhost
+ARG CLICKHOUSE_HOST=localhost
+ARG REDIS_HOST=localhost
+
+# Needed by turbo build when checking diffs (or something)
+RUN apk add --no-cache git
+
+# Prep app folder
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+# Install dependencies
+COPY . .
+RUN yarn install
+
+# Generate build artifacts
+RUN yarn workspace '@hive/storage' db
+RUN yarn generate
+RUN yarn build

--- a/localdev/docker-compose.yml
+++ b/localdev/docker-compose.yml
@@ -1,0 +1,136 @@
+version: '3.8'
+services:
+  server:
+    image: 'hive-baseimage:dev'
+    healthcheck:
+      test: ['CMD', 'wget', '--spider', '-q', 'localhost:4000/_readiness']
+      interval: 5s
+      timeout: 5s
+      retries: 6
+      start_period: 5s
+    env_file: ../packages/services/server/.env
+    working_dir: /usr/src/app/packages/services/server
+    command: 'yarn dev'
+    environment:
+      POSTGRES_HOST: db
+      CLICKHOUSE_HOST: clickhouse
+      REDIS_HOST: redis
+      TOKENS_ENDPOINT: http://tokens:6001
+      SCHEMA_ENDPOINT: http://schema:6500
+      USAGE_ESTIMATOR_ENDPOINT: http://usage_estimator:4011
+      RATE_LIMIT_ENDPOINT: http://rate_limit:4012
+      CDN_BASE_URL: http://local_cdn:4010
+
+      # ???
+      WEBHOOKS_ENDPOINT: http://webhooks:6250
+
+  tokens:
+    command: 'yarn dev'
+    env_file: ../packages/services/tokens/.env
+    environment:
+      POSTGRES_HOST: db
+    healthcheck:
+      test: ['CMD', 'wget', '--spider', '-q', 'localhost:6001/_readiness']
+      interval: 5s
+      timeout: 5s
+      retries: 6
+      start_period: 5s
+    image: 'hive-baseimage:dev'
+    working_dir: /usr/src/app/packages/services/tokens
+
+  schema:
+    command: 'yarn dev'
+    env_file: ./../packages/services/schema/.env
+    healthcheck:
+      test: ['CMD', 'wget', '--spider', '-q', 'localhost:6500/_readiness']
+      interval: 5s
+      timeout: 5s
+      retries: 6
+    environment:
+      REDIS_HOST: redis
+    image: 'hive-baseimage:dev'
+    working_dir: /usr/src/app/packages/services/schema
+
+  usage_estimator:
+    command: 'yarn dev'
+    env_file: ../packages/services/usage-estimator/.env
+    healthcheck:
+      test: ['CMD', 'wget', '--spider', '-q', 'localhost:4011/_readiness']
+      interval: 5s
+      timeout: 5s
+      retries: 6
+      start_period: 5s
+    environment:
+      POSTGRES_CONNECTION_STRING: 'postgresql://postgres:postgres@db:5432/registry'
+      CLICKHOUSE_HOST: 'clickhouse'
+    image: 'hive-baseimage:dev'
+    working_dir: /usr/src/app/packages/services/usage-estimator
+
+  rate_limit:
+    image: 'hive-baseimage:dev'
+    env_file: ../packages/services/rate-limit/.env
+    healthcheck:
+      test: ['CMD', 'wget', '--spider', '-q', 'localhost:4012/_readiness']
+      interval: 5s
+      timeout: 5s
+      retries: 6
+      start_period: 5s
+    working_dir: /usr/src/app/packages/services/rate-limit
+    command: 'yarn dev'
+    environment:
+      POSTGRES_CONNECTION_STRING: 'postgresql://postgres:postgres@db:5432/registry'
+      USAGE_ESTIMATOR_ENDPOINT: http://usage_estimator:4011
+      EMAILS_ENDPOINT: http://emails:3011
+
+  # Needed?
+  local_cdn:
+    image: 'hive-baseimage:dev'
+    healthcheck:
+      test: ['CMD', 'wget', '--spider', '-q', 'localhost:4010/_readiness']
+      interval: 5s
+      timeout: 5s
+      retries: 6
+      start_period: 5s
+    working_dir: /usr/src/app/packages/services/cdn-worker
+    command: 'yarn dev'
+
+  usage:
+    image: 'hive-baseimage:dev'
+    env_file: ../packages/services/usage/.env
+    healthcheck:
+      test: ['CMD', 'wget', '--spider', '-q', 'localhost:4001/_readiness']
+      interval: 5s
+      timeout: 5s
+      retries: 6
+      start_period: 5s
+    working_dir: /usr/src/app/packages/services/usage
+    command: 'yarn dev'
+    environment:
+      TOKENS_ENDPOINT: http://tokens:6001
+      RATE_LIMIT_ENDPOINT: http://rate_limit:4012
+      KAFKA_BROKER: broker:29092
+
+  app:
+    image: 'hive-baseimage:dev'
+    env_file: ../packages/web/app/.env
+    healthcheck:
+      test: ['CMD', 'wget', '--spider', '-q', 'localhost:9000/_readiness']
+      interval: 5s
+      timeout: 5s
+      retries: 6
+      start_period: 5s
+    ports:
+      - '9000:9000'
+    working_dir: /usr/src/app/packages/web/app
+    command: 'yarn dev'
+    environment:
+      GRAPHQL_ENDPOINT: http://server:4000/graphql
+      APP_BASE_URL: http://localhost:9000
+      AUTH0_BASE_URL: http://localhost:9000
+      PORT: 9000
+
+# Connect to the network created by the `@hive/storage` docker compose config
+networks:
+  default:
+    external: true
+    name: storage_stack

--- a/localdev/scripts/start
+++ b/localdev/scripts/start
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -e -o pipefail
+
+CUR_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1 && pwd)"
+PROJECT_ROOT="${CUR_DIR}/../.."
+
+start_storage_containers() {
+  pushd "${PROJECT_ROOT}/services/storage"
+  yarn run db:start
+  popd
+}
+
+# To run a (potentially failed, intermediate) container/layer interactively:
+# docker run --rm -it <container/layer_id> bash
+build_base_docker_image() {
+  pushd "${PROJECT_ROOT}"
+
+  # Build docker image
+  # Set storage hosts to their docker network hostname to run migrations
+  export DOCKER_BUILDKIT=${DOCKER_BUILDKIT:-0}
+  docker build \
+    --build-arg POSTGRES_HOST="db" \
+    --build-arg CLICKHOUSE_HOST="clickhouse" \
+    --build-arg REDIS_HOST="redis" \
+    --network='storage_stack' \
+    -t 'hive-baseimage:dev' \
+    .
+
+  popd
+}
+
+start_localdev_containers() {
+  pushd "${PROJECT_ROOT}/localdev"
+  docker compose --project-name 'hive-local' \
+    up \
+    --detach \
+    --remove-orphans
+  popd
+}
+
+main() {
+  start_storage_containers
+  build_base_docker_image
+  start_localdev_containers
+}
+
+main

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "license": "MIT",
   "scripts": {
+    "dev": "./localdev/scripts/start",
     "seed": "node scripts/seed-local-env.js",
     "postinstall": "husky install && patch-package && node ./scripts/patch-manifests.js && node ./scripts/sync-env-files.js && node ./scripts/turborepo-cleanup.js && node ./scripts/turborepo-setup.js",
     "pre-commit": "lint-staged",

--- a/packages/services/storage/docker-compose.yml
+++ b/packages/services/storage/docker-compose.yml
@@ -12,11 +12,12 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: registry
       PGDATA: /var/lib/postgresql/data
     volumes:
       - ./volumes/postgresql/db:/var/lib/postgresql/data
     ports:
-      - '5432:5432'
+      - '${DOCKER_HOST_PORT_POSTGRES:-5432}:5432'
 
   redis:
     image: docker.io/bitnami/redis:6.2
@@ -32,7 +33,7 @@ services:
       - ALLOW_EMPTY_PASSWORD=yes
       - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
     ports:
-      - '6379:6379'
+      - '${DOCKER_HOST_PORT_REDIS:-6379}:6379'
     volumes:
       - './volumes/redis/db:/bitnami/redis/data'
 
@@ -51,7 +52,7 @@ services:
       - ./volumes/clickhouse/db:/var/lib/clickhouse
       - ./configs/clickhouse:/etc/clickhouse-server/conf.d
     ports:
-      - '8123:8123'
+      - '${DOCKER_HOST_PORT_CLICKHOUSE:-8123}:8123'
     networks:
       - 'stack'
 

--- a/scripts/sync-env-files.js
+++ b/scripts/sync-env-files.js
@@ -2,14 +2,14 @@
  * The goal here is to sync the .env file with the .env.template file, in every package.
  * <sync> is a special value that will be replaced with the value from the root .env file.
  */
-import { constants } from 'fs';
+import { constants, existsSync } from 'fs';
 import { readFile, writeFile, access } from 'fs/promises';
 import { join, dirname, relative } from 'path';
 import { parse } from 'dotenv';
 import glob from 'glob';
 
-if (!!process.env.CI) {
-  console.log('[sync-env-files] CI Detected, skipping');
+if (!!process.env.CI || existsSync('/.dockerenv')) {
+  console.log('[sync-env-files] CI/Docker Environment Detected, skipping');
   process.exit(0);
 }
 


### PR DESCRIPTION
### Why
Right now for local development, the server processes talk to the dockerized storage processes over the `localhost` network, expecting them to be available on that service's default port (e.g. `5432` for `postgres`)

This competes with my local, non-dockerized `postgres` (and `redis`) instances managed by brew since they also run on the default ports.

This isn't _too_ much of a problem until I start trying to run both Hive and other GraphQL servers on my local machine (to test `usage` data propagation E2E locally), since only one of the `postgres`/`redis` instances ends up snagging the default port first, and so one of the services will end up talking to the wrong `postgres`/`redis` instance.

It would be nice if there was a way to run the entire `hive` application in a single Docker network and only expose the `app` container on the host network, in order to more easily isolate running `hive` with other apps locally.

### What Changed
- `localdev/docker-compose.yml`
  - runs all the same things as `.vscode/terminals.json`
  - includes running with each package's `.env` file (without storing them in the container)
    - overrides the relevant `*_ENDPOINT` / `*_HOST` variables to point to the respective services in the docker network
  - attaches to the same `storage_stack` docker network created by the `@hive/storage` docker compose configuration.
- `packages/services/storage/docker-compose.yml`
  - Make the localhost published ports for `clickhouse`, `postgres`, and `redis` configurable (by default they remain the default service ports)

### Screenshot

![image](https://user-images.githubusercontent.com/6402435/186534615-6c9c8a1f-0295-4f7f-89e6-51dda2fbd092.png)


Just thought I would share the solution I've drafted, if there's any interest in including this I'm open to any feedback to make it mergeable.