### PR TITLE
Use the production version of CLI

### DIFF
--- a/integration-tests/testkit/cli.ts
+++ b/integration-tests/testkit/cli.ts
@@ -2,11 +2,15 @@ import { resolve } from 'path';
 import { execaCommand } from '@esm2cjs/execa';
 import { getServiceHost } from './utils';
 
-const binPath = resolve(__dirname, '../../packages/libraries/cli/bin/dev');
+const binPath = resolve(__dirname, '../../packages/libraries/cli/bin/run');
+const cliDir = resolve(__dirname, '../../packages/libraries/cli');
 
 async function exec(cmd: string) {
   const outout = await execaCommand(`${binPath} ${cmd}`, {
     shell: true,
+    env: {
+      OCLIF_CLI_CUSTOM_PATH: cliDir,
+    },
   });
 
   if (outout.failed) {

--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
       "bullmq@1.81.4": "patches/bullmq@1.81.4.patch",
       "mjml-core@4.13.0": "patches/mjml-core@4.13.0.patch",
       "slonik@30.1.2": "patches/slonik@30.1.2.patch",
-      "@graphql-inspector/core@3.4.0": "patches/@graphql-inspector__core@3.4.0.patch"
+      "@graphql-inspector/core@3.4.0": "patches/@graphql-inspector__core@3.4.0.patch",
+      "@oclif/core@1.23.0": "patches/@oclif__core@1.23.0.patch"
     }
   }
 }

