### PR TITLE
Hoist all modules because of common deps

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 enable-pre-post-scripts=true
+shamefully-hoist=true


### PR DESCRIPTION
If you have a layout like this:
```
packages/
  service-common/
    package.json -> depends on "fastify-cors"
    node_modules
      fastify-cors
  server/
    package.json -> depends on "service-common@workspace"
    src/
      index.ts -> imports "service-common"
```

and you use `tsup` - the built code will **not** bundle the deps of `service-common`, instead the deps will be accessed regulary through an import statement.

In essence, code like this:
```js
// server/src/index.ts
import '@service-common';
```

will build to:
```
// server/dist/index.ts
<code from service-common>
```

The easiest solution is to simply hoist all deps so that the built code can run.

We might revisit this in the future with a more comprehensive solution that doesn't require hoisting, but for now - this should be enough.