### PR TITLE
Fix error message overflow

### DIFF
--- a/packages/web/app/pages/[orgId]/[projectId]/[targetId]/history.tsx
+++ b/packages/web/app/pages/[orgId]/[projectId]/[targetId]/history.tsx
@@ -107,7 +107,7 @@ const DiffView = ({
         <p className="text-base text-gray-500">
           Previous or current schema is most likely incomplete and was force published
         </p>
-        <pre className="mt-5 rounded-lg bg-red-900 p-3 text-xs text-white">
+        <pre className="mt-5 rounded-lg bg-red-900 p-3 text-xs text-white whitespace-pre-wrap">
           {error.graphQLErrors[0].message}
         </pre>
       </div>


### PR DESCRIPTION
When the error message is very long, the text is overflowing. Adding `whitespace-pre-wrap` class from tailwind to wrap the text.

Before:
![image](https://user-images.githubusercontent.com/11473501/204623358-b73d443c-505c-4ce1-9f49-d41c07c68e5f.png)

After:
![image](https://user-images.githubusercontent.com/11473501/204623552-db419e0a-5819-472b-b2dd-8bc85e47ea80.png)

