### PR TITLE
Ignore `.hive` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,5 @@ integration-tests/testkit/gql/
 
 # bob
 .bob
+
+.hive


### PR DESCRIPTION
When starting the services using docker compose, a local `.hive` folder is filled with artefacts. Ignore it.