### PR TITLE
envoy - bump timeoutPolicy to 60s and retry twice on reset

### DIFF
--- a/deployment/services/proxy.ts
+++ b/deployment/services/proxy.ts
@@ -62,6 +62,7 @@ export function deployProxy({
         name: 'server',
         path: '/server',
         service: graphql.service,
+        timeoutInSeconds: 60,
       },
       {
         name: 'registry-api-health',
@@ -74,17 +75,22 @@ export function deployProxy({
         path: '/registry',
         customRewrite: '/graphql',
         service: graphql.service,
+        timeoutInSeconds: 60,
+        retryOnReset: true,
       },
       {
         name: 'graphql-api',
         path: '/graphql',
         customRewrite: '/graphql',
         service: graphql.service,
+        timeoutInSeconds: 60,
+        retryOnReset: true,
       },
       {
         name: 'usage',
         path: '/usage',
         service: usage.service,
+        retryOnReset: true,
       },
     ])
     .get();

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -102,7 +102,7 @@ export class Proxy {
 
     const proxyController = new k8s.helm.v3.Chart('contour-proxy', {
       chart: 'contour',
-      version: '7.8.0',
+      version: '10.0.0',
       namespace: ns.metadata.name,
       fetchOpts: {
         repo: 'https://charts.bitnami.com/bitnami',
@@ -130,9 +130,6 @@ export class Proxy {
             'user_agent',
             'x_forwarded_for',
           ],
-          timeouts: {
-            'request-timeout': '60s',
-          },
         },
         contour: {
           podAnnotations: {

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -147,7 +147,6 @@ export class Proxy {
             'user_agent',
             'x_forwarded_for',
           ],
-          debug: true,
         },
         contour: {
           podAnnotations: {

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -81,6 +81,9 @@ export class Proxy {
                       },
                     ],
                   },
+                  timeoutPolicy: {
+                    response: '60s',
+                  },
                 }),
           })),
         },
@@ -130,6 +133,7 @@ export class Proxy {
             'user_agent',
             'x_forwarded_for',
           ],
+          debug: true,
         },
         contour: {
           podAnnotations: {

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -12,6 +12,8 @@ export class Proxy {
       name: string;
       path: string;
       service: k8s.core.v1.Service;
+      timeoutInSeconds?: number;
+      retryOnReset?: boolean;
       customRewrite?: string;
       virtualHost?: Output<string>;
       httpsUpstream?: boolean;
@@ -81,9 +83,21 @@ export class Proxy {
                       },
                     ],
                   },
-                  timeoutPolicy: {
-                    response: '60s',
-                  },
+                  ...(route.timeoutInSeconds
+                    ? {
+                        timeoutPolicy: {
+                          response: `${route.timeoutInSeconds}s`,
+                        },
+                      }
+                    : {}),
+                  ...(route.retryOnReset
+                    ? {
+                        retryPolicy: {
+                          count: 2,
+                          retryOn: 'reset',
+                        },
+                      }
+                    : {}),
                 }),
           })),
         },

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -94,7 +94,7 @@ export class Proxy {
                     ? {
                         retryPolicy: {
                           count: 2,
-                          retryOn: 'reset',
+                          retryOn: ['reset'],
                         },
                       }
                     : {}),

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -130,6 +130,9 @@ export class Proxy {
             'user_agent',
             'x_forwarded_for',
           ],
