### PR TITLE
Fix logger issue with heartbeat onError

### DIFF
--- a/packages/services/emails/src/index.ts
+++ b/packages/services/emails/src/index.ts
@@ -56,7 +56,7 @@ async function main() {
           enabled: true,
           endpoint: env.heartbeat.endpoint,
           intervalInMS: 20_000,
-          onError: server.log.error,
+          onError: e => server.log.error(e, `Heartbeat failed with error`),
           isReady: readiness,
         })
       : startHeartbeats({ enabled: false });

--- a/packages/services/tokens/src/index.ts
+++ b/packages/services/tokens/src/index.ts
@@ -64,7 +64,7 @@ export async function main() {
           enabled: true,
           endpoint: env.heartbeat.endpoint,
           intervalInMS: 20_000,
-          onError: server.log.error,
+          onError: e => server.log.error(e, `Heartbeat failed with error`),
           isReady: readiness,
         })
       : startHeartbeats({ enabled: false });

--- a/packages/services/usage-ingestor/src/index.ts
+++ b/packages/services/usage-ingestor/src/index.ts
@@ -47,7 +47,7 @@ async function main() {
           enabled: true,
           endpoint: env.heartbeat.endpoint,
           intervalInMS: 20_000,
-          onError: server.log.error,
+          onError: e => server.log.error(e, `Heartbeat failed with error`),
           isReady: readiness,
         })
       : startHeartbeats({ enabled: false });

--- a/packages/services/webhooks/src/index.ts
+++ b/packages/services/webhooks/src/index.ts
@@ -56,7 +56,7 @@ async function main() {
           enabled: true,
           endpoint: env.heartbeat.endpoint,
           intervalInMS: 20_000,
-          onError: server.log.error,
+          onError: e => server.log.error(e, `Heartbeat failed with error`),
           isReady: readiness,
         })
       : startHeartbeats({ enabled: false });


### PR DESCRIPTION
`pino` does not allow to pass the logging functions, it needs the `this` context because it does not do `bind` ahead of time.

This should fix that.

Related  https://github.com/pinojs/pino/issues/956 