### PR TITLE
Fix router docker file

### DIFF
--- a/packages/libraries/router/Dockerfile
+++ b/packages/libraries/router/Dockerfile
@@ -20,5 +20,4 @@ RUN apt update && apt install -y ca-certificates \
 
 COPY --from=build /usr/src/router/target/release/router .
 
-ENV RUST_BACKTRACE=full
 ENTRYPOINT ["./router"]

--- a/packages/libraries/router/Dockerfile
+++ b/packages/libraries/router/Dockerfile
@@ -1,20 +1,24 @@
-FROM rust:1-slim as build
+FROM --platform=linux/amd64 rust:1-slim as build
 
 WORKDIR /usr/src/router
 
 # build
-RUN apt update && apt install -y curl nodejs npm
-RUN update-ca-certificates
+RUN apt update && apt install -y curl nodejs npm \
+    && rm -rf /var/lib/apt/lists/* \
+    && update-ca-certificates
 RUN rustup component add rustfmt
 
 COPY ./ .
 RUN cargo build --release
 
 # final binary
-FROM debian:bullseye-slim
+FROM --platform=linux/amd64 debian:bullseye-slim
 
-RUN mkdir /app
-COPY --from=build /usr/src/router/target/release/router /app
+RUN apt update && apt install -y ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && update-ca-certificates
+
+COPY --from=build /usr/src/router/target/release/router .
 
 ENV RUST_BACKTRACE=full
-ENTRYPOINT /app/router
+ENTRYPOINT ["./router"]


### PR DESCRIPTION
Seems when I raised the PR with a Dockerfile I had only checked the binary ran; since then I've tried to call our graph & uncovered the following issues fixed by this PR:

- [x] Fix entrypoint was wrapped in shell, so args are not passed direct
- [x] CA bundle wasn't available so TLS requests failed
- [x] Drop `RUST_BACKTRACE`

