### PR TITLE
Avoid generics on literals

### DIFF
--- a/deployment/services/kafka.ts
+++ b/deployment/services/kafka.ts
@@ -10,13 +10,13 @@ export function deployKafka() {
 
   if (!eventhubConfig.getBoolean('inCluster')) {
     return {
-      connectionEnv: <Record<string, pulumi.Output<string> | string>>{
+      connectionEnv: {
         KAFKA_SSL: '1',
         KAFKA_SASL_MECHANISM: 'plain',
         KAFKA_CONCURRENCY: '1',
         KAFKA_SASL_USERNAME: '$ConnectionString',
         KAFKA_SASL_PASSWORD: eventhubConfig.requireSecret('key'),
-      },
+      } as Record<string, pulumi.Output<string> | string>,
       config: {
         endpoint: eventhubConfig.require('endpoint'),
         bufferSize: eventhubConfig.require('bufferSize'),
@@ -50,10 +50,10 @@ export function deployKafka() {
   }).deploy();
 
   return {
-    connectionEnv: <Record<string, pulumi.Output<string> | string>>{
+    connectionEnv: {
       KAFKA_CONNECTION_MODE: 'docker',
       KAFKA_CONCURRENCY: '1',
-    },
+    } as Record<string, pulumi.Output<string> | string>,
     service: localKafka.service,
     deployment: localKafka.deployment,
     config: {


### PR DESCRIPTION
(TBH I didnt even know this syntax is possible haha)

Replace generic on literal with `as` statement, fixes issues with prettier and https://github.com/the-guild-org/shared-config/pull/154#pullrequestreview-1249865147.

The change will still have the same effect, see [TS playground](https://www.typescriptlang.org/play?#code/C4TwDgpgBAysBOBnKBeKAlCBjA9vAJgDyIICWAdgOYA0UJ8FlAfANwBQbu5JUAhgFywEyNAG8oAdxy8AFoIDk9eVAC+7Lj14AxXqQA2guElRRxU2YICMq9pxzdgUAEYmz0uVEUJlKvsiOI6vY8Tjr6rpLuVqp+QkjsQA).