### PR TITLE
Present user's permissions when opening a modal

### DIFF
--- a/packages/web/app/src/components/organization/Permissions.tsx
+++ b/packages/web/app/src/components/organization/Permissions.tsx
@@ -153,11 +153,11 @@ export function usePermissionsManager({
   const notify = useNotifications();
   const [, mutate] = useMutation(UpdateOrganizationMemberAccessDocument);
 
-  const [targetScopes, setTargetScopes] = React.useState<TargetAccessScope[]>([]);
-
-  const [projectScopes, setProjectScopes] = React.useState<ProjectAccessScope[]>([]);
-
-  const [organizationScopes, setOrganizationScopes] = React.useState<OrganizationAccessScope[]>([]);
+  const [targetScopes, setTargetScopes] = React.useState<TargetAccessScope[]>(member.targetAccessScopes);
+  const [projectScopes, setProjectScopes] = React.useState<ProjectAccessScope[]>(member.projectAccessScopes);
+  const [organizationScopes, setOrganizationScopes] = React.useState<OrganizationAccessScope[]>(
+    member.organizationAccessScopes
+  );
 
   const submit = React.useCallback(
     evt => {

--- a/packages/web/app/src/components/v2/modals/change-permissions.tsx
+++ b/packages/web/app/src/components/v2/modals/change-permissions.tsx
@@ -27,7 +27,7 @@ export const ChangePermissionsModal = ({
     <Modal open={isOpen} onOpenChange={toggleModalOpen} className="w-[600px]">
       <form className="flex flex-col items-center gap-5" onSubmit={manager.submit}>
         <Heading>Permissions</Heading>
-        <Accordion defaultIndex={0}>
+        <Accordion defaultIndex={0} width="100%">
           <PermissionsSpace
             title="Organization"
             scopes={scopes.organization}


### PR DESCRIPTION
Currently, when you want to modify user's access, every access scope shows "no access", even though the user has some of them. This PR fixes it, the currently available scopes will be visible every time the modal is open.
Closes #500
