### PR TITLE
Separate Docker build for app and Rust in "main" pipeline

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -12,9 +12,19 @@ jobs:
       imageTag: ${{ github.sha }}
       publishSourceMaps: true
       publishLatest: true
-      targets: |
-        build
-        rust
+      targets: build
+    secrets: inherit
+
+  # Builds Rust crates, and creates Docker images
+  build-rust:
+    name: build_rust
+    uses: ./.github/workflows/build-and-dockerize.yaml
+    with:
+      imageTag: ${{ github.sha }}
+      publishLatest: true
+      targets: rust
+      build: false
+      publishPrComment: false
     secrets: inherit
 
   # Build and publish Rust crates and binaries


### PR DESCRIPTION
Right now the Rust docker build takes forever in `main` and it prevents us from having an image for the rest of the services quickly. 