### PR TITLE
Avoid overfetching and get operation's body on-demand

### DIFF
--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -1,3 +1,4 @@
+import { OperationBodyByHashInput } from './../../packages/web/app/src/graphql/index';
 import { gql } from '@app/gql';
 import { fetch } from '@whatwg-node/fetch';
 import type {
@@ -686,7 +687,6 @@ export function readOperationsStats(input: OperationsStatsSelectorInput, token: 
           operations {
             nodes {
               id
-              document
               operationHash
               kind
               name
@@ -706,6 +706,20 @@ export function readOperationsStats(input: OperationsStatsSelectorInput, token: 
     token,
     variables: {
       input,
+    },
+  });
+}
+
+export function readOperationBody(selector: OperationBodyByHashInput, token: string) {
+  return execute({
+    document: gql(/* GraphQL */ `
+      query readOperationBody($selector: OperationBodyByHashInput!) {
+        operationBodyByHash(selector: $selector)
+      }
+    `),
+    token,
+    variables: {
+      selector,
     },
   });
 }

--- a/integration-tests/testkit/seed.ts
+++ b/integration-tests/testkit/seed.ts
@@ -32,6 +32,7 @@ import {
   updateBaseSchema,
   updateMemberAccess,
   updateSchemaVersionStatus,
+  readOperationBody,
 } from './flow';
 import { execute } from './graphql';
 import { collect, CollectedOperation } from './usage';
@@ -199,6 +200,19 @@ export function initSeed() {
                   return {
                     token,
                     secret,
+                    async readOperationBody(hash: string) {
+                      const operationBodyResult = await readOperationBody(
+                        {
+                          organization: organization.cleanId,
+                          project: project.cleanId,
+                          target: target.cleanId,
+                          hash,
+                        },
+                        secret,
+                      ).then(r => r.expectNoGraphQLErrors());
+
+                      return operationBodyResult.operationBodyByHash;
+                    },
                     async readOperationsStats(from: string, to: string) {
                       const statsResult = await readOperationsStats(
                         {

--- a/integration-tests/testkit/seed.ts
+++ b/integration-tests/testkit/seed.ts
@@ -25,6 +25,7 @@ import {
   inviteToOrganization,
   joinOrganization,
   publishSchema,
+  readOperationBody,
   readOperationsStats,
   readTokenInfo,
   schemaSyncCDN,
@@ -32,7 +33,6 @@ import {
   updateBaseSchema,
   updateMemberAccess,
   updateSchemaVersionStatus,
-  readOperationBody,
 } from './flow';
 import { execute } from './graphql';
 import { collect, CollectedOperation } from './usage';

--- a/integration-tests/tests/api/legacy-auth.spec.ts
+++ b/integration-tests/tests/api/legacy-auth.spec.ts
@@ -47,7 +47,7 @@ test.concurrent(
 
     const op = operationsStats.operations.nodes[0];
     expect(op.count).toEqual(1);
-    await expect(readOperationBody(op.operationHash!)).resolves.toEqual('ping');
+    await expect(readOperationBody(op.operationHash!)).resolves.toEqual('query ping{ping}');
     expect(op.operationHash).toBeDefined();
     expect(op.duration.p75).toEqual(200);
     expect(op.duration.p90).toEqual(200);

--- a/integration-tests/tests/api/legacy-auth.spec.ts
+++ b/integration-tests/tests/api/legacy-auth.spec.ts
@@ -11,7 +11,8 @@ test.concurrent(
     const { inviteAndJoinMember, createProject } = await createOrg();
     await inviteAndJoinMember();
     const { createToken } = await createProject(ProjectType.Single);
-    const { publishSchema, collectOperations, readOperationsStats } = await createToken({});
+    const { publishSchema, collectOperations, readOperationsStats, readOperationBody } =
+      await createToken({});
 
     const result = await publishSchema({
       sdl: `type Query { ping: String }`,
@@ -46,7 +47,7 @@ test.concurrent(
 
     const op = operationsStats.operations.nodes[0];
     expect(op.count).toEqual(1);
-    expect(op.document).toMatch('ping');
+    await expect(readOperationBody(op.operationHash!)).resolves.toEqual('ping');
     expect(op.operationHash).toBeDefined();
     expect(op.duration.p75).toEqual(200);
     expect(op.duration.p90).toEqual(200);

--- a/integration-tests/tests/api/target/usage.spec.ts
+++ b/integration-tests/tests/api/target/usage.spec.ts
@@ -101,7 +101,7 @@ test.concurrent('collect operation', async () => {
   const op = operationsStats.operations.nodes[0];
 
   expect(op.count).toEqual(1);
-  expect(op.document).toMatch('ping');
+  await expect(writeToken.readOperationBody(op.operationHash!)).resolves.toEqual('ping');
   expect(op.operationHash).toBeDefined();
   expect(op.duration.p75).toEqual(200);
   expect(op.duration.p90).toEqual(200);
@@ -213,10 +213,17 @@ test.concurrent('normalize and collect operation without breaking its syntax', a
 
   const op = operationsStats.operations.nodes[0];
   expect(op.count).toEqual(1);
+
+  const doc = await writeToken.readOperationBody(op.operationHash!);
+
+  if (!doc) {
+    throw new Error('Operation body is empty');
+  }
+
   expect(() => {
-    parse(op.document);
+    parse(doc);
   }).not.toThrow();
-  expect(print(parse(op.document))).toEqual(print(parse(normalized_document)));
+  expect(print(parse(doc))).toEqual(print(parse(normalized_document)));
   expect(op.operationHash).toBeDefined();
   expect(op.duration.p75).toEqual(200);
   expect(op.duration.p90).toEqual(200);
@@ -273,7 +280,7 @@ test.concurrent(
 
     const op = operationsStats.operations.nodes[0];
     expect(op.count).toEqual(totalAmount);
-    expect(op.document).toMatch('ping');
+    await expect(writeToken.readOperationBody(op.operationHash!)).resolves.toEqual('ping');
     expect(op.operationHash).toBeDefined();
     expect(op.duration.p75).toEqual(200);
     expect(op.duration.p90).toEqual(200);

--- a/integration-tests/tests/api/target/usage.spec.ts
+++ b/integration-tests/tests/api/target/usage.spec.ts
@@ -101,7 +101,9 @@ test.concurrent('collect operation', async () => {
   const op = operationsStats.operations.nodes[0];
 
   expect(op.count).toEqual(1);
-  await expect(writeToken.readOperationBody(op.operationHash!)).resolves.toEqual('ping');
+  await expect(writeToken.readOperationBody(op.operationHash!)).resolves.toEqual(
+    'query ping{ping}',
+  );
   expect(op.operationHash).toBeDefined();
   expect(op.duration.p75).toEqual(200);
   expect(op.duration.p90).toEqual(200);
@@ -280,7 +282,9 @@ test.concurrent(
 
     const op = operationsStats.operations.nodes[0];
     expect(op.count).toEqual(totalAmount);
-    await expect(writeToken.readOperationBody(op.operationHash!)).resolves.toEqual('ping');
+    await expect(writeToken.readOperationBody(op.operationHash!)).resolves.toEqual(
+      'query ping{ping}',
+    );
     expect(op.operationHash).toBeDefined();
     expect(op.duration.p75).toEqual(200);
     expect(op.duration.p90).toEqual(200);

--- a/packages/services/api/src/modules/operations/module.graphql.ts
+++ b/packages/services/api/src/modules/operations/module.graphql.ts
@@ -7,6 +7,7 @@ export default gql`
     operationsStats(selector: OperationsStatsSelectorInput!): OperationsStats!
     hasCollectedOperations(selector: TargetSelectorInput!): Boolean!
     clientStatsByTargets(selector: ClientStatsByTargetsInput!): ClientStatsConnection!
+    operationBodyByHash(selector: OperationBodyByHashInput!): String
   }
 
   input OperationsStatsSelectorInput {
@@ -15,6 +16,13 @@ export default gql`
     target: ID!
     period: DateRangeInput!
     operations: [ID!]
+  }
+
+  input OperationBodyByHashInput {
+    organization: ID!
+    project: ID!
+    target: ID!
+    hash: String!
   }
 
   input ClientStatsByTargetsInput {
@@ -100,7 +108,6 @@ export default gql`
 
   type OperationStats {
     id: ID!
-    document: String!
     operationHash: String
     kind: String!
     name: String!

--- a/packages/services/api/src/modules/operations/providers/operations-manager.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-manager.ts
@@ -67,6 +67,25 @@ export class OperationsManager {
     this.logger = logger.child({ source: 'OperationsManager' });
   }
 
+  async getOperationBody({
+    organization,
+    project,
+    target,
+    hash,
+  }: { hash: string } & TargetSelector) {
+    await this.authManager.ensureTargetAccess({
+      organization,
+      project,
+      target,
+      scope: TargetAccessScope.REGISTRY_READ,
+    });
+
+    return await this.reader.readOperationBody({
+      target,
+      hash,
+    });
+  }
+
   async countUniqueOperations({
     organization,
     project,
@@ -82,13 +101,11 @@ export class OperationsManager {
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
-    return (
-      await this.reader.countUniqueDocuments({
-        target,
-        period,
-        operations,
-      })
-    ).length;
+    return await this.reader.countUniqueDocuments({
+      target,
+      period,
+      operations,
+    });
   }
 
   async hasCollectedOperations({ organization, project, target }: TargetSelector) {
@@ -272,7 +289,8 @@ export class OperationsManager {
       scope: TargetAccessScope.REGISTRY_READ,
     });
 
-    return this.reader.countUniqueDocuments({
+    // Maybe it needs less data
+    return this.reader.readUniqueDocuments({
       target,
       period,
       operations,

--- a/packages/services/api/src/modules/operations/resolvers.ts
+++ b/packages/services/api/src/modules/operations/resolvers.ts
@@ -106,6 +106,21 @@ export const resolvers: OperationsModule.Resolvers = {
         };
       });
     },
+    async operationBodyByHash(_, { selector }, { injector }) {
+      const translator = injector.get(IdTranslator);
+      const [organization, project, target] = await Promise.all([
+        translator.translateOrganizationId(selector),
+        translator.translateProjectId(selector),
+        translator.translateTargetId(selector),
+      ]);
+
+      return injector.get(OperationsManager).getOperationBody({
+        organization,
+        project,
+        target,
+        hash: selector.hash,
+      });
+    },
   },
   OperationsStats: {
     async operations(
@@ -134,9 +149,8 @@ export const resolvers: OperationsModule.Resolvers = {
       return operations
         .map(op => {
           return {
-            id: hash(`${op.operationName}__${op.document}`),
+            id: hash(`${op.operationName}__${op.operationHash!}`),
             kind: op.kind,
-            document: op.document,
             name: op.operationName,
             count: op.count,
             countOk: op.countOk,

--- a/packages/web/app/src/components/target/operations/List.tsx
+++ b/packages/web/app/src/components/target/operations/List.tsx
@@ -39,7 +39,7 @@ import {
   VscChevronUp,
   VscWarning,
 } from 'react-icons/vsc';
-import { useQuery } from 'urql';
+import { gql, useQuery } from 'urql';
 import { useDebouncedCallback } from 'use-debounce';
 import { Scale, Section } from '@/components/common';
 import { GraphQLHighlight } from '@/components/common/GraphQLSDLBlock';
@@ -58,7 +58,7 @@ interface Operation {
   failureRate: number;
   requests: number;
   percentage: number;
-  document: string;
+  hash: string;
 }
 
 const Sortable = ({
@@ -84,9 +84,51 @@ const Sortable = ({
   );
 };
 
+const GraphQLOperationBody_GetOperationBodyQuery = gql(/* GraphQL */ `
+  query GraphQLOperationBody_GetOperationBodyQuery($selector: OperationBodyByHashInput!) {
+    operationBodyByHash(selector: $selector)
+  }
+`);
+
+function GraphQLOperationBody({
+  hash,
+  organization,
+  project,
+  target,
+}: {
+  hash: string;
+  organization: string;
+  project: string;
+  target: string;
+}) {
+  const [result] = useQuery({
+    query: GraphQLOperationBody_GetOperationBodyQuery,
+    variables: { selector: { hash, organization, project, target } },
+  });
+
+  const { data, fetching, error } = result;
+
+  if (fetching) {
+    return <div>Loading...</div>;
+  }
+
+  if (error) {
+    return <div>Oh no... {error.message}</div>;
+  }
+
+  if (data?.operationBodyByHash) {
+    return <GraphQLHighlight tw="pt-6" light code={data.operationBodyByHash} />;
+  }
+
+  return null;
+}
+
 const OperationRow: React.FC<{
   operation: Operation;
-}> = ({ operation }) => {
+  organization: string;
+  project: string;
+  target: string;
+}> = ({ operation, organization, project, target }) => {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const linkRef = React.useRef<HTMLButtonElement | null>(null);
   const count = useFormattedNumber(operation.requests);
@@ -153,7 +195,12 @@ const OperationRow: React.FC<{
           </DrawerHeader>
 
           <DrawerBody>
-            <GraphQLHighlight tw="pt-6" light code={operation.document} />
+            <GraphQLOperationBody
+              hash={operation.hash}
+              organization={organization}
+              project={project}
+              target={target}
+            />
           </DrawerBody>
         </DrawerContent>
       </Drawer>
@@ -205,7 +252,20 @@ const OperationsTable: React.FC<{
   sorting: SortingState;
   setSorting: OnChangeFn<SortingState>;
   className?: string;
-}> = ({ operations, sorting, setSorting, pagination, setPagination, className }) => {
+  organization: string;
+  project: string;
+  target: string;
+}> = ({
+  operations,
+  sorting,
+  setSorting,
+  pagination,
+  setPagination,
+  className,
+  organization,
+  project,
+  target,
+}) => {
   const tableInstance = useTableInstance(table, {
     columns,
     data: operations,
@@ -318,7 +378,15 @@ const OperationsTable: React.FC<{
             if (!row.original) {
               return null;
             }
-            return <OperationRow operation={row.original} key={row.original.id} />;
+            return (
+              <OperationRow
+                operation={row.original}
+                key={row.original.id}
+                organization={organization}
+                project={project}
+                target={target}
+              />
+            );
           })}
         </Tbody>
       </Table>
@@ -383,8 +451,11 @@ const OperationsTable: React.FC<{
 const OperationsTableContainer: React.FC<{
   operations: readonly OperationStatsFieldsFragment[];
   operationsFilter: readonly string[];
+  organization: string;
+  project: string;
+  target: string;
   className?: string;
-}> = ({ operations, operationsFilter, className }) => {
+}> = ({ operations, operationsFilter, organization, project, target, className }) => {
   const data = React.useMemo(() => {
     const records: Array<Operation> = [];
     for (const op of operations) {
@@ -405,7 +476,7 @@ const OperationsTableContainer: React.FC<{
         failureRate: 1 - op.countOk / op.count,
         requests: op.count,
         percentage: op.percentage,
-        document: op.document,
+        hash: op.operationHash!,
       });
     }
 
@@ -446,6 +517,9 @@ const OperationsTableContainer: React.FC<{
       setPagination={safeSetPagination}
       sorting={sorting}
       setSorting={setSorting}
+      organization={organization}
+      project={project}
+      target={target}
     />
   );
 };
@@ -486,6 +560,9 @@ export const OperationsList: React.FC<{
         operations={operations}
         operationsFilter={operationsFilter}
         className={className}
+        organization={organization}
+        project={project}
+        target={target}
       />
     </OperationsFallback>
   );

--- a/packages/web/app/src/graphql/fragments.graphql
+++ b/packages/web/app/src/graphql/fragments.graphql
@@ -82,7 +82,6 @@ fragment UserFields on User {
 
 fragment OperationStatsFields on OperationStats {
   id
-  document
   operationHash
   name
   kind


### PR DESCRIPTION
This should speed up the slowest ClickHouse query from 12s to 1s.

I noticed that we reuse one query that is super heavy, and we do it for no reason.

The query is used in two places:
- to count the number of operations (unique per body)
- to generate a list of operations

In the first case, I wrote a much faster query to just count the operations.

In the second scenario, I had to do a little more.
On the "Operations" page, a body of an operation is only visible when a user clicks on a table's row.
The slowest part of the query is the `body` column in the `group` clause.
I decided to ignore `body` as it's needed only when a user performs a specific action and moved it to a separate query, that is executed lazily.

