### PR TITLE
fix: set config.api.externalResolver to true in order to avoid weird …

### DIFF
--- a/packages/web/app/pages/api/join-waiting-list.ts
+++ b/packages/web/app/pages/api/join-waiting-list.ts
@@ -37,3 +37,9 @@ async function joinWaitingList(req: NextApiRequest, res: NextApiResponse) {
 }
 
 export default withSentry(joinWaitingList);
+
+export const config = {
+  api: {
+    externalResolver: true,
+  },
+};

--- a/packages/web/app/pages/api/proxy.ts
+++ b/packages/web/app/pages/api/proxy.ts
@@ -75,8 +75,7 @@ async function graphql(req: NextApiRequest, res: NextApiResponse) {
     accessSpan.setHttpStatus(401);
     accessSpan.finish();
     finishTransaction();
-
-    res.status(401).send({});
+    res.status(401).json({});
     return;
   }
 
@@ -141,5 +140,6 @@ export const config = {
     bodyParser: {
       sizeLimit: '6mb',
     },
+    externalResolver: true,
   },
 };

--- a/packages/web/app/src/lib/api/extract-access-token-from-request.ts
+++ b/packages/web/app/src/lib/api/extract-access-token-from-request.ts
@@ -16,7 +16,7 @@ export async function extractAccessTokenFromRequest(req: NextApiRequest, res: Ne
     req,
     res
   );
-  // Session can be undefined in case access token was sent.
+  // Session can be undefined in case no access token was sent.
   const accessToken = (req as any).session?.getAccessToken() || null;
   return accessToken;
 }

--- a/packages/web/app/src/lib/api/extract-access-token-from-request.ts
+++ b/packages/web/app/src/lib/api/extract-access-token-from-request.ts
@@ -8,8 +8,15 @@ import { backendConfig } from '@/config/backend-config';
 supertokens.init(backendConfig());
 
 export async function extractAccessTokenFromRequest(req: NextApiRequest, res: NextApiResponse): Promise<string> {
-  await superTokensNextWrapper(async next => await verifySession()(req as any, res as any, next), req, res);
-  // TODO: figure out what kind of error this can raise :)
-  const accessToken = (req as any).session.getAccessToken();
+  await superTokensNextWrapper(
+    async next =>
+      await verifySession({
+        sessionRequired: false,
+      })(req as any, res as any, next),
+    req,
+    res
+  );
+  // Session can be undefined in case access token was sent.
+  const accessToken = (req as any).session?.getAccessToken() || null;
   return accessToken;
 }


### PR DESCRIPTION
…behavior (https://github.com/getsentry/sentry-javascript/issues/3852#issuecomment-918820923)