### PR TITLE
Adjustments to Pulumi code to support more pre-prod envs

### DIFF
--- a/deployment/index.ts
+++ b/deployment/index.ts
@@ -41,7 +41,7 @@ const imagePullSecret = dockerImages.createRepositorySecret(
 );
 
 // eslint-disable-next-line no-process-env
-const imagesTag = process.env.DOCKER_IMAGE_TAG;
+const imagesTag = process.env.DOCKER_IMAGE_TAG as string;
 
 if (!imagesTag) {
   throw new Error(`DOCKER_IMAGE_TAG env variable is not set.`);
@@ -91,9 +91,7 @@ const cfBroker = deployCFBroker({
 deployCloudflarePolice({ envName, rootDns });
 
 const redisApi = deployRedis({ deploymentEnv });
-
 const kafkaApi = deployKafka();
-
 const clickhouseApi = deployClickhouse();
 
 const dbMigrations = deployDbMigrations({
@@ -217,7 +215,10 @@ const googleConfig = {
   clientSecret: oauthConfig.requireSecret('googleSecret'),
 };
 
-const supertokens = deploySuperTokens({ apiKey: supertokensApiKey.result });
+const supertokens = deploySuperTokens(
+  { apiKey: supertokensApiKey.result },
+  { dependencies: [dbMigrations] },
+);
 
 const graphqlApi = deployGraphQL({
   clickhouse: clickhouseApi,
@@ -280,6 +281,7 @@ const proxy = deployProxy({
   docs,
   graphql: graphqlApi,
   usage: usageApi,
+  deploymentEnv,
 });
 
 deployCloudFlareSecurityTransform({

--- a/deployment/package.json
+++ b/deployment/package.json
@@ -12,9 +12,11 @@
     "@pulumi/kubernetesx": "0.1.6",
     "@pulumi/pulumi": "3.49.0",
     "@pulumi/random": "4.8.2",
+    "js-yaml": "4.1.0",
     "pg-connection-string": "2.5.0"
   },
   "devDependencies": {
+    "@types/js-yaml": "4.0.5",
     "@types/mime-types": "2.1.1",
     "@types/node": "18.11.5"
   }

--- a/deployment/services/cf-broker.ts
+++ b/deployment/services/cf-broker.ts
@@ -1,5 +1,6 @@
 import * as pulumi from '@pulumi/pulumi';
 import { CloudflareBroker } from '../utils/cloudflare';
+import { isProduction } from '../utils/helpers';
 
 const commonConfig = new pulumi.Config('common');
 const cfConfig = new pulumi.Config('cloudflareCustom');
@@ -24,7 +25,7 @@ export function deployCFBroker({
     // We can't cdn for staging env, since CF certificate only covers
     // one level of subdomains. See: https://community.cloudflare.com/t/ssl-handshake-error-cloudflare-proxy/175088
     // So for staging env, we are going to use `broker-staging` instead of `broker.staging`.
-    cdnDnsRecord: envName === 'staging' ? `broker-${rootDns}` : `broker.${rootDns}`,
+    cdnDnsRecord: isProduction(envName) ? `broker.${rootDns}` : `broker-${rootDns}`,
     secretSignature: cfBrokerSignature,
     sentryDsn: commonEnv.SENTRY_DSN,
     release,

--- a/deployment/services/cf-cdn.ts
+++ b/deployment/services/cf-cdn.ts
@@ -1,5 +1,6 @@
 import * as pulumi from '@pulumi/pulumi';
 import { CloudflareCDN } from '../utils/cloudflare';
+import { isProduction } from '../utils/helpers';
 
 const commonConfig = new pulumi.Config('common');
 const cfConfig = new pulumi.Config('cloudflareCustom');
@@ -31,7 +32,7 @@ export function deployCFCDN({
     // We can't cdn for staging env, since CF certificate only covers
     // one level of subdomains. See: https://community.cloudflare.com/t/ssl-handshake-error-cloudflare-proxy/175088
     // So for staging env, we are going to use `cdn-staging` instead of `cdn.staging`.
-    cdnDnsRecord: envName === 'staging' ? `cdn-${rootDns}` : `cdn.${rootDns}`,
+    cdnDnsRecord: isProduction(envName) ? `cdn.${rootDns}` : `cdn-${rootDns}`,
     authPrivateKey: cdnAuthPrivateKey,
     sentryDsn: commonEnv.SENTRY_DSN,
     release,

--- a/deployment/services/graphql.ts
+++ b/deployment/services/graphql.ts
@@ -17,6 +17,7 @@ import { Emails } from './emails';
 import { StripeBillingService } from './billing';
 import { Output } from '@pulumi/pulumi';
 import * as k8s from '@pulumi/kubernetes';
+import { isProduction } from '../utils/helpers';
 
 const commonConfig = new pulumi.Config('common');
 const cloudflareConfig = new pulumi.Config('cloudflare');
@@ -89,7 +90,7 @@ export function deployGraphQL({
     {
       imagePullSecret,
       image,
-      replicas: 2,
+      replicas: isProduction(deploymentEnv) ? 2 : 1,
       pdb: true,
       readinessProbe: '/_readiness',
       livenessProbe: '/_health',

--- a/deployment/services/kafka.ts
+++ b/deployment/services/kafka.ts
@@ -1,20 +1,68 @@
 import * as pulumi from '@pulumi/pulumi';
+import { Kafka as KafkaDeployment } from '../utils/kafka';
+import { getLocalComposeConfig } from '../utils/local-config';
+import { serviceLocalHost } from '../utils/local-endpoint';
 
 export type Kafka = ReturnType<typeof deployKafka>;
 
 export function deployKafka() {
   const eventhubConfig = new pulumi.Config('eventhub');
 
+  if (!eventhubConfig.getBoolean('inCluster')) {
+    return {
+      connectionEnv: <Record<string, pulumi.Output<string> | string>>{
+        KAFKA_SSL: '1',
+        KAFKA_SASL_MECHANISM: 'plain',
+        KAFKA_CONCURRENCY: '1',
+        KAFKA_SASL_USERNAME: '$ConnectionString',
+        KAFKA_SASL_PASSWORD: eventhubConfig.requireSecret('key'),
+      },
+      config: {
+        endpoint: eventhubConfig.require('endpoint'),
+        bufferSize: eventhubConfig.require('bufferSize'),
+        bufferInterval: eventhubConfig.require('bufferInterval'),
+        bufferDynamic: eventhubConfig.require('bufferDynamic'),
+        topic: eventhubConfig.require('topic'),
+        consumerGroup: eventhubConfig.require('consumerGroup'),
+      },
+      service: null,
+      deployment: null,
+    };
+  }
+
+  const kafkaService = getLocalComposeConfig().service('broker');
+  const zookeeper = getLocalComposeConfig().service('zookeeper');
+  const usageService = getLocalComposeConfig().service('usage');
+  const usageIngestorService = getLocalComposeConfig().service('usage-ingestor');
+
+  const localKafka = new KafkaDeployment('kafka-broker', {
+    env: {
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true',
+      KAFKA_BROKER_ID: '1',
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT',
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: '1',
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0',
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: '1',
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: '1',
+    },
+    zookeeperImage: zookeeper.image,
+    image: kafkaService.image,
+  }).deploy();
+
   return {
+    connectionEnv: <Record<string, pulumi.Output<string> | string>>{
+      KAFKA_CONNECTION_MODE: 'docker',
+      KAFKA_CONCURRENCY: '1',
+    },
+    service: localKafka.service,
+    deployment: localKafka.deployment,
     config: {
-      key: eventhubConfig.requireSecret('key'),
-      user: '$ConnectionString',
-      endpoint: eventhubConfig.require('endpoint'),
-      bufferSize: eventhubConfig.require('bufferSize'),
-      bufferInterval: eventhubConfig.require('bufferInterval'),
-      bufferDynamic: eventhubConfig.require('bufferDynamic'),
-      topic: eventhubConfig.require('topic'),
-      consumerGroup: eventhubConfig.require('consumerGroup'),
+      endpoint: serviceLocalHost(localKafka.service).apply(v => `${v}:29092`),
+      bufferSize: String(usageService.environment['KAFKA_BUFFER_SIZE'] || ''),
+      bufferInterval: String(usageService.environment['KAFKA_BUFFER_INTERVAL'] || ''),
+      bufferDynamic: String(usageService.environment['KAFKA_BUFFER_DYNAMIC'] || ''),
+      topic: usageService.environment['KAFKA_TOPIC'],
+      consumerGroup: usageIngestorService.environment['KAFKA_CONSUMER_GROUP'] as string,
     },
   };
 }

--- a/deployment/services/proxy.ts
+++ b/deployment/services/proxy.ts
@@ -5,6 +5,8 @@ import { GraphQL } from './graphql';
 import { App } from './app';
 import { Usage } from './usage';
 import { Docs } from './docs';
+import { isProduction } from '../utils/helpers';
+import { DeploymentEnvironment } from '../types';
 
 const commonConfig = new pulumi.Config('common');
 
@@ -15,7 +17,9 @@ export function deployProxy({
   app,
   docs,
   usage,
+  deploymentEnv,
 }: {
+  deploymentEnv: DeploymentEnvironment;
   appHostname: string;
   docsHostname: string;
   graphql: GraphQL;
@@ -26,8 +30,9 @@ export function deployProxy({
   const { tlsIssueName } = new CertManager().deployCertManagerAndIssuer();
   return new Proxy(tlsIssueName, {
     address: commonConfig.get('staticIp'),
+    aksReservedIpResourceGroup: commonConfig.get('aksReservedIpResourceGroup'),
   })
-    .deployProxy({ replicas: 2 })
+    .deployProxy({ replicas: isProduction(deploymentEnv) ? 2 : 1 })
     .registerService(
       {
         record: docsHostname,

--- a/deployment/services/redis.ts
+++ b/deployment/services/redis.ts
@@ -1,8 +1,8 @@
 import * as pulumi from '@pulumi/pulumi';
 import { serviceLocalHost } from '../utils/local-endpoint';
 import { Redis as RedisStore } from '../utils/redis';
-import { isStaging } from '../utils/helpers';
 import { DeploymentEnvironment } from '../types';
+import { isProduction } from '../utils/helpers';
 
 const redisConfig = new pulumi.Config('redis');
 
@@ -13,14 +13,14 @@ export function deployRedis({ deploymentEnv }: { deploymentEnv: DeploymentEnviro
   const redisApi = new RedisStore({
     password: redisPassword,
   }).deploy({
-    limits: isStaging(deploymentEnv)
+    limits: isProduction(deploymentEnv)
       ? {
-          memory: '80Mi',
-          cpu: '50m',
-        }
-      : {
           memory: '800Mi',
           cpu: '1000m',
+        }
+      : {
+          memory: '80Mi',
+          cpu: '50m',
         },
   });
 

--- a/deployment/services/schema.ts
+++ b/deployment/services/schema.ts
@@ -4,6 +4,7 @@ import { DeploymentEnvironment } from '../types';
 import { Redis } from './redis';
 import type { Broker } from './cf-broker';
 import * as k8s from '@pulumi/kubernetes';
+import { isProduction } from '../utils/helpers';
 
 const commonConfig = new pulumi.Config('common');
 const commonEnv = commonConfig.requireObject<Record<string, string>>('env');
@@ -46,7 +47,7 @@ export function deploySchema({
       readinessProbe: '/_readiness',
       livenessProbe: '/_health',
       exposesMetrics: true,
-      replicas: 2,
+      replicas: isProduction(deploymentEnv) ? 2 : 1,
       pdb: true,
     },
     [redis.deployment, redis.service],

--- a/deployment/services/supertokens.ts
+++ b/deployment/services/supertokens.ts
@@ -3,7 +3,12 @@ import * as kx from '@pulumi/kubernetesx';
 import { serviceLocalEndpoint } from '../utils/local-endpoint';
 import { Output } from '@pulumi/pulumi';
 
-export function deploySuperTokens({ apiKey }: { apiKey: Output<string> }) {
+export function deploySuperTokens(
+  { apiKey }: { apiKey: Output<string> },
+  resourceOptions: {
+    dependencies: pulumi.Resource[];
+  },
+) {
   const apiConfig = new pulumi.Config('api');
 
   const port = 3567;
@@ -48,9 +53,15 @@ export function deploySuperTokens({ apiKey }: { apiKey: Output<string> }) {
     ],
   });
 
-  const deployment = new kx.Deployment('supertokens', {
-    spec: pb.asDeploymentSpec({ replicas: 1 }), // <-- here,
-  });
+  const deployment = new kx.Deployment(
+    'supertokens',
+    {
+      spec: pb.asDeploymentSpec({ replicas: 1 }), // <-- here,
+    },
+    {
+      dependsOn: resourceOptions.dependencies,
+    },
+  );
 
   const service = deployment.createService({});
 

--- a/deployment/services/usage-ingestor.ts
+++ b/deployment/services/usage-ingestor.ts
@@ -68,12 +68,8 @@ export function deployUsageIngestor({
         ...commonEnv,
         SENTRY: commonEnv.SENTRY_ENABLED,
         ...clickhouseEnv,
-        KAFKA_SSL: '1',
+        ...kafka.connectionEnv,
         KAFKA_BROKER: kafka.config.endpoint,
-        KAFKA_SASL_MECHANISM: 'plain',
-        KAFKA_SASL_USERNAME: kafka.config.user,
-        KAFKA_SASL_PASSWORD: kafka.config.key,
-        KAFKA_CONCURRENCY: '1',
         KAFKA_TOPIC: kafka.config.topic,
         KAFKA_CONSUMER_GROUP: kafka.config.consumerGroup,
         RELEASE: release,
@@ -90,6 +86,12 @@ export function deployUsageIngestor({
         maxReplicas: maxReplicas,
       },
     },
-    [clickhouse.deployment, clickhouse.service, dbMigrations],
+    [
+      clickhouse.deployment,
+      clickhouse.service,
+      dbMigrations,
+      kafka.deployment,
+      kafka.service,
+    ].filter(Boolean),
   ).deploy();
 }

--- a/deployment/utils/clickhouse.ts
+++ b/deployment/utils/clickhouse.ts
@@ -1,6 +1,7 @@
 import * as kx from '@pulumi/kubernetesx';
 import * as k8s from '@pulumi/kubernetes';
 import { PodBuilder } from './pod-builder';
+import { getLocalComposeConfig } from './local-config';
 
 export class Clickhouse {
   constructor(
@@ -12,7 +13,7 @@ export class Clickhouse {
   ) {}
 
   deploy() {
-    const image = 'clickhouse/clickhouse-server:22.3.5.5-alpine';
+    const clickhouseService = getLocalComposeConfig().service('clickhouse');
     const port = 8123;
 
     const env: any[] = Array.isArray(this.options.env)
@@ -35,7 +36,7 @@ export class Clickhouse {
       containers: [
         {
           name: this.name,
-          image,
+          image: clickhouseService.image,
           env,
           volumeMounts: [cm.mount('/etc/clickhouse-server/conf.d')],
           ports: {

--- a/deployment/utils/helpers.ts
+++ b/deployment/utils/helpers.ts
@@ -1,13 +1,9 @@
 import { DeploymentEnvironment } from '../types';
 
 export function isProduction(deploymentEnv: DeploymentEnvironment | string): boolean {
-  return !isStaging(deploymentEnv);
-}
-
-export function isStaging(deploymentEnv: DeploymentEnvironment | string): boolean {
   return isDeploymentEnvironment(deploymentEnv)
-    ? deploymentEnv.ENVIRONMENT === 'staging'
-    : deploymentEnv === 'staging';
+    ? deploymentEnv.ENVIRONMENT === 'production'
+    : deploymentEnv === 'production' || deploymentEnv === 'prod';
 }
 
 export function isDeploymentEnvironment(value: any): value is DeploymentEnvironment {

--- a/deployment/utils/kafka.ts
+++ b/deployment/utils/kafka.ts
@@ -1,0 +1,139 @@
+import * as kx from '@pulumi/kubernetesx';
+import * as pulumi from '@pulumi/pulumi';
+import { serviceLocalHost } from './local-endpoint';
+import { PodBuilder } from './pod-builder';
+
+export class Kafka {
+  constructor(
+    protected name: string,
+    protected options: {
+      image: string;
+      zookeeperImage: string;
+      env?: kx.types.Container['env'];
+    },
+  ) {}
+
+  deployZookeeper() {
+    const pb = new PodBuilder({
+      restartPolicy: 'Always',
+      containers: [
+        {
+          name: 'zookeeper',
+          image: this.options.zookeeperImage,
+          env: {
+            ZOOKEEPER_CLIENT_PORT: '2181',
+            ZOOKEEPER_TICK_TIME: '2000',
+          },
+          ports: [
+            {
+              name: 'zookeeper',
+              containerPort: 2181,
+            },
+          ],
+        },
+      ],
+    });
+
+    const deployment = new kx.Deployment('kafka-zookeeper', {
+      spec: pb.asExtendedDeploymentSpec({
+        replicas: 1,
+        strategy: {
+          type: 'RollingUpdate',
+        },
+      }),
+    });
+    const service = deployment.createService({});
+
+    return { deployment, service };
+  }
+
+  deployKafka(options: {
+    dependencies: pulumi.Resource[];
+    zookeeperEnv: kx.types.Container['env'];
+  }) {
+    const env: any[] = Array.isArray(this.options.env)
+      ? this.options.env
+      : Object.keys(this.options.env as kx.types.EnvMap).map(name => ({
+          name,
+          value: (this.options.env as kx.types.EnvMap)[name],
+        }));
+    const ports = [29092, 9092];
+    const pb = new PodBuilder({
+      restartPolicy: 'Always',
+      containers: [
+        {
+          name: this.name,
+          image: this.options.image,
+          env: [
+            ...env,
+            ...(options.zookeeperEnv as any[]),
+            {
+              name: 'POD_IP',
+              valueFrom: {
+                fieldRef: {
+                  fieldPath: 'status.podIP',
+                },
+              },
+            },
+            {
+              name: 'KAFKA_ADVERTISED_LISTENERS',
+              value: `PLAINTEXT://$(POD_IP):29092,PLAINTEXT_HOST://localhost:9092`,
+            },
+          ],
+          ports: ports.map(p => ({ name: `kafka-${p}`, containerPort: p })),
+          livenessProbe: {
+            initialDelaySeconds: 3,
+            periodSeconds: 20,
+            failureThreshold: 10,
+            timeoutSeconds: 5,
+            exec: {
+              command: [
+                'cub',
+                'kafka-ready',
+                '1',
+                '5',
+                '-b',
+                '127.0.0.1:9092',
+                '-c',
+                '/etc/kafka/kafka.properties',
+              ],
+            },
+          },
+        },
+      ],
+    });
+
+    const deployment = new kx.Deployment(
+      this.name,
+      {
+        spec: pb.asExtendedDeploymentSpec({
+          replicas: 1,
+          strategy: {
+            type: 'RollingUpdate',
+          },
+        }),
+      },
+      {
+        dependsOn: options.dependencies,
+      },
+    );
+
+    const service = deployment.createService({});
+
+    return { deployment, service, ports };
+  }
+
+  deploy() {
+    const zookeeper = this.deployZookeeper();
+
+    return this.deployKafka({
+      dependencies: [zookeeper.deployment, zookeeper.service],
+      zookeeperEnv: [
+        {
+          name: 'KAFKA_ZOOKEEPER_CONNECT',
+          value: serviceLocalHost(zookeeper.service).apply(v => `${v}:2181`),
+        },
+      ],
+    });
+  }
+}

--- a/deployment/utils/local-config.ts
+++ b/deployment/utils/local-config.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'fs';
+import * as yaml from 'js-yaml';
+
+let loadedConfig: any = null;
+
+export function getLocalComposeConfig() {
+  if (!loadedConfig) {
+    loadedConfig = yaml.load(readFileSync('../docker-compose.community.yml', 'utf8'));
+  }
+
+  return {
+    config: loadedConfig,
+    service(name: string) {
+      const service = loadedConfig.services[name];
+
+      if (!service) {
+        throw new Error(`Service ${name} not found in Docker compose file!`);
+      }
+
+      return service;
+    },
+  };
+}

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -4,7 +4,10 @@ import { Output } from '@pulumi/pulumi';
 export class Proxy {
   private lbService: Output<k8s.core.v1.Service> | null = null;
 
-  constructor(private tlsSecretName: string, private staticIp?: { address?: string }) {}
+  constructor(
+    private tlsSecretName: string,
+    private staticIp?: { address?: string; aksReservedIpResourceGroup?: string },
+  ) {}
 
   registerService(
     dns: { record: string; apex?: boolean },
@@ -162,6 +165,13 @@ export class Proxy {
         envoy: {
           service: {
             loadBalancerIP: this.staticIp?.address,
+            annotations:
+              this.staticIp?.address && this.staticIp?.aksReservedIpResourceGroup
+                ? {
+                    'service.beta.kubernetes.io/azure-load-balancer-resource-group':
+                      this.staticIp?.aksReservedIpResourceGroup,
+                  }
+                : undefined,
           },
           podAnnotations: {
             'prometheus.io/scrape': 'true',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,8 +151,10 @@ importers:
       '@pulumi/kubernetesx': 0.1.6
       '@pulumi/pulumi': 3.49.0
       '@pulumi/random': 4.8.2
+      '@types/js-yaml': 4.0.5
       '@types/mime-types': 2.1.1
       '@types/node': 18.11.5
+      js-yaml: 4.1.0
       pg-connection-string: 2.5.0
     dependencies:
       '@manypkg/get-packages': 1.1.3
@@ -162,8 +164,10 @@ importers:
       '@pulumi/kubernetesx': 0.1.6_puxfobbytwebdjj5c7rtoyrjxu
       '@pulumi/pulumi': 3.49.0_@types+node@18.11.5
       '@pulumi/random': 4.8.2_@types+node@18.11.5
+      js-yaml: 4.1.0
       pg-connection-string: 2.5.0
     devDependencies:
+      '@types/js-yaml': 4.0.5
       '@types/mime-types': 2.1.1
       '@types/node': 18.11.5
 
@@ -18749,7 +18753,6 @@ packages:
     hasBin: true
     dependencies:
       argparse: 2.0.1
-    dev: true
 
   /jsbn/0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}


### PR DESCRIPTION
## TODO

- [x] Support lightweight deployment (fewer replicas for some services)
- [x] Support for running in-cluster Kafka and Zookeeper 
- [x] Make the code agnostic to a non-prod environment
- [x] Use Docker image versions from `docker-compose.community.yaml` to run in-cluster services (clickhouse, kafka, zookeeper) 
- [x] Allow cluster-based deployment to use static pre-defined IP (to support epithermal environments without switching IP when destroyed) 
- [x] Fix issues with dependencies across services 
- [ ] Merge https://github.com/the-guild-org/graphql-hive-deployment/pull/1364 