### PR TITLE
Improve rate-limit email title

### DIFF
--- a/integration-tests/tests/api/rate-limit/emails.spec.ts
+++ b/integration-tests/tests/api/rate-limit/emails.spec.ts
@@ -9,7 +9,12 @@ function generateUnique() {
 }
 
 function filterEmailsByOrg(orgName: string, emails: emails.Email[]) {
-  return emails.filter(email => email.subject.startsWith(orgName));
+  return emails
+    .filter(email => email.subject.includes(orgName))
+    .map(email => ({
+      subject: email.subject,
+      email: email.to,
+    }));
 }
 
 test('rate limit approaching and reached for organization', async () => {

--- a/integration-tests/tests/api/rate-limit/emails.spec.ts
+++ b/integration-tests/tests/api/rate-limit/emails.spec.ts
@@ -101,7 +101,7 @@ test('rate limit approaching and reached for organization', async () => {
 
   expect(sent).toContainEqual({
     to: adminEmail,
-    subject: `${org.name} has exceeded its rate limit`,
+    subject: `GraphQL-Hive operations quota for ${org.name} exceeded`,
     body: expect.any(String),
   });
   expect(filterEmailsByOrg(org.name, sent)).toHaveLength(2);

--- a/packages/services/rate-limit/src/emails.ts
+++ b/packages/services/rate-limit/src/emails.ts
@@ -50,7 +50,7 @@ export function createEmailScheduler(config?: { endpoint: string }) {
             period: input.period,
             limit: input.usage.quota,
           }),
-          subject: `${input.organization.name} has exceeded its rate limit`,
+          subject: `GraphQL-Hive operations quota for ${input.organization.name} exceeded`,
           body: `
           <mjml>
             <mj-body>
@@ -59,7 +59,7 @@ export function createEmailScheduler(config?: { endpoint: string }) {
                   <mj-image width="150px" src="https://graphql-hive.com/logo.png"></mj-image>
                   <mj-divider border-color="#ca8a04"></mj-divider>
                   <mj-text>
-                    Your organization <strong>${
+                    Your Hive organization <strong>${
                       input.organization.name
                     }</strong> has reached over 100% of the operations limit quota.
                     Used ${numberFormatter.format(input.usage.current)} of ${numberFormatter.format(input.usage.quota)}.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -596,7 +596,7 @@ importers:
       '@envelop/graphql-modules': 4.0.2
       '@envelop/sentry': 4.0.2
       '@envelop/types': 3.0.0
-      '@graphql-hive/client': 0.21.0
+      '@graphql-hive/client': 0.21.1
       '@hive/api': workspace:*
       '@hive/service-common': workspace:*
       '@hive/storage': workspace:*


### PR DESCRIPTION
The title today contains the term `rate-limit` which might be a bit confusing. We are using this term internally for limiting the reserved quota, but I think it's kinda confusing when it's sent to end-users.   