### PR TITLE
Added posibility to use mail smtp server without trusted certificate

### DIFF
--- a/packages/services/emails/src/environment.ts
+++ b/packages/services/emails/src/environment.ts
@@ -56,7 +56,7 @@ const SMTPEmailModel = zod.object({
   EMAIL_PROVIDER_SMTP_PORT: NumberFromString,
   EMAIL_PROVIDER_SMTP_AUTH_USERNAME: zod.string(),
   EMAIL_PROVIDER_SMTP_AUTH_PASSWORD: zod.string(),
-  EMAIL_PROVIDER_SMTP_REJECT_UNAUTHORIZED: zod.booleanValue
+  EMAIL_PROVIDER_SMTP_REJECT_UNAUTHORIZED: zod.boolean().optional()
 });
 
 const SendmailEmailModel = zod.object({

--- a/packages/services/emails/src/environment.ts
+++ b/packages/services/emails/src/environment.ts
@@ -56,6 +56,7 @@ const SMTPEmailModel = zod.object({
   EMAIL_PROVIDER_SMTP_PORT: NumberFromString,
   EMAIL_PROVIDER_SMTP_AUTH_USERNAME: zod.string(),
   EMAIL_PROVIDER_SMTP_AUTH_PASSWORD: zod.string(),
+  EMAIL_PROVIDER_SMTP_REJECT_UNAUTHORIZED: zod.booleanValue
 });
 
 const SendmailEmailModel = zod.object({
@@ -154,6 +155,9 @@ const emailProviderConfig =
           user: email.EMAIL_PROVIDER_SMTP_AUTH_USERNAME,
           pass: email.EMAIL_PROVIDER_SMTP_AUTH_PASSWORD,
         },
+        tls: {
+          rejectUnauthorized: email.EMAIL_PROVIDER_SMTP_REJECT_UNAUTHORIZED
+        }
       } as const)
     : email.EMAIL_PROVIDER === 'sendmail'
     ? ({ provider: 'sendmail' } as const)

--- a/packages/services/emails/src/providers.ts
+++ b/packages/services/emails/src/providers.ts
@@ -91,6 +91,9 @@ function smtp(config: SMTPEmailProviderConfig, emailFrom: string) {
       user: config.auth.user,
       pass: config.auth.pass,
     },
+    tls: {
+      rejectUnauthorized: config.tls.rejectUnauthorized
+    }
   });
 
   return {


### PR DESCRIPTION
Without this setup it is not possible to send emails via smtp server with self-signed certificate. You will reverie such error

{"level":50,"time":1669707712901,"pid":1,"hostname":"hive-emails-deploy-7944bbd7-f5gft","code":"ESOCKET","command":"CONN","stack":"Error: self signed certificate\n    at TLSSocket.onConnectSecure (node:_tls_wrap:1539:34)\n    at TLSSocket.emit (node:events:513:28)\n    at TLSSocket.emit (node:domain:489:12)\n    at TLSSocket._finishInit (node:_tls_wrap:953:8)\n    at TLSWrap.ssl.onhandshakedone (node:_tls_wrap:734:12)","type":"Error","msg":"self signed certificate"}