### PR TITLE
Use Redpanda instead of Kafka and ZooKeeper (integration tests and local)

### DIFF
--- a/docker-compose.community.yml
+++ b/docker-compose.community.yml
@@ -106,8 +106,8 @@ services:
       retries: 6
       start_period: 5s
     environment:
-      - REDIS_PASSWORD=${REDIS_PASSWORD}
-      - REDIS_DISABLE_COMMANDS=FLUSHDB,FLUSHALL
+      REDIS_PASSWORD: '${REDIS_PASSWORD}'
+      REDIS_DISABLE_COMMANDS: 'FLUSHDB,FLUSHALL'
     volumes:
       - './.hive/redis/db:/bitnami/redis/data'
 

--- a/docker-compose.community.yml
+++ b/docker-compose.community.yml
@@ -38,62 +38,28 @@ services:
     volumes:
       - ./.hive/clickhouse/db:/var/lib/clickhouse
 
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.3.1
-    hostname: zookeeper
-    networks:
-      - 'stack'
-    ulimits:
-      nofile:
-        soft: 20000
-        hard: 40000
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-    volumes:
-      - ./.hive/zookeeper/db:/var/lib/zookeeper/data
-
   broker:
-    image: confluentinc/cp-kafka:7.3.1
+    image: vectorized/redpanda:latest
+    container_name: broker
     hostname: broker
-    depends_on:
-      zookeeper:
-        condition: service_started
     networks:
       - 'stack'
-    ulimits:
-      nofile:
-        soft: 20000
-        hard: 40000
-    healthcheck:
-      test:
-        [
-          'CMD',
-          'cub',
-          'kafka-ready',
-          '1',
-          '5',
-          '-b',
-          '127.0.0.1:9092',
-          '-c',
-          '/etc/kafka/kafka.properties',
-        ]
-      interval: 15s
-      timeout: 10s
-      retries: 6
-      start_period: 15s
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
-    volumes:
-      - ./.hive/broker/db:/var/lib/kafka/data
+    command:
+      - redpanda
+      - start
+      - --smp
+      - '1'
+      - --set redpanda.empty_seed_starts_cluster=false
+      - --seeds "redpanda-1:33145"
+      - --kafka-addr
+      - PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+      - --advertise-kafka-addr
+      - PLAINTEXT://broker:29092,OUTSIDE://localhost:9092
+      - --pandaproxy-addr
+      - PLAINTEXT://0.0.0.0:28082,OUTSIDE://0.0.0.0:8082
+      - --advertise-pandaproxy-addr
+      - PLAINTEXT://broker:28082,OUTSIDE://localhost:8082
+      - --advertise-rpc-addr redpanda-1:33145
 
   redis:
     image: bitnami/redis:7.0.7
@@ -318,7 +284,7 @@ services:
       - 'stack'
     depends_on:
       broker:
-        condition: service_healthy
+        condition: service_started
       tokens:
         condition: service_healthy
     ports:
@@ -340,7 +306,7 @@ services:
       - 'stack'
     depends_on:
       broker:
-        condition: service_healthy
+        condition: service_started
       clickhouse:
         condition: service_healthy
     environment:

--- a/docker-compose.community.yml
+++ b/docker-compose.community.yml
@@ -38,28 +38,62 @@ services:
     volumes:
       - ./.hive/clickhouse/db:/var/lib/clickhouse
 
-  broker:
-    image: vectorized/redpanda:latest
-    container_name: broker
-    hostname: broker
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.3.1
+    hostname: zookeeper
     networks:
       - 'stack'
