### PR TITLE
feat: import auth0 accounts into supertokens when doing a password reset

### DIFF
--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -46,6 +46,7 @@ export interface PersistedOperationSelector extends ProjectSelector {
 export interface Storage {
   getUserBySuperTokenId(_: { superTokensUserId: string }): Promise<User | null>;
   setSuperTokensUserId(_: { auth0UserId: string; superTokensUserId: string; externalUserId: string }): Promise<void>;
+  getUserWithoutAssociatedSuperTokenIdByAuth0Email(_: { email: string }): Promise<User | null>;
   getUserById(_: { id: string }): Promise<User | null>;
 
   createUser(_: {

--- a/packages/services/api/src/shared/entities.ts
+++ b/packages/services/api/src/shared/entities.ts
@@ -169,6 +169,7 @@ export interface User {
   provider: AuthProvider;
   superTokensUserId: string | null;
   isAdmin: boolean;
+  externalAuthUserId: string | null;
 }
 
 export interface Member {

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -84,6 +84,7 @@ export async function createStorage(connection: string): Promise<Storage> {
       fullName: user.full_name,
       displayName: user.display_name,
       isAdmin: user.is_admin ?? false,
+      externalAuthUserId: user.external_auth_user_id ?? null,
     };
   }
 
@@ -285,6 +286,25 @@ export async function createStorage(connection: string): Promise<Storage> {
           public."users"
         WHERE
           "supertoken_user_id" = ${superTokensUserId}
+        LIMIT 1
+      `);
+
+      if (user) {
+        return transformUser(user);
+      }
+
+      return null;
+    },
+    async getUserWithoutAssociatedSuperTokenIdByAuth0Email({ email }) {
+      const user = await pool.maybeOne<Slonik<users>>(sql`
+        SELECT
+          *
+        FROM
+          public."users"
+        WHERE
+          "email" = ${email}
+          AND "supertoken_user_id" IS NULL
+          AND "external_auth_user_id" LIKE 'auth0|%'
         LIMIT 1
       `);
 

--- a/packages/web/app/src/config/backend-config.ts
+++ b/packages/web/app/src/config/backend-config.ts
@@ -422,13 +422,15 @@ async function checkWhetherAuth0EmailUserWithoutAssociatedSuperTokensIdExists(
     }
   );
 
+  const body = await response.text();
+
   if (response.status !== 200) {
-    throw new Error('Failed to check whether user exists in Auth0.');
+    throw new Error(
+      `Failed to check whether the Auth0 email user without an associated supertokenId exists. Status: ${response.status}. Body: ${body}`
+    );
   }
 
-  const body = await response.json();
-
-  const { user } = CheckAuth0EmailUserExistsResponseModel.parse(body);
+  const { user } = CheckAuth0EmailUserExistsResponseModel.parse(JSON.parse(body));
 
   return user;
 }


### PR DESCRIPTION
Currently, the password of accounts that have not been migrated from Auth0 to SuperTokens (via a login) cannot be recovered.

This PR solves this by applying the following flow upon a password reset:

- Check if user exists in our database but not within supertokens
- If he does not exist in supertokens, create an supertokens user with a random password
- Continue the flow as usual