### PR TITLE
BillingDetails.postalCode as String, fetch less billingConfiguration in web/app

### DIFF
--- a/packages/services/api/src/modules/billing/module.graphql.ts
+++ b/packages/services/api/src/modules/billing/module.graphql.ts
@@ -35,7 +35,7 @@ export default gql`
     country: String
     line1: String
     line2: String
-    postalCode: Int
+    postalCode: String
     state: String
   }
 

--- a/packages/services/api/src/modules/billing/resolvers.ts
+++ b/packages/services/api/src/modules/billing/resolvers.ts
@@ -94,7 +94,7 @@ export const resolvers: BillingModule.Resolvers = {
     country: bd => bd.address?.country || null,
     line1: bd => bd.address?.line1 || null,
     line2: bd => bd.address?.line2 || null,
-    postalCode: bd => (bd.address?.postal_code ? parseInt(bd.address?.postal_code) : null),
+    postalCode: bd => bd.address?.postal_code ?? null,
     state: bd => bd.address?.state || null,
   },
   Query: {

--- a/packages/web/app/src/graphql/fragments.graphql
+++ b/packages/web/app/src/graphql/fragments.graphql
@@ -419,20 +419,11 @@ fragment OrgBillingInfoFields on Organization {
   plan
   ...OrgRateLimitFields
   billingConfiguration {
-    hasActiveSubscription
     paymentMethod {
       brand
       last4
       expMonth
       expYear
-    }
-    billingAddress {
-      city
-      country
-      line1
-      line2
-      postalCode
-      state
     }
     invoices {
       ...BillingInvoiceFields


### PR DESCRIPTION
`BillingDetails.postalCode` was `Int`, but some postal codes include other characters than numbers.
App does not need some parts of billingConfiguration (postalCode included).
