### PR TITLE
Fix invoking router with shell

### DIFF
--- a/packages/libraries/router/Dockerfile
+++ b/packages/libraries/router/Dockerfile
@@ -17,4 +17,4 @@ RUN mkdir /app
 COPY --from=build /usr/src/router/target/release/router /app
 
 ENV RUST_BACKTRACE=full
-ENTRYPOINT /app/router
+ENTRYPOINT ["/app/router"]


### PR DESCRIPTION
Allow arguments to be easily passed to the docker image