### PR TITLE
Use default skipError of @envelop/sentry

### DIFF
--- a/packages/services/server/src/graphql-handler.ts
+++ b/packages/services/server/src/graphql-handler.ts
@@ -1,4 +1,3 @@
-import { isGraphQLError } from '@envelop/core';
 import { useGenericAuth } from '@envelop/generic-auth';
 import { useGraphQLModules } from '@envelop/graphql-modules';
 import { useSentry } from '@envelop/sentry';
@@ -153,7 +152,6 @@ export const graphqlHandler = (options: GraphQLHandlerOptions): RouteHandlerMeth
           // It's the readiness check
           return args.operationName === 'readiness';
         },
-        skipError: isGraphQLError,
       }),
       useSentryUser(),
       useErrorHandler(({ errors, context }): void => {


### PR DESCRIPTION
We used to detect non-masked errors with `isGraphQLError` but now it's `isOriginalGraphQLError`