### PR TITLE
Fixed parse env variable EMAIL_PROVIDER_SMTP_REJECT_UNAUTHORIZED

### DIFF
--- a/packages/services/emails/src/environment.ts
+++ b/packages/services/emails/src/environment.ts
@@ -56,7 +56,7 @@ const SMTPEmailModel = zod.object({
   EMAIL_PROVIDER_SMTP_PORT: NumberFromString,
   EMAIL_PROVIDER_SMTP_AUTH_USERNAME: zod.string(),
   EMAIL_PROVIDER_SMTP_AUTH_PASSWORD: zod.string(),
-  EMAIL_PROVIDER_SMTP_REJECT_UNAUTHORIZED: zod.boolean().optional(),
+  EMAIL_PROVIDER_SMTP_REJECT_UNAUTHORIZED: zod.string(),
 });
 
 const SendmailEmailModel = zod.object({
@@ -156,7 +156,7 @@ const emailProviderConfig =
           pass: email.EMAIL_PROVIDER_SMTP_AUTH_PASSWORD,
         },
         tls: {
-          rejectUnauthorized: email.EMAIL_PROVIDER_SMTP_REJECT_UNAUTHORIZED,
+          rejectUnauthorized: !(email.EMAIL_PROVIDER_SMTP_REJECT_UNAUTHORIZED === 'false'),
         },
       } as const)
     : email.EMAIL_PROVIDER === 'sendmail'

--- a/packages/services/emails/src/environment.ts
+++ b/packages/services/emails/src/environment.ts
@@ -56,7 +56,9 @@ const SMTPEmailModel = zod.object({
   EMAIL_PROVIDER_SMTP_PORT: NumberFromString,
   EMAIL_PROVIDER_SMTP_AUTH_USERNAME: zod.string(),
   EMAIL_PROVIDER_SMTP_AUTH_PASSWORD: zod.string(),
-  EMAIL_PROVIDER_SMTP_REJECT_UNAUTHORIZED: zod.string().optional(),
+  EMAIL_PROVIDER_SMTP_REJECT_UNAUTHORIZED: emptyString(
+    zod.union([zod.literal('0'), zod.literal('1')]).optional(),
+  ),
 });
 
 const SendmailEmailModel = zod.object({
@@ -156,7 +158,7 @@ const emailProviderConfig =
           pass: email.EMAIL_PROVIDER_SMTP_AUTH_PASSWORD,
         },
         tls: {
-          rejectUnauthorized: !(email.EMAIL_PROVIDER_SMTP_REJECT_UNAUTHORIZED === 'false'),
+          rejectUnauthorized: !(email.EMAIL_PROVIDER_SMTP_REJECT_UNAUTHORIZED === '0'),
         },
       } as const)
     : email.EMAIL_PROVIDER === 'sendmail'

--- a/packages/services/emails/src/environment.ts
+++ b/packages/services/emails/src/environment.ts
@@ -56,7 +56,7 @@ const SMTPEmailModel = zod.object({
   EMAIL_PROVIDER_SMTP_PORT: NumberFromString,
   EMAIL_PROVIDER_SMTP_AUTH_USERNAME: zod.string(),
   EMAIL_PROVIDER_SMTP_AUTH_PASSWORD: zod.string(),
-  EMAIL_PROVIDER_SMTP_REJECT_UNAUTHORIZED: zod.string(),
+  EMAIL_PROVIDER_SMTP_REJECT_UNAUTHORIZED: zod.string().optional(),
 });
 
 const SendmailEmailModel = zod.object({


### PR DESCRIPTION
Fixed parse from env, as env variable is always string and zod cannot parse string to boolean - it is needed to convert it to boolean