### PR TITLE
Architecture Diagram

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,7 @@
+# Architecture
+
+## Diagram
+
+![Design Diagram](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/kamilkisiela/graphql-hive/main/docs/architecture.puml)
+
+Note: The relationships in this diagram is based on [this docker-compose](https://github.com/kamilkisiela/graphql-hive/blob/main/docker-compose.community.yml)

--- a/docs/architecture.puml
+++ b/docs/architecture.puml
@@ -1,0 +1,63 @@
+@startuml
+
+actor "UI User" as uiuser
+actor "CLI User" as cliuser
+actor "Running Server" as gqlserver
+
+component zookeeper
+component supertokens
+
+queue kafka
+
+database ClickHouse
+database Postgres
+database redis
+
+component server
+component schema
+component tokens
+component webhooks
+component emails
+component usage
+component "usage-ingestor" as usageing
+component app
+
+component "storage (migrations)" as storageSvc
+storageSvc ---d-> ClickHouse
+storageSvc ---d-> Postgres
+
+kafka -l-> zookeeper
+
+app --> supertokens
+app --> server
+app --> emails
+
+usageing --> ClickHouse
+kafka -> usageing
+usage -d-> kafka
+gqlserver -> usage
+
+emails -d-> redis
+webhooks -d-> redis
+tokens -d-> Postgres
+schema -d-> redis
+
+server -d-> Postgres
+server -d--> ClickHouse
+server -d-> redis
+server -d-> tokens
+server -d-> webhooks
+server -d-> schema
+server -d-> emails
+server -d-> supertokens
+
+supertokens -> Postgres
+
+uiuser --> app
+cliuser --> server
+
+emails -[hidden]-> webhooks
+
+usage ----> tokens
+
+@enduml


### PR DESCRIPTION
Adds a design diagram.

I verified the link works on the fork, it should work after it merges:

![Design Diagram](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/Enrico2/graphql-hive/integration/add_diagram/docs/architecture.puml)