### PR TITLE
Use workspace:* for client lib in server package

### DIFF
--- a/packages/services/server/package.json
+++ b/packages/services/server/package.json
@@ -36,7 +36,7 @@
     "zod": "3.20.2"
   },
   "devDependencies": {
-    "@graphql-hive/client": "0.22.0",
+    "@graphql-hive/client": "workspace:*",
     "@hive/api": "workspace:*",
     "@hive/cdn-script": "workspace:*",
     "@hive/service-common": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -610,7 +610,7 @@ importers:
       '@escape.tech/graphql-armor-max-depth': 1.8.1
       '@escape.tech/graphql-armor-max-directives': 1.6.1
       '@escape.tech/graphql-armor-max-tokens': 1.3.1
-      '@graphql-hive/client': 0.21.4
+      '@graphql-hive/client': workspace:*
       '@hive/api': workspace:*
       '@hive/cdn-script': workspace:*
       '@hive/service-common': workspace:*


### PR DESCRIPTION
it should fix: https://github.com/kamilkisiela/graphql-hive/actions/runs/3939974567/jobs/6740492300

> ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because pnpm-lock.yaml is not up to date with packages/services/server/package.json

It happens when we cut a new release of libraries