### PR TITLE
Refactor external composition service and added better documentation

### DIFF
--- a/packages/services/external-composition/federation-2/README.md
+++ b/packages/services/external-composition/federation-2/README.md
@@ -1,1 +1,64 @@
 # Composition Service for Apollo Federation 2
+
+# Background
+
+Hive comes with support for Apollo Federation v2, based on
+[external composition](https://docs.graphql-hive.com/features/external-schema-composition).
+
+This package provides a reference for running external composition as a NodeJS service, on your
+local infrastructure, and connect GraphQL Hive (SaaS or self-service).
+
+# Usage
+
+Start by deciding on your encryption secret. This is needed in order to ensure you endpoint is
+secured and can be triggered only by Hive platform. Your secret can be any string you decide, and it
+will be used as private key to hash the requests to your composition service.
+
+We are going to use that secret later as `SECERT` env var, and also in Hive dashboard.
+
+## Running as Docker container
+
+You can run this service as Docker container
+(`ghcr.io/kamilkisiela/graphql-hive/composition-federation-2`), from the published
+[Docker image we provide](https://github.com/kamilkisiela/graphql-hive/pkgs/container/graphql-hive%2Fcomposition-federation-2).
+
+To run the service, use the following command:
+
+```
+docker run -p 3069 -e SECRET="MY_SECRET_HERE" ghcr.io/kamilkisiela/graphql-hive/composition-federation-2
+```
+
+The container runs on port `3069` by default (you can chnage it using `PORT` env var), and listens
+to `POST /compose` requests coming from Hive platform.
+
+You should make this service publicly available and accessible to use it with Hive SaaS platform, or
+make it availble in your local/private network if you are using Hive on-prem.
+
+## Running from source code
+
+You can clone this repository, install dependencies (`pnpm install`) and then run this service
+directly, by running:
+
+```
+cd packages/services/external-composition/federation-2
+export SECRET="MY_SECRET_HERE"
+pnpm dev
+```
+
+Or, to run the built version:
+
+```
+cd packages/services/external-composition/federation-2
+pnpm build
+export SECRET="MY_SECRET_HERE"
+node dist/index.js
+```
+
+## Hive Integration
+
+[Here you can find instructions on how to integrate your external composition service with Hive](https://docs.graphql-hive.com/features/external-schema-composition#configuration).
+
+You'll need to use the public address of your service, and the secret you selected.
+
+The service created here listens to `POST /compose` requests, so the endpoint you are using should
+be composed from the public endpoint of this service, and the `/compose` path.

--- a/packages/services/external-composition/federation-2/package.json
+++ b/packages/services/external-composition/federation-2/package.json
@@ -8,11 +8,11 @@
     "dev": "tsup-node src/dev.ts --format esm --shims --target node16 --watch --sourcemap --onSuccess 'node --enable-source-maps dist/dev.js' | pino-pretty --translateTime HH:MM:ss TT --ignore pid,hostname"
   },
   "dependencies": {
-    "@apollo/composition": "^2.2.1",
+    "@apollo/composition": "^2.2.2",
     "@whatwg-node/fetch": "^0.5.3",
     "@whatwg-node/server": "^0.4.17",
     "graphql": "^16.6.0",
-    "zod": "^3.15.1"
+    "zod": "^3.20.2"
   },
   "devDependencies": {
     "@graphql-hive/external-composition": "workspace:*"

--- a/packages/services/external-composition/federation-2/src/index.ts
+++ b/packages/services/external-composition/federation-2/src/index.ts
@@ -1,97 +1,11 @@
-import { verifyRequest, compose, signatureHeaderName } from '@graphql-hive/external-composition';
-import { composeServices } from '@apollo/composition';
-import { parse, printSchema } from 'graphql';
 import { createServer } from 'node:http';
 import process from 'node:process';
-import { createServerAdapter } from '@whatwg-node/server';
-import { Response } from '@whatwg-node/fetch';
-import { env } from './environment';
+import { createRequestListener } from './server';
+import { resolveEnv } from './environment';
 
-const composeFederation = compose(services => {
-  const result = composeServices(
-    services.map(service => {
-      return {
-        typeDefs: parse(service.sdl),
-        name: service.name,
-        url: service.url,
-      };
-    }),
-  );
-
-  if (result.errors?.length) {
-    return {
-      type: 'failure',
-      result: {
-        errors: result.errors.map(error => ({
-          message: error.message,
-        })),
-      },
-    };
-  }
-
-  if (!result.supergraphSdl) {
-    return {
-      type: 'failure',
-      result: {
-        errors: [{ message: 'supergraphSdl not defined' }],
-      },
-    };
-  }
-
-  return {
-    type: 'success',
-    result: {
-      supergraph: result.supergraphSdl,
-      sdl: printSchema(result.schema.toGraphQLJSSchema()),
-    },
-  };
-});
-
-const requestListener = createServerAdapter(async request => {
-  const url = new URL(request.url);
-
-  if (url.pathname === '/_readiness') {
-    return new Response('Ok.', {
-      status: 200,
-    });
-  }
-
-  if (request.method === 'POST' && url.pathname === '/compose') {
-    const signatureHeaderValue = request.headers.get(signatureHeaderName);
-    if (signatureHeaderValue === null) {
-      return new Response(`Missing signature header '${signatureHeaderName}'.`, { status: 400 });
-    }
-
-    const body = await request.text();
-
-    const error = verifyRequest({
-      // Stringified body, or raw body if you have access to it
-      body,
-      // Pass here the signature from `X-Hive-Signature-256` header
-      signature: signatureHeaderValue,
-      // Pass here the secret you configured in GraphQL Hive
-      secret: env.secret,
-    });
-
-    if (error) {
-      return new Response(error, { status: 500 });
-    } else {
-      const result = composeFederation(JSON.parse(body));
-      return new Response(JSON.stringify(result), {
-        status: 200,
-        headers: {
-          'content-type': 'application/json',
-        },
-      });
-    }
-  }
-
-  return new Response('', {
-    status: 404,
-  });
-});
-
-const server = createServer(requestListener);
+// eslint-disable-next-line no-process-env
+const env = resolveEnv(process.env);
+const server = createServer(createRequestListener(env));
 
 server.listen(env.http.port, () => {
   console.log(`Listening on http://localhost:${env.http.port}`);

--- a/packages/services/external-composition/federation-2/src/server.ts
+++ b/packages/services/external-composition/federation-2/src/server.ts
@@ -1,0 +1,104 @@
+import { verifyRequest, compose, signatureHeaderName } from '@graphql-hive/external-composition';
+import { composeServices } from '@apollo/composition';
+import { parse, printSchema } from 'graphql';
+import { createServerAdapter } from '@whatwg-node/server';
+import { Response } from '@whatwg-node/fetch';
+import { ResolvedEnv } from './environment';
+
+const composeFederation = compose(services => {
+  try {
+    const result = composeServices(
+      services.map(service => {
+        return {
+          typeDefs: parse(service.sdl),
+          name: service.name,
+          url: service.url,
+        };
+      }),
+    );
+
+    if (result.errors?.length) {
+      return {
+        type: 'failure',
+        result: {
+          errors: result.errors.map(error => ({
+            message: error.message,
+          })),
+        },
+      };
+    } else {
+      if (!result.supergraphSdl) {
+        return {
+          type: 'failure',
+          result: {
+            errors: [{ message: 'supergraphSdl not defined' }],
+          },
+        };
+      }
+
+      return {
+        type: 'success',
+        result: {
+          supergraph: result.supergraphSdl,
+          sdl: printSchema(result.schema.toGraphQLJSSchema()),
+        },
+      };
+    }
+  } catch (e) {
+    return {
+      type: 'failure',
+      result: {
+        errors: [
+          {
+            message: (e as Error).message,
+          },
+        ],
+      },
+    };
+  }
+});
+
+export const createRequestListener = (env: ResolvedEnv): ReturnType<typeof createServerAdapter> =>
+  createServerAdapter(async request => {
+    const url = new URL(request.url);
+
+    if (url.pathname === '/_readiness') {
+      return new Response('Ok.', {
+        status: 200,
+      });
+    }
+
+    if (request.method === 'POST' && url.pathname === '/compose') {
+      const signatureHeaderValue = request.headers.get(signatureHeaderName);
+      if (signatureHeaderValue === null) {
+        return new Response(`Missing signature header '${signatureHeaderName}'.`, { status: 400 });
+      }
+
+      const body = await request.text();
+
+      const error = verifyRequest({
+        // Stringified body, or raw body if you have access to it
+        body,
+        // Pass here the signature from `X-Hive-Signature-256` header
+        signature: signatureHeaderValue,
+        // Pass here the secret you configured in GraphQL Hive
+        secret: env.secret,
+      });
+
+      if (error) {
+        return new Response(error, { status: 500 });
+      } else {
+        const result = composeFederation(JSON.parse(body));
+        return new Response(JSON.stringify(result), {
+          status: 200,
+          headers: {
+            'content-type': 'application/json',
+          },
+        });
+      }
+    }
+
+    return new Response('', {
+      status: 404,
+    });
+  });

--- a/packages/web/docs/src/pages/features/external-schema-composition.mdx
+++ b/packages/web/docs/src/pages/features/external-schema-composition.mdx
@@ -240,6 +240,40 @@ await server.listen({
 
 ### Apollo Federation v2 example
 
+#### CloudFlare Worker
+
+We provide a ready-to-use CloudFlare Worker project
+
+#### Pre-built Docker image
+
+We provide a
+[Docker image](https://github.com/kamilkisiela/graphql-hive/pkgs/container/graphql-hive%2Fcomposition-federation-2)
+for running external composition service for Apollo Federation v2.
+
+The pre-built image implements the best-practice to secure your endpoint, and uses the latest
+version of Apollo Federation v2.
+
+Start by deciding on your encryption secret. This is needed in order to ensure you endpoint is
+secured and can be triggered only by Hive platform. Your secret can be any string you decide, and it
+will be used as private key to hash the requests to your composition service.
+
+To run the container, you can use the following command:
+
+```
+docker run -p 3069 -e SECRET="MY_SECRET_HERE" ghcr.io/kamilkisiela/graphql-hive/composition-federation-2
+```
+
+You should make this service publicly available, and then configure it in Hive platform (see
+`Configuration` section above).
+
+The container created here listens to `POST /compose` requests, so the endpoint you are using should
+be composed from the public endpoint of this service, and the `/compose` path.
+
+#### Custom NodeJS Server
+
+You can also build your own server for the composition endpoint. The following example shows how to
+do that.
+
 The following example shows how to implement an external composition endpoint for Apollo Federation
 v2 in NodeJS.
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -535,13 +535,13 @@ importers:
       '@whatwg-node/fetch': ^0.5.3
       '@whatwg-node/server': ^0.4.17
       graphql: 16.6.0
-      zod: ^3.15.1
+      zod: ^3.20.2
     dependencies:
       '@apollo/composition': 2.2.1_graphql@16.6.0
       '@whatwg-node/fetch': 0.5.3
       '@whatwg-node/server': 0.4.17
       graphql: 16.6.0
-      zod: 3.19.1
+      zod: 3.20.2
     devDependencies:
       '@graphql-hive/external-composition': link:../../../libraries/external-composition
 
@@ -12572,7 +12572,7 @@ packages:
       tsup: 5.12.7_typescript@4.8.4
       typescript: 4.8.4
       yargs: 17.6.0
-      zod: 3.19.1
+      zod: 3.20.2
     transitivePeerDependencies:
       - postcss
       - supports-color
@@ -27530,6 +27530,10 @@ packages:
 
   /zod/3.19.1:
     resolution: {integrity: sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==}
+    dev: false
+
+  /zod/3.20.2:
+    resolution: {integrity: sha512-1MzNQdAvO+54H+EaK5YpyEy0T+Ejo/7YLHS93G3RnYWh5gaotGHwGeN/ZO687qEDU2y4CdStQYXVHIgrUl5UVQ==}
 
   /zrender/5.3.1:
     resolution: {integrity: sha512-7olqIjy0gWfznKr6vgfnGBk7y4UtdMvdwFmK92vVQsQeDPyzkHW1OlrLEKg6GHz1W5ePf0FeN1q2vkl/HFqhXw==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -530,14 +530,14 @@ importers:
 
   packages/services/external-composition/federation-2:
     specifiers:
-      '@apollo/composition': ^2.2.1
+      '@apollo/composition': ^2.2.2
       '@graphql-hive/external-composition': workspace:*
       '@whatwg-node/fetch': ^0.5.3
       '@whatwg-node/server': ^0.4.17
       graphql: 16.6.0
       zod: ^3.20.2
     dependencies:
-      '@apollo/composition': 2.2.1_graphql@16.6.0
+      '@apollo/composition': 2.2.2_graphql@16.6.0
       '@whatwg-node/fetch': 0.5.3
       '@whatwg-node/server': 0.4.17
       graphql: 16.6.0
@@ -1404,19 +1404,19 @@ packages:
     dependencies:
       graphql: 16.6.0
 
-  /@apollo/composition/2.2.1_graphql@16.6.0:
-    resolution: {integrity: sha512-xmd4NiCU+rW6elTZuIflR+GzZf626fJX7NVraTHXgDL8pZ7eluPal/T6vsQEg+Cb9tlAUjDhCB4RqVYPgV69RQ==}
+  /@apollo/composition/2.2.2_graphql@16.6.0:
+    resolution: {integrity: sha512-5wj9FqDu4E4xfOOLz4SKib8eJQgamHCgOdxwmrGj9N3B8o6P2A+zMfKEVHvEnSpRMKRm9HVcdSGdYV6QcjDIdQ==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
       graphql: ^16.5.0
     dependencies:
-      '@apollo/federation-internals': 2.2.1_graphql@16.6.0
-      '@apollo/query-graphs': 2.2.1_graphql@16.6.0
+      '@apollo/federation-internals': 2.2.2_graphql@16.6.0
+      '@apollo/query-graphs': 2.2.2_graphql@16.6.0
       graphql: 16.6.0
     dev: false
 
-  /@apollo/federation-internals/2.2.1_graphql@16.6.0:
-    resolution: {integrity: sha512-T+nxIhppu/5jNFIhfzYERIhgDvp2QqbSqnQpViDNEmK/iPKsXLFtOedZZgsAUpMIQoUedNNNuceTE9+lDUn+bA==}
+  /@apollo/federation-internals/2.2.2_graphql@16.6.0:
+    resolution: {integrity: sha512-Q16I75qZ6jA8lCoZedM5938oZONrJyL7Pk6TOqw44fndea0As0pb2Ug8dV3pAWq4HhJ+/vBu2WoP14CFcxA9Yw==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
       graphql: ^16.5.0
@@ -1471,13 +1471,13 @@ packages:
       '@types/node': 10.17.60
       long: 4.0.0
 
-  /@apollo/query-graphs/2.2.1_graphql@16.6.0:
-    resolution: {integrity: sha512-lDK1HfsJlM4P2AcdhNYxXnq5zWohyLiWVyhC0SEnhR/BRfoP2UOC31MHK0waRLAQP5SBMBVolRn6AhtSFNmEyA==}
+  /@apollo/query-graphs/2.2.2_graphql@16.6.0:
+    resolution: {integrity: sha512-NHxqfDEsMNFqwxSQ8lqj9APP0jGQAvxt0LOEb4WZgVdw303g1qxu2BapUS4YjxKVRqHDap/EAzBHgwg4J2zfjA==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
       graphql: ^16.5.0
     dependencies:
-      '@apollo/federation-internals': 2.2.1_graphql@16.6.0
+      '@apollo/federation-internals': 2.2.2_graphql@16.6.0
       '@types/uuid': 8.3.4
       deep-equal: 2.1.0
       graphql: 16.6.0
@@ -12177,7 +12177,7 @@ packages:
   /axios/0.21.4:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.2_debug@4.3.4
+      follow-redirects: 1.15.2
     transitivePeerDependencies:
       - debug
     dev: false
@@ -16590,6 +16590,16 @@ packages:
 
   /focus-visible/5.2.0:
     resolution: {integrity: sha512-Rwix9pBtC1Nuy5wysTmKy+UjbDJpIfg8eHjw0rjZ1mX4GNLz1Bmd16uDpI3Gk1i70Fgcs8Csg2lPm8HULFg9DQ==}
+    dev: false
+
+  /follow-redirects/1.15.2:
+    resolution: {integrity: sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
     dev: false
 
   /follow-redirects/1.15.2_debug@4.3.4:


### PR DESCRIPTION
Changes in this PR:
- [x] Update to latest Federation
- [x] Use latest Zod's `coerce` function to parse `PORT` env var (this caused an error because runtime got `"123"` instead of `123` and caused a NodeJS error at runtime) 
- [x] Use Zod's `default` where possible. 
- [x] Refactor code and separate request handler and NodeJS runtime 
- [x] Added missing README
- [x] Update documentation and mention the ready-to-use Docker image