-    command:
-      - redpanda
-      - start
-      - --smp
-      - '1'
-      - --set redpanda.empty_seed_starts_cluster=false
-      - --seeds "redpanda-1:33145"
-      - --kafka-addr
-      - PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
-      - --advertise-kafka-addr
-      - PLAINTEXT://broker:29092,OUTSIDE://localhost:9092
-      - --pandaproxy-addr
-      - PLAINTEXT://0.0.0.0:28082,OUTSIDE://0.0.0.0:8082
-      - --advertise-pandaproxy-addr
-      - PLAINTEXT://broker:28082,OUTSIDE://localhost:8082
-      - --advertise-rpc-addr redpanda-1:33145
+    ulimits:
+      nofile:
+        soft: 20000
+        hard: 40000
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    volumes:
+      - ./.hive/zookeeper/db:/var/lib/zookeeper/data
+
+  broker:
+    image: confluentinc/cp-kafka:7.3.1
+    hostname: broker
+    depends_on:
+      zookeeper:
+        condition: service_started
+    networks:
+      - 'stack'
+    ulimits:
+      nofile:
+        soft: 20000
+        hard: 40000
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'cub',
+          'kafka-ready',
+          '1',
+          '5',
+          '-b',
+          '127.0.0.1:9092',
+          '-c',
+          '/etc/kafka/kafka.properties',
+        ]
+      interval: 15s
+      timeout: 10s
+      retries: 6
+      start_period: 15s
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+    volumes:
+      - ./.hive/broker/db:/var/lib/kafka/data
 
   redis:
     image: bitnami/redis:7.0.7
@@ -284,7 +318,7 @@ services:
       - 'stack'
     depends_on:
       broker:
-        condition: service_started
+        condition: service_healthy
       tokens:
         condition: service_healthy
     ports:
@@ -306,7 +340,7 @@ services:
       - 'stack'
     depends_on:
       broker:
-        condition: service_started
+        condition: service_healthy
       clickhouse:
         condition: service_healthy
     environment:

--- a/integration-tests/docker-compose.integration.yaml
+++ b/integration-tests/docker-compose.integration.yaml
@@ -174,9 +174,11 @@ services:
       RATE_LIMIT_ENDPOINT: '${RATE_LIMIT_ENDPOINT}'
       EMAIL_PROVIDER: '${EMAIL_PROVIDER}'
 
+  redis:
+    image: redis:7.0.7-alpine
+
   broker:
     image: vectorized/redpanda:latest
-    container_name: broker
     hostname: broker
     networks:
       - 'stack'
@@ -198,12 +200,13 @@ services:
       - --advertise-rpc-addr redpanda-1:33145
     mem_limit: 300m
     mem_reservation: 100m
-    depends_on: {}
+    depends_on: []
     healthcheck:
-      test: ['CMD', 'wget', '--spider', '-q', 'http://localhost:9644/public_metrics']
-      interval: 10s
-      timeout: 10s
-      retries: 3
+      test: 'curl -f http://localhost:9644/public_metrics'
+      interval: 3s
+      timeout: 3s
+      retries: 6
+      start_period: 5s
 
   db:
     ports:

--- a/integration-tests/docker-compose.integration.yaml
+++ b/integration-tests/docker-compose.integration.yaml
@@ -198,6 +198,12 @@ services:
       - --advertise-rpc-addr redpanda-1:33145
     mem_limit: 300m
     mem_reservation: 100m
+    depends_on: {}
+    healthcheck:
+      test: ['CMD', 'wget', '--spider', '-q', 'http://localhost:9644/public_metrics']
+      interval: 10s
+      timeout: 10s
+      retries: 3
 
   db:
     ports:

--- a/integration-tests/docker-compose.integration.yaml
+++ b/integration-tests/docker-compose.integration.yaml
@@ -175,6 +175,27 @@ services:
       EMAIL_PROVIDER: '${EMAIL_PROVIDER}'
 
   broker:
+    image: vectorized/redpanda:latest
+    container_name: broker
+    hostname: broker
+    networks:
+      - 'stack'
+    command:
+      - redpanda
+      - start
+      - --smp
+      - '1'
+      - --set redpanda.empty_seed_starts_cluster=false
+      - --seeds "redpanda-1:33145"
+      - --kafka-addr
+      - PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+      - --advertise-kafka-addr
+      - PLAINTEXT://broker:29092,OUTSIDE://localhost:9092
+      - --pandaproxy-addr
+      - PLAINTEXT://0.0.0.0:28082,OUTSIDE://0.0.0.0:8082
+      - --advertise-pandaproxy-addr
+      - PLAINTEXT://broker:28082,OUTSIDE://localhost:8082
+      - --advertise-rpc-addr redpanda-1:33145
     mem_limit: 300m
     mem_reservation: 100m
 
@@ -191,11 +212,21 @@ services:
   usage:
     environment:
       RATE_LIMIT_ENDPOINT: '${RATE_LIMIT_ENDPOINT}'
