### PR TITLE
Fix last visited org cookie

### DIFF
--- a/packages/web/app/pages/_app.tsx
+++ b/packages/web/app/pages/_app.tsx
@@ -61,8 +61,16 @@ function App({ Component, pageProps }: AppProps): ReactElement {
       gtag.pageview(url);
 
       const orgId = Router.query.orgId as string;
-      if (orgId && orgId !== cookies.get(LAST_VISITED_ORG_KEY)) {
-        cookies.set(LAST_VISITED_ORG_KEY, orgId);
+      const lastVisitedOrgCookieValue = cookies.get(LAST_VISITED_ORG_KEY);
+
+      // Make sure we do have orgId and the cookie is not in the legacy format
+      if (lastVisitedOrgCookieValue?.includes(':') && orgId) {
+        const [lastVisitedOrgId, checksum] = lastVisitedOrgCookieValue.split(':');
+
+        if (orgId !== lastVisitedOrgId) {
+          // Update the cookie with the new orgId
+          cookies.set(LAST_VISITED_ORG_KEY, `${orgId}:${checksum}`);
+        }
       }
     };
 


### PR DESCRIPTION
Now it includes a checksum, if it's a different session, it won't use the cookie.

The format is the following: `${cleanId}:${checksum}` where the checksum is specific to the user's session.

Few rules:
- Cookie is not used when the checksum does not match the user's session.
- Cookie is not updated/used when it's in the legacy format (we used to store just the `cleanId`).
- Cookies in the legacy format are replaced with the new format.
- If loading an organization fails, the cookie is removed.

This way a user won't end up in a situation where the cookie tells him/her to visit the wrong organization.