### PR TITLE
Introduce tokens_http_requests and usage_tokens_duration_seconds metrics

### DIFF
--- a/packages/services/usage/src/metrics.ts
+++ b/packages/services/usage/src/metrics.ts
@@ -10,6 +10,12 @@ export const tokenRequests = new metrics.Counter({
   help: 'Number of requests to Tokens service',
 });
 
+export const tokensDuration = new metrics.Histogram({
+  name: 'usage_tokens_duration_seconds',
+  help: 'Duration of an HTTP Request to Tokens service in seconds',
+  labelNames: ['status'],
+});
+
 export const httpRequests = new metrics.Counter({
   name: 'usage_http_requests',
   help: 'Number of http requests',


### PR DESCRIPTION
It should give us more insights.

`tokens_http_requests` - to track number of calls received by the tokens service
`usage_tokens_duration_seconds` - to track the duration (useful once we switch to Redis at some point)