### PR TITLE
fix: use correct key prefix for migration

### DIFF
--- a/packages/migrations/src/actions/2023.01.17T10.46.28.import-legacy-s3-keys-to-database.mts
+++ b/packages/migrations/src/actions/2023.01.17T10.46.28.import-legacy-s3-keys-to-database.mts
@@ -100,7 +100,7 @@ export const up: slonik.Migration = async ({ context: { connection, sql } }) => 
   let lastCursor: null | Cursor = null;
 
   async function seedLegacyCDNKey(item: zod.TypeOf<typeof TargetsModel>[number]): Promise<void> {
-    const s3Key = `s3-legacy-keys/${item.id}`;
+    const s3Key = `cdn-legacy-keys/${item.id}`;
     const privateAccessKey = generateLegacyCDNAccessToken(item.id);
     const firstCharacters = privateAccessKey.substring(0, 3);
     const lastCharacters = privateAccessKey.substring(privateAccessKey.length - 3);


### PR DESCRIPTION
<img width="244" alt="image" src="https://user-images.githubusercontent.com/14338007/214256497-87596348-7d68-43eb-b58c-d6c4a96874fb.png">


fail