--- a/patches/@oclif__core@1.23.0.patch
+++ b/patches/@oclif__core@1.23.0.patch
@@ -1,0 +1,21 @@
+diff --git a/lib/module-loader.js b/lib/module-loader.js
+index acb43adf1747c928199fffef48418e9833dd8843..64753c3babf4940bdef31c926614e956ca9d31d5 100644
+--- a/lib/module-loader.js
++++ b/lib/module-loader.js
+@@ -124,7 +124,15 @@ class ModuleLoader {
+         let isESM;
+         let filePath;
+         try {
+-            filePath = require.resolve(modulePath);
++            try {
++                filePath = require.resolve(modulePath);
++            } catch (error) {
++                const customPath = process.env.OCLIF_CLI_CUSTOM_PATH;
++                if (typeof customPath !== 'string') {
++                    throw error;
++                }
++                filePath = require.resolve(path.resolve(customPath, modulePath) + '.js');
++            }
+             isESM = ModuleLoader.isPathModule(filePath);
+         }
+         catch {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,18 +7,21 @@ patchedDependencies:
   bullmq@1.81.4:
     hash: d7likfulu5mfjaaerbpls6og24
     path: patches/bullmq@1.81.4.patch
-  mjml-core@4.13.0:
-    hash: zxxsxbqejjmcwuzpigutzzq6wa
-    path: patches/mjml-core@4.13.0.patch
   '@theguild/buddy@0.1.0':
     hash: ryylgra5xglhidfoiaxehn22hq
     path: patches/@theguild__buddy@0.1.0.patch
-  '@graphql-inspector/core@3.4.0':
-    hash: tu4s2cjheabese6hdiqk5i3mii
-    path: patches/@graphql-inspector__core@3.4.0.patch
+  '@oclif/core@1.23.0':
+    hash: zhte2hlj7lfobytjpalcwwo474
+    path: patches/@oclif__core@1.23.0.patch
+  mjml-core@4.13.0:
+    hash: zxxsxbqejjmcwuzpigutzzq6wa
+    path: patches/mjml-core@4.13.0.patch
   slonik@30.1.2:
     hash: wg2hxbo7txnklmvja4aeqnygfi
     path: patches/slonik@30.1.2.patch
+  '@graphql-inspector/core@3.4.0':
+    hash: tu4s2cjheabese6hdiqk5i3mii
+    path: patches/@graphql-inspector__core@3.4.0.patch
 
 importers:
 
@@ -235,7 +238,7 @@ importers:
       '@graphql-tools/load': 7.8.0_graphql@16.6.0
       '@graphql-tools/url-loader': 7.16.4_graphql@16.6.0
       '@graphql-tools/utils': 8.13.1_graphql@16.6.0
-      '@oclif/core': 1.23.0
+      '@oclif/core': 1.23.0_zhte2hlj7lfobytjpalcwwo474
       '@oclif/plugin-help': 5.1.20
       '@oclif/plugin-update': 3.0.9
       colors: 1.4.0
@@ -8128,7 +8131,7 @@ packages:
       supports-color: 8.1.1
       tslib: 2.4.1
 
-  /@oclif/core/1.23.0:
+  /@oclif/core/1.23.0_zhte2hlj7lfobytjpalcwwo474:
     resolution: {integrity: sha512-LnQoRtyQLQCsEHQsY7Ju0Z+g84XIVTxtVWr9hq81Juzj0o2f4zaFZ3f39VfnXvxI4m+QmROaoUJvr417eSEuhg==}
     engines: {node: '>=14.0.0'}
     dependencies:
@@ -8160,6 +8163,7 @@ packages:
       tslib: 2.4.1
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
+    patched: true
 
   /@oclif/linewrap/1.0.0:
     resolution: {integrity: sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==}
@@ -8168,14 +8172,14 @@ packages:
     resolution: {integrity: sha512-N8xRxE/isFcdBDI8cobixEZA5toxIK5jbxpwALNTr4s8KNAtBA3ORQrSiY0fWGkcv0sCGMwZw7rJ0Izh18JPsw==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@oclif/core': 1.23.0
+      '@oclif/core': 1.23.0_zhte2hlj7lfobytjpalcwwo474
 
   /@oclif/plugin-not-found/2.3.8:
     resolution: {integrity: sha512-PfUVr67dHORFSeQthUwrPMJB/mRRNT4ENNdbafCOlL0HqC+WTuFy5nih+qnHBEli15RaOuMNoW3kR5MyBH82hA==}
     engines: {node: '>=12.0.0'}
     dependencies:
       '@oclif/color': 1.0.2
-      '@oclif/core': 1.23.0
+      '@oclif/core': 1.23.0_zhte2hlj7lfobytjpalcwwo474
       fast-levenshtein: 3.0.0
       lodash: 4.17.21
     dev: true
@@ -8185,7 +8189,7 @@ packages:
     engines: {node: '>=12.0.0'}
     dependencies:
       '@oclif/color': 1.0.2
-      '@oclif/core': 1.23.0
+      '@oclif/core': 1.23.0_zhte2hlj7lfobytjpalcwwo474
       cross-spawn: 7.0.3
       debug: 4.3.4
       filesize: 6.4.0
@@ -8204,7 +8208,7 @@ packages:
     resolution: {integrity: sha512-wen8nqrKUB5KB9PSqkBfAWB8LarmE9kOljMEXEWjDz5T0Yp77+/3IUiswu1ffYKUELBqaVsgsqb2uV4VP4oF9w==}
     engines: {node: '>=12.0.0'}
     dependencies:
-      '@oclif/core': 1.23.0
+      '@oclif/core': 1.23.0_zhte2hlj7lfobytjpalcwwo474
       chalk: 4.1.2
       debug: 4.3.4
       fs-extra: 9.1.0
@@ -21371,7 +21375,7 @@ packages:
     engines: {node: '>=12.0.0'}
     hasBin: true
     dependencies:
-      '@oclif/core': 1.23.0
+      '@oclif/core': 1.23.0_zhte2hlj7lfobytjpalcwwo474
       '@oclif/plugin-help': 5.1.20
       '@oclif/plugin-not-found': 2.3.8
       '@oclif/plugin-warn-if-update-available': 2.0.17


### PR DESCRIPTION
```
./bin/dev whoami  5.15s
./bin/run whoami  0.35s

tests/cli/schema.spec.ts (149.848 s)
tests/cli/schema.spec.ts ( 38.438 s)
```

Speeds up the integration tests by almost 2 minutes.

 It's a little hacky, because `@oclif/core` uses `require.resolve` to load the commands and they are in an entirely different directory (not part of `require.resolve.paths()`).