+          timeouts: {
+            'request-timeout': '60s',
+          },
         },
         contour: {
           podAnnotations: {

--- a/packages/web/app/pages/[orgId]/[projectId]/[targetId]/explorer.tsx
+++ b/packages/web/app/pages/[orgId]/[projectId]/[targetId]/explorer.tsx
@@ -2,13 +2,13 @@ import { ReactElement } from 'react';
 import { gql, useQuery } from 'urql';
 
 import { authenticated } from '@/components/authenticated-container';
-import { withSessionProtection } from '@/lib/supertokens/guard';
 import { TargetLayout } from '@/components/layouts';
 import { SchemaExplorerFilter } from '@/components/target/explorer/filter';
 import { GraphQLObjectTypeComponent } from '@/components/target/explorer/object-type';
 import { SchemaExplorerProvider, useSchemaExplorerContext } from '@/components/target/explorer/provider';
 import { DataWrapper, noSchema, Title } from '@/components/v2';
 import { OrganizationFieldsFragment, ProjectFieldsFragment, TargetFieldsFragment } from '@/graphql';
+import { withSessionProtection } from '@/lib/supertokens/guard';
 
 const SchemaView_SchemaExplorer = gql(/* GraphQL */ `
   query SchemaView_SchemaExplorer($organization: ID!, $project: ID!, $target: ID!, $period: DateRangeInput!) {

--- a/packages/web/app/pages/[orgId]/[projectId]/[targetId]/explorer/[typename].tsx
+++ b/packages/web/app/pages/[orgId]/[projectId]/[targetId]/explorer/[typename].tsx
@@ -2,7 +2,6 @@ import { ReactElement } from 'react';
 import { DocumentType, gql, useQuery } from 'urql';
 
 import { authenticated } from '@/components/authenticated-container';
-import { withSessionProtection } from '@/lib/supertokens/guard';
 import { TargetLayout } from '@/components/layouts';
 import {
   GraphQLEnumTypeComponent,
@@ -33,6 +32,7 @@ import {
 import { DataWrapper, noSchema, Title } from '@/components/v2';
 import { OrganizationFieldsFragment, ProjectFieldsFragment, TargetFieldsFragment } from '@/graphql';
 import { useRouteSelector } from '@/lib/hooks/use-route-selector';
+import { withSessionProtection } from '@/lib/supertokens/guard';
 
 const SchemaTypeExplorer_Type = gql(/* GraphQL */ `
   query SchemaTypeExplorer_Type(

--- a/packages/web/app/pages/[orgId]/[projectId]/[targetId]/history.tsx
+++ b/packages/web/app/pages/[orgId]/[projectId]/[targetId]/history.tsx
@@ -6,7 +6,6 @@ import reactStringReplace from 'react-string-replace';
 import { useQuery } from 'urql';
 
 import { authenticated } from '@/components/authenticated-container';
-import { withSessionProtection } from '@/lib/supertokens/guard';
 import { Label } from '@/components/common';
 import { TargetLayout } from '@/components/layouts';
 import {
@@ -28,6 +27,7 @@ import {
   VersionsDocument,
 } from '@/graphql';
 import { useRouteSelector } from '@/lib/hooks/use-route-selector';
+import { withSessionProtection } from '@/lib/supertokens/guard';
 
 function labelize(message: string) {
   const findSingleQuotes = /'([^']+)'/gim;

--- a/packages/web/app/pages/[orgId]/[projectId]/[targetId]/index.tsx
+++ b/packages/web/app/pages/[orgId]/[projectId]/[targetId]/index.tsx
@@ -14,7 +14,6 @@ import { gql, useMutation, useQuery } from 'urql';
 import { useDebouncedCallback } from 'use-debounce';
 
 import { authenticated } from '@/components/authenticated-container';
-import { withSessionProtection } from '@/lib/supertokens/guard';
 import { TargetLayout } from '@/components/layouts';
 import { MarkAsValid } from '@/components/target/history/MarkAsValid';
 import { Button, DataWrapper, GraphQLBlock, noSchema, Title } from '@/components/v2';
@@ -28,6 +27,7 @@ import {
   TargetFieldsFragment,
 } from '@/graphql';
 import { TargetAccessScope, useTargetAccess } from '@/lib/access/target';
+import { withSessionProtection } from '@/lib/supertokens/guard';
 
 const SchemaServiceName_UpdateSchemaServiceName = gql(/* GraphQL */ `
   mutation SchemaServiceName_UpdateSchemaServiceName($input: UpdateSchemaServiceNameInput!) {

--- a/packages/web/app/pages/[orgId]/[projectId]/[targetId]/laboratory.tsx
+++ b/packages/web/app/pages/[orgId]/[projectId]/[targetId]/laboratory.tsx
@@ -3,12 +3,12 @@ import { createGraphiQLFetcher } from '@graphiql/toolkit';
 import { GraphiQL } from 'graphiql';
 
 import { authenticated } from '@/components/authenticated-container';
-import { withSessionProtection } from '@/lib/supertokens/guard';
 import { TargetLayout } from '@/components/layouts';
 import { Button, Title } from '@/components/v2';
 import { HiveLogo, Link2Icon } from '@/components/v2/icon';
 import { ConnectLabModal } from '@/components/v2/modals/connect-lab';
 import { useRouteSelector } from '@/lib/hooks/use-route-selector';
+import { withSessionProtection } from '@/lib/supertokens/guard';
 import 'graphiql/graphiql.css';
 
 const Page = ({ endpoint }: { endpoint: string }): ReactElement => {

--- a/packages/web/app/pages/[orgId]/[projectId]/[targetId]/operations.tsx
+++ b/packages/web/app/pages/[orgId]/[projectId]/[targetId]/operations.tsx
@@ -7,7 +7,6 @@ import { VscChevronDown } from 'react-icons/vsc';
 import { useQuery } from 'urql';
 
 import { authenticated } from '@/components/authenticated-container';
-import { withSessionProtection } from '@/lib/supertokens/guard';
 import { TargetLayout } from '@/components/layouts';
 import { OperationsFilterTrigger } from '@/components/target/operations/Filters';
 import { OperationsList } from '@/components/target/operations/List';
@@ -20,6 +19,7 @@ import {
   TargetFieldsFragment,
 } from '@/graphql';
 import { getDocsUrl } from '@/lib/docs-url';
+import { withSessionProtection } from '@/lib/supertokens/guard';
 
 function floorDate(date: Date): Date {
   const time = 1000 * 60;

--- a/packages/web/app/pages/[orgId]/[projectId]/[targetId]/settings.tsx
+++ b/packages/web/app/pages/[orgId]/[projectId]/[targetId]/settings.tsx
@@ -7,7 +7,6 @@ import { gql, useMutation, useQuery } from 'urql';
 import * as Yup from 'yup';
 
 import { authenticated } from '@/components/authenticated-container';
-import { withSessionProtection } from '@/lib/supertokens/guard';
 import { TargetLayout } from '@/components/layouts';
 import { SchemaEditor } from '@/components/schema-editor';
 import { Button, Card, Checkbox, Heading, Input, Switch, Table, Tag, TimeAgo, Title } from '@/components/v2';
@@ -24,6 +23,7 @@ import {
 } from '@/graphql';
 import { canAccessTarget, TargetAccessScope } from '@/lib/access/target';
 import { useRouteSelector } from '@/lib/hooks/use-route-selector';
+import { withSessionProtection } from '@/lib/supertokens/guard';
 
 const columns = [
   { key: 'checkbox' },

--- a/packages/web/app/pages/[orgId]/[projectId]/alerts.tsx
+++ b/packages/web/app/pages/[orgId]/[projectId]/alerts.tsx
@@ -2,7 +2,6 @@ import { ReactElement, useCallback, useState } from 'react';
 import { useMutation, useQuery } from 'urql';
 
 import { authenticated } from '@/components/authenticated-container';
-import { withSessionProtection } from '@/lib/supertokens/guard';
 import { ProjectLayout } from '@/components/layouts';
 import { Button, Card, Checkbox, Heading, Table, Tag, Title } from '@/components/v2';
 import { CreateAlertModal, CreateChannelModal } from '@/components/v2/modals';
@@ -17,6 +16,7 @@ import {
 } from '@/graphql';
 import { ProjectAccessScope, useProjectAccess } from '@/lib/access/project';
 import { useRouteSelector } from '@/lib/hooks/use-route-selector';
+import { withSessionProtection } from '@/lib/supertokens/guard';
 
 const channelAlertsColumns = [{ key: 'checkbox', width: 'auto' }, { key: 'name' }, { key: 'type' }] as const;
 

--- a/packages/web/app/pages/[orgId]/[projectId]/index.tsx
+++ b/packages/web/app/pages/[orgId]/[projectId]/index.tsx
@@ -4,7 +4,6 @@ import clsx from 'clsx';
 import { useQuery } from 'urql';
 
 import { authenticated } from '@/components/authenticated-container';
-import { withSessionProtection } from '@/lib/supertokens/guard';
 import { ProjectLayout } from '@/components/layouts';
 import { Activities, Badge, Button, Card, DropdownMenu, EmptyList, Heading, TimeAgo, Title } from '@/components/v2';
 import { LinkIcon, MoreIcon, SettingsIcon } from '@/components/v2/icon';
@@ -12,6 +11,7 @@ import { TargetQuery, TargetsDocument, VersionsDocument } from '@/graphql';
 import { getDocsUrl } from '@/lib/docs-url';
 import { useClipboard } from '@/lib/hooks/use-clipboard';
 import { useRouteSelector } from '@/lib/hooks/use-route-selector';
+import { withSessionProtection } from '@/lib/supertokens/guard';
 
 const TargetCard = ({ target }: { target: Exclude<TargetQuery['target'], null | undefined> }): ReactElement => {
   const router = useRouteSelector();

--- a/packages/web/app/pages/[orgId]/[projectId]/settings.tsx
+++ b/packages/web/app/pages/[orgId]/[projectId]/settings.tsx
@@ -5,7 +5,6 @@ import { gql, useMutation, useQuery } from 'urql';
 import * as Yup from 'yup';
 
 import { authenticated } from '@/components/authenticated-container';
-import { withSessionProtection } from '@/lib/supertokens/guard';
 import { ProjectLayout } from '@/components/layouts';
 import { ExternalCompositionSettings } from '@/components/project/settings/external-composition';
 import { Button, Card, Heading, Input, Link, Select, Spinner, Tag, Title } from '@/components/v2';
@@ -19,6 +18,7 @@ import {
 } from '@/graphql';
 import { canAccessProject, ProjectAccessScope, useProjectAccess } from '@/lib/access/project';
 import { useRouteSelector } from '@/lib/hooks/use-route-selector';
+import { withSessionProtection } from '@/lib/supertokens/guard';
 
 const Settings_UpdateProjectGitRepositoryMutation = gql(/* GraphQL */ `
   mutation Settings_UpdateProjectGitRepository($input: UpdateProjectGitRepositoryInput!) {

--- a/packages/web/app/pages/[orgId]/index.tsx
+++ b/packages/web/app/pages/[orgId]/index.tsx
@@ -4,7 +4,6 @@ import { onlyText } from 'react-children-utilities';
 import { useQuery } from 'urql';
 
 import { authenticated } from '@/components/authenticated-container';
-import { withSessionProtection } from '@/lib/supertokens/guard';
 import { OrganizationLayout } from '@/components/layouts';
 import { Activities, Button, Card, DropdownMenu, EmptyList, Heading, Skeleton, TimeAgo, Title } from '@/components/v2';
 import { getActivity } from '@/components/v2/activities';
@@ -15,6 +14,7 @@ import { getDocsUrl } from '@/lib/docs-url';
 import { fixDuplicatedFragments } from '@/lib/graphql';
 import { useClipboard } from '@/lib/hooks/use-clipboard';
 import { useRouteSelector } from '@/lib/hooks/use-route-selector';
+import { withSessionProtection } from '@/lib/supertokens/guard';
 
 const projectActivitiesDocument = fixDuplicatedFragments(ProjectActivitiesDocument);
 

--- a/packages/web/app/pages/[orgId]/members.tsx
+++ b/packages/web/app/pages/[orgId]/members.tsx
@@ -5,7 +5,6 @@ import { DocumentType, gql, useMutation, useQuery } from 'urql';
 import * as Yup from 'yup';
 
 import { authenticated } from '@/components/authenticated-container';
-import { withSessionProtection } from '@/lib/supertokens/guard';
 import { OrganizationLayout } from '@/components/layouts';
 import { Avatar, Button, Card, Checkbox, DropdownMenu, Input, Title } from '@/components/v2';
 import { CopyIcon, KeyIcon, MoreIcon, SettingsIcon, TrashIcon } from '@/components/v2/icon';
@@ -16,6 +15,7 @@ import { useClipboard } from '@/lib/hooks/use-clipboard';
 import { useNotifications } from '@/lib/hooks/use-notifications';
 import { useRouteSelector } from '@/lib/hooks/use-route-selector';
 import { useToggle } from '@/lib/hooks/use-toggle';
+import { withSessionProtection } from '@/lib/supertokens/guard';
 
 export const DateFormatter = Intl.DateTimeFormat('en', {
   year: 'numeric',

--- a/packages/web/app/pages/[orgId]/settings.tsx
+++ b/packages/web/app/pages/[orgId]/settings.tsx
@@ -4,7 +4,6 @@ import { gql, useMutation, useQuery } from 'urql';
 import * as Yup from 'yup';
 
 import { authenticated } from '@/components/authenticated-container';
-import { withSessionProtection } from '@/lib/supertokens/guard';
 import { OrganizationLayout } from '@/components/layouts';
 import { OIDCIntegrationSection } from '@/components/organization/settings/oidc-integration-section';
 import { Button, Card, Heading, Input, Spinner, Tag, Title } from '@/components/v2';
@@ -20,6 +19,7 @@ import {
 } from '@/graphql';
 import { canAccessOrganization, OrganizationAccessScope, useOrganizationAccess } from '@/lib/access/organization';
 import { useRouteSelector } from '@/lib/hooks/use-route-selector';
+import { withSessionProtection } from '@/lib/supertokens/guard';
 
 const Integrations = (): ReactElement => {
   const router = useRouteSelector();

--- a/packages/web/app/pages/[orgId]/subscription/index.tsx
+++ b/packages/web/app/pages/[orgId]/subscription/index.tsx
@@ -4,7 +4,6 @@ import { Stat, StatHelpText, StatLabel, StatNumber } from '@chakra-ui/react';
 import { endOfMonth, startOfMonth } from 'date-fns';
 
 import { authenticated } from '@/components/authenticated-container';
-import { withSessionProtection } from '@/lib/supertokens/guard';
 import { OrganizationLayout } from '@/components/layouts';
 import { BillingView } from '@/components/organization/billing/Billing';
 import { CurrencyFormatter } from '@/components/organization/billing/helpers';
@@ -15,6 +14,7 @@ import { Card, Heading, Tabs, Title } from '@/components/v2';
 import { OrganizationFieldsFragment, OrgBillingInfoFieldsFragment, OrgRateLimitFieldsFragment } from '@/graphql';
 import { OrganizationAccessScope, useOrganizationAccess } from '@/lib/access/organization';
 import { getIsStripeEnabled } from '@/lib/billing/stripe-public-key';
+import { withSessionProtection } from '@/lib/supertokens/guard';
 
 const DateFormatter = Intl.DateTimeFormat('en-US', {
   month: 'short',

--- a/packages/web/app/pages/[orgId]/subscription/manage.tsx
+++ b/packages/web/app/pages/[orgId]/subscription/manage.tsx
@@ -5,7 +5,6 @@ import { CardElement, useElements, useStripe } from '@stripe/react-stripe-js';
 import { useMutation, useQuery } from 'urql';
 
 import { authenticated } from '@/components/authenticated-container';
-import { withSessionProtection } from '@/lib/supertokens/guard';
 import { Section } from '@/components/common';
 import { DataWrapper, QueryError } from '@/components/common/DataWrapper';
 import { OrganizationLayout } from '@/components/layouts';
@@ -25,6 +24,7 @@ import {
   UpgradeToProDocument,
 } from '@/graphql';
 import { OrganizationAccessScope, useOrganizationAccess } from '@/lib/access/organization';
+import { withSessionProtection } from '@/lib/supertokens/guard';
 
 const Inner = ({
   organization,


### PR DESCRIPTION
I updated the helm chart `7.8.0 -> 10.0.0`
Whenever a request is dropped because of connection reset, we do a retry (max 2) now.
The timeout (response) is higher `60s -> 15s` for all upstream routes.