+    depends_on:
+      broker:
+        condition: service_started # Redpand is ready when it starts
+      tokens:
+        condition: service_healthy
 
   usage-ingestor:
     environment:
       CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MS: '${CLICKHOUSE_ASYNC_INSERT_BUSY_TIMEOUT_MS}'
       CLICKHOUSE_ASYNC_INSERT_MAX_DATA_SIZE: '${CLICKHOUSE_ASYNC_INSERT_MAX_DATA_SIZE}'
+    depends_on:
+      broker:
+        condition: service_started # Redpand is ready when it starts
+      tokens:
+        condition: service_healthy
 
   emails:
     environment:
@@ -203,7 +234,16 @@ services:
     ports:
       - '3011:3011'
 
-  # Awkwardly, we need to override the `app` service as it's not used in the integration tests
+  #
+  # Awkwardly, we need to override some services for different reasons
+  #
+
+  # It's not part of integration tests
   app:
+    image: node:18.13.0-alpine3.16
+    command: ['npx', 'http-server']
+
+  # Redpand is used for integration tests, instead of Kafka. Zookeeper is no longer needed
+  zookeeper:
     image: node:18.13.0-alpine3.16
     command: ['npx', 'http-server']

--- a/integration-tests/docker-compose.integration.yaml
+++ b/integration-tests/docker-compose.integration.yaml
@@ -174,6 +174,10 @@ services:
       RATE_LIMIT_ENDPOINT: '${RATE_LIMIT_ENDPOINT}'
       EMAIL_PROVIDER: '${EMAIL_PROVIDER}'
 
+  broker:
+    mem_limit: 300m
+    mem_reservation: 100m
+
   db:
     ports:
       - '5432:5432'

--- a/packages/services/storage/docker-compose.yml
+++ b/packages/services/storage/docker-compose.yml
@@ -85,72 +85,32 @@ services:
     networks:
       - 'stack'
 
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.3.1
-    hostname: zookeeper
-    networks:
-      - 'stack'
-    ports:
-      - '2181:2181'
-    ulimits:
-      nofile:
-        soft: 20000
-        hard: 40000
-    healthcheck:
-      test: echo srvr | nc zookeeper 2181 || exit 1
-      retries: 20
-      interval: 10s
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-    volumes:
-      - ./volumes/zookeeper/db:/var/lib/zookeeper/data
-      - ./volumes/zookeeper/log:/var/lib/zookeeper/log
-
   broker:
-    image: confluentinc/cp-kafka:7.3.1
-    hostname: borker
-    depends_on:
-      zookeeper:
-        condition: service_started
+    image: vectorized/redpanda:latest
+    container_name: broker
+    hostname: broker
     networks:
       - 'stack'
-    ports:
-      - '29092:29092'
-      - '9092:9092'
-    ulimits:
-      nofile:
-        soft: 20000
-        hard: 40000
-    healthcheck:
-      test:
-        [
-          'CMD',
-          'cub',
-          'kafka-ready',
-          '1',
-          '5',
-          '-b',
-          '127.0.0.1:9092',
-          '-c',
-          '/etc/kafka/kafka.properties',
-        ]
-      interval: 15s
-      timeout: 10s
-      retries: 6
-      start_period: 15s
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+    command:
+      - redpanda
+      - start
+      - --smp
+      - '1'
+      - --set redpanda.empty_seed_starts_cluster=false
+      - --seeds "redpanda-1:33145"
+      - --kafka-addr
+      - PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+      - --advertise-kafka-addr
+      - PLAINTEXT://broker:29092,OUTSIDE://localhost:9092
+      - --pandaproxy-addr
+      - PLAINTEXT://0.0.0.0:28082,OUTSIDE://0.0.0.0:8082
+      - --advertise-pandaproxy-addr
+      - PLAINTEXT://broker:28082,OUTSIDE://localhost:8082
+      - --advertise-rpc-addr redpanda-1:33145
+    mem_limit: 300m
+    mem_reservation: 100m
     volumes:
-      - ./volumes/broker/db:/var/lib/kafka/data
+      - ./volumes/broker/db:/var/lib/redpanda/data
 
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-postgresql:4.3


### PR DESCRIPTION
With a memory limit, it operates on 75MB of RAM and spins up much much faster.