### PR TITLE
Fix createServicesFetcher handle null service url

### DIFF
--- a/.changeset/famous-readers-cheat.md
+++ b/.changeset/famous-readers-cheat.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/client': patch
+---
+
+Fix createServicesFetcher handling null service url

--- a/.changeset/famous-readers-cheat.md
+++ b/.changeset/famous-readers-cheat.md
@@ -1,5 +1,5 @@
 ---
-'@graphql-hive/client': patch
+'@graphql-hive/client': minor
 ---
 
 Fix createServicesFetcher handling null service url

--- a/packages/libraries/client/src/gateways.ts
+++ b/packages/libraries/client/src/gateways.ts
@@ -4,7 +4,7 @@ import type { SchemaFetcherOptions, ServicesFetcherOptions } from './internal/ty
 
 interface Schema {
   sdl: string;
-  url: string;
+  url: string | null;
   name: string;
 }
 
@@ -62,7 +62,11 @@ export function createSchemaFetcher({ endpoint, key }: SchemaFetcherOptions) {
 
   return function schemaFetcher() {
     return fetcher().then(schema => ({
-      id: createHash('sha256').update(schema.sdl).update(schema.url).update(schema.name).digest('base64'),
+      id: createHash('sha256')
+        .update(schema.sdl)
+        .update(schema.url || '')
+        .update(schema.name)
+        .digest('base64'),
       ...schema,
     }));
   };
@@ -74,7 +78,11 @@ export function createServicesFetcher({ endpoint, key }: ServicesFetcherOptions)
   return function schemaFetcher() {
     return fetcher().then(services =>
       services.map(service => ({
-        id: createHash('sha256').update(service.sdl).update(service.url).update(service.name).digest('base64'),
+        id: createHash('sha256')
+          .update(service.sdl)
+          .update(service.url || '')
+          .update(service.name)
+          .digest('base64'),
         ...service,
       }))
     );


### PR DESCRIPTION
We found that when a service doesn't set an explicit service URL, which seems to be valid state, the fetcher fails when it tries to create the hash since you can't give `null` into a Node.js crypto hash

screenshot of reference:

![2022-10-29_20-33](https://user-images.githubusercontent.com/8672915/198861775-17a16b64-2bb2-4863-8618-6aecc6516aae.jpeg)


cc @saihaj @kamilkisiela 
