### PR TITLE
weird reproduction - no organization created

### DIFF
--- a/packages/services/api/src/modules/auth/providers/auth-manager.ts
+++ b/packages/services/api/src/modules/auth/providers/auth-manager.ts
@@ -202,11 +202,13 @@ export class AuthManager {
     email: string;
     externalAuthUserId: string | null;
   }): Promise<User> {
+    console.log('LOL ensuring internal user');
     let internalUser = await this.storage.getUserBySuperTokenId({
       superTokensUserId: input.superTokensUserId,
     });
 
     if (!internalUser) {
+      console.log('LOL no internal user found');
       internalUser = await this.userManager.createUser({
         superTokensUserId: input.superTokensUserId,
         externalAuthUserId: input.externalAuthUserId,
@@ -214,6 +216,7 @@ export class AuthManager {
       });
     }
 
+    console.log('LOL emit user event');
     await this.messageBus.emit<EnsurePersonalOrganizationEventPayload>(ENSURE_PERSONAL_ORGANIZATION_EVENT, {
       name: internalUser.displayName,
       user: {
@@ -221,6 +224,7 @@ export class AuthManager {
         superTokensUserId: input.superTokensUserId,
       },
     });
+    console.log('LOL emit user event done');
 
     return internalUser;
   }

--- a/packages/services/api/src/modules/organization/providers/organization-manager.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-manager.ts
@@ -73,10 +73,12 @@ export class OrganizationManager {
     private billingProvider: BillingProvider,
     private emails: Emails
   ) {
+    console.log('LOL org manager is created bruv');
     this.logger = logger.child({ source: 'OrganizationManager' });
-    this.messageBus.on<EnsurePersonalOrganizationEventPayload>(ENSURE_PERSONAL_ORGANIZATION_EVENT, data =>
-      this.ensurePersonalOrganization(data)
-    );
+    this.messageBus.on<EnsurePersonalOrganizationEventPayload>(ENSURE_PERSONAL_ORGANIZATION_EVENT, async data => {
+      console.log('LOL process this shit');
+      await this.ensurePersonalOrganization(data);
+    });
   }
 
   getOrganizationFromToken: () => Promise<Organization | never> = share(async () => {
@@ -589,6 +591,7 @@ export class OrganizationManager {
   }
 
   async ensurePersonalOrganization(payload: EnsurePersonalOrganizationEventPayload) {
+    console.log('LOL ensurePersonalOrganization');
     const myOrg = await this.storage.getMyOrganization({
       user: payload.user.id,
     });


### PR DESCRIPTION
Reproduction instructions:

1. run `yarn build && yarn docker:build`
2. run the docker-compose stack using the build images
3. sign up until you get an empty page (this only happens sometimes) tear down the stack and re-create it until you hit this scenario
4. check the logs

```
laurinquast@Laurins-MBP 123 % docker-compose -f docker-compose.community.yml logs  server | grep "LOL"
server_1          | LOL org manager is created bruv
server_1          | LOL ensuring internal user
server_1          | LOL no internal user found
server_1          | LOL emit user event
server_1          | LOL emit user event done
```

5. Notice that `LOL process this shit` is missing in the logs...



Afetr enablding `DEBUG` I get the following log - so the event is triggered for sure...

```
server_1          | [14:22:56.211][emittery:emitSerial][undefined] Event Name: ensure-personal-organization-event
server_1          |     data: {"name":"laurinquast","user":{"id":"5171c687-11e3-4473-bce6-9af15fb695dd","superTokensUserId":"ce4e2f1c-3906-4833-b111-656dad1375eb"}}
```
______

It seems like the event emitter is sometimes not shared or the event is swallowed 🤔 