### PR TITLE
feat: use s3 bucket for validating CDN access tokens

### DIFF
--- a/deployment/index.ts
+++ b/deployment/index.ts
@@ -84,7 +84,6 @@ const cdn = deployCFCDN({
   rootDns,
   s3Config,
   release: imagesTag,
-  cdnAuthPrivateKey,
 });
 
 const cfBroker = deployCFBroker({
@@ -247,6 +246,7 @@ const graphqlApi = deployGraphQL({
   dbMigrations,
   redis: redisApi,
   usage: usageApi,
+  cdnAuthPrivateKey,
   cdn,
   usageEstimator: usageEstimationApi,
   rateLimit: rateLimitApi,

--- a/deployment/services/cf-cdn.ts
+++ b/deployment/services/cf-cdn.ts
@@ -14,7 +14,6 @@ export function deployCFCDN({
   release,
   envName,
   s3Config,
-  cdnAuthPrivateKey,
 }: {
   rootDns: string;
   envName: string;
@@ -25,7 +24,6 @@ export function deployCFCDN({
     accessKeyId: pulumi.Output<string>;
     secretAccessKey: pulumi.Output<string>;
   };
-  cdnAuthPrivateKey: pulumi.Output<string>;
 }) {
   const cdn = new CloudflareCDN({
     envName,
@@ -34,7 +32,6 @@ export function deployCFCDN({
     // one level of subdomains. See: https://community.cloudflare.com/t/ssl-handshake-error-cloudflare-proxy/175088
     // So for staging env, we are going to use `cdn-staging` instead of `cdn.staging`.
     cdnDnsRecord: isProduction(envName) ? `cdn.${rootDns}` : `cdn-${rootDns}`,
-    authPrivateKey: cdnAuthPrivateKey,
     sentryDsn: commonEnv.SENTRY_DSN,
     release,
     s3Config,

--- a/deployment/services/graphql.ts
+++ b/deployment/services/graphql.ts
@@ -49,6 +49,7 @@ export function deployGraphQL({
   auth0Config,
   s3Config,
   imagePullSecret,
+  cdnAuthPrivateKey,
 }: {
   release: string;
   image: string;
@@ -59,6 +60,7 @@ export function deployGraphQL({
   schema: Schema;
   redis: Redis;
   cdn: CDN;
+  cdnAuthPrivateKey: Output<string>;
   usage: Usage;
   usageEstimator: UsageEstimator;
   dbMigrations: DbMigrations;
@@ -137,7 +139,7 @@ export function deployGraphQL({
         CDN_CF_AUTH_TOKEN: cloudflareConfig.requireSecret('apiToken'),
         CDN_CF_NAMESPACE_ID: cdn.cfStorageNamespaceId,
         CDN_CF_BASE_URL: cdn.workerBaseUrl,
-        CDN_AUTH_PRIVATE_KEY: cdn.authPrivateKey,
+        CDN_AUTH_PRIVATE_KEY: cdnAuthPrivateKey,
         // Hive
         HIVE: '1',
         HIVE_REPORTING: '1',

--- a/deployment/utils/cloudflare.ts
+++ b/deployment/utils/cloudflare.ts
@@ -9,7 +9,6 @@ export class CloudflareCDN {
       envName: string;
       zoneId: string;
       cdnDnsRecord: string;
-      authPrivateKey: pulumi.Output<string>;
       sentryDsn: string;
       release: string;
       s3Config: {
@@ -57,12 +56,6 @@ export class CloudflareCDN {
       ],
       secretTextBindings: [
         {
-          // KEY_DATA is in use in cdn-script.js as well, its the name of the global variable,
-          // basically it's the private key for the hmac key.
-          name: 'KEY_DATA',
-          text: this.config.authPrivateKey,
-        },
-        {
           name: 'SENTRY_DSN',
           text: this.config.sentryDsn,
         },
@@ -103,7 +96,6 @@ export class CloudflareCDN {
     });
 
     return {
-      authPrivateKey: this.config.authPrivateKey,
       workerBaseUrl: workerUrl,
       cfStorageNamespaceId: kvStorage.id,
     };

--- a/packages/services/cdn-worker/src/dev-polyfill.ts
+++ b/packages/services/cdn-worker/src/dev-polyfill.ts
@@ -19,7 +19,6 @@ if (!globalThis.crypto) {
 export const devStorage = new Map<string, string>();
 
 // eslint-disable-next-line no-process-env
-(globalThis as any).KEY_DATA = process.env.CDN_AUTH_PRIVATE_KEY || '';
 (globalThis as any).HIVE_DATA = devStorage;
 // eslint-disable-next-line no-process-env
 (globalThis as any).S3_ENDPOINT = process.env.S3_ENDPOINT || '';

--- a/packages/services/cdn-worker/src/dev.ts
+++ b/packages/services/cdn-worker/src/dev.ts
@@ -36,20 +36,15 @@ const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 4010;
 // @ts-ignore
 declare let HIVE_DATA: KVNamespace;
 
-/**
- * Secret used to sign the CDN keys
- */
-declare let KEY_DATA: string;
-
 const handleRequest = createRequestHandler({
   getRawStoreValue: value => HIVE_DATA.get(value),
-  isKeyValid: createIsKeyValid({ keyData: KEY_DATA }),
+  isKeyValid: createIsKeyValid({ s3, getCache: null, waitUntil: null, analytics: null }),
 });
 
 const artifactStorageReader = new ArtifactStorageReader(s3, S3_PUBLIC_URL);
 
 const handleArtifactRequest = createArtifactRequestHandler({
-  isKeyValid: createIsKeyValid({ keyData: KEY_DATA }),
+  isKeyValid: createIsKeyValid({ s3, getCache: null, waitUntil: null, analytics: null }),
   async getArtifactAction(targetId, artifactType, eTag) {
     return artifactStorageReader.generateArtifactReadUrl(targetId, artifactType, eTag);
   },

--- a/packages/services/cdn-worker/src/index.ts
+++ b/packages/services/cdn-worker/src/index.ts
@@ -30,11 +30,6 @@ const artifactStorageReader = new ArtifactStorageReader(s3, null);
  */
 declare let HIVE_DATA: KVNamespace;
 
-/**
- * Secret used to sign the CDN keys
- */
-declare let KEY_DATA: string;
-
 declare let SENTRY_DSN: string;
 /**
  * Name of the environment, e.g. staging, production
@@ -66,7 +61,6 @@ const analytics = createAnalytics({
 
 self.addEventListener('fetch', async (event: FetchEvent) => {
   const isKeyValid = createIsKeyValid({
-    keyData: KEY_DATA,
     waitUntil: p => event.waitUntil(p),
     getCache: () => caches.open('artifacts-auth'),
     s3,

--- a/packages/services/cdn-worker/tests/cdn.spec.ts
+++ b/packages/services/cdn-worker/tests/cdn.spec.ts
@@ -1,4 +1,5 @@
 import { createHmac } from 'crypto';
+import * as bcrypt from 'bcryptjs';
 import '../src/dev-polyfill';
 import {
   InvalidArtifactTypeResponse,
@@ -27,13 +28,26 @@ describe('CDN Worker', () => {
     const targetId = 'fake-target-id';
     const map = new Map();
     map.set(`target:${targetId}:schema`, JSON.stringify({ sdl: `type Query { dummy: String }` }));
+    const token = createToken(SECRET, targetId);
 
     const handleRequest = createRequestHandler({
-      isKeyValid: createIsKeyValid({ keyData: SECRET }),
+      isKeyValid: createIsKeyValid({
+        getCache: null,
+        waitUntil: null,
+        s3: {
+          endpoint: 'http://localhost:1337',
+          bucketName: 'artifacts',
+          client: {
+            async fetch() {
+              return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
+                status: 200,
+              });
+            },
+          },
+        },
+      }),
       getRawStoreValue: (key: string) => map.get(key),
     });
-
-    const token = createToken(SECRET, targetId);
 
     const schemaRequest = new Request(`https://fake-worker.com/${targetId}/schema`, {
       headers: {
@@ -63,7 +77,21 @@ describe('CDN Worker', () => {
     map.set(`target:${targetId}:schema`, JSON.stringify({ sdl: `type Query { dummy: String }` }));
 
     const handleRequest = createRequestHandler({
-      isKeyValid: createIsKeyValid({ keyData: SECRET }),
+      isKeyValid: createIsKeyValid({
+        getCache: null,
+        waitUntil: null,
+        s3: {
+          endpoint: 'http://localhost:1337',
+          bucketName: 'artifacts',
+          client: {
+            async fetch() {
+              return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
+                status: 200,
+              });
+            },
+          },
+        },
+      }),
       getRawStoreValue: (key: string) => map.get(key),
     });
 
@@ -114,12 +142,26 @@ describe('CDN Worker', () => {
       JSON.stringify({ sdl: `type Query { dummy: String }` }),
     );
 
+    const token = createToken(SECRET, targetId);
+
     const handleRequest = createRequestHandler({
-      isKeyValid: createIsKeyValid({ keyData: SECRET }),
+      isKeyValid: createIsKeyValid({
+        getCache: null,
+        waitUntil: null,
+        s3: {
+          endpoint: 'http://localhost:1337',
+          bucketName: 'artifacts',
+          client: {
+            async fetch() {
+              return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
+                status: 200,
+              });
+            },
+          },
+        },
+      }),
       getRawStoreValue: (key: string) => map.get(key),
     });
-
-    const token = createToken(SECRET, targetId);
 
     const firstRequest = new Request(`https://fake-worker.com/${targetId}/supergraph`, {
       headers: {
@@ -164,7 +206,21 @@ describe('CDN Worker', () => {
     map.set(`target:${targetId}:metadata`, JSON.stringify({ sdl: `type Query { dummy: String }` }));
 
     const handleRequest = createRequestHandler({
-      isKeyValid: createIsKeyValid({ keyData: SECRET }),
+      isKeyValid: createIsKeyValid({
+        getCache: null,
+        waitUntil: null,
+        s3: {
+          endpoint: 'http://localhost:1337',
+          bucketName: 'artifacts',
+          client: {
+            async fetch() {
+              return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
+                status: 200,
+              });
+            },
+          },
+        },
+      }),
       getRawStoreValue: (key: string) => map.get(key),
     });
 
@@ -213,7 +269,21 @@ describe('CDN Worker', () => {
     map.set(`target:${targetId}:schema`, JSON.stringify({ sdl: `type Query { dummy: String }` }));
 
     const handleRequest = createRequestHandler({
-      isKeyValid: createIsKeyValid({ keyData: SECRET }),
+      isKeyValid: createIsKeyValid({
+        getCache: null,
+        waitUntil: null,
+        s3: {
+          endpoint: 'http://localhost:1337',
+          bucketName: 'artifacts',
+          client: {
+            async fetch() {
+              return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
+                status: 200,
+              });
+            },
+          },
+        },
+      }),
       getRawStoreValue: (key: string) => map.get(key),
     });
 
@@ -267,7 +337,21 @@ describe('CDN Worker', () => {
     );
 
     const handleRequest = createRequestHandler({
-      isKeyValid: createIsKeyValid({ keyData: SECRET }),
+      isKeyValid: createIsKeyValid({
+        getCache: null,
+        waitUntil: null,
+        s3: {
+          endpoint: 'http://localhost:1337',
+          bucketName: 'artifacts',
+          client: {
+            async fetch() {
+              return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
+                status: 200,
+              });
+            },
+          },
+        },
+      }),
       getRawStoreValue: (key: string) => map.get(key),
     });
 
@@ -375,7 +459,21 @@ describe('CDN Worker', () => {
       map.set(`target:${targetId}:schema`, JSON.stringify({ sdl: `type Query { dummy: String }` }));
 
       const handleRequest = createRequestHandler({
-        isKeyValid: createIsKeyValid({ keyData: SECRET }),
+        isKeyValid: createIsKeyValid({
+          getCache: null,
+          waitUntil: null,
+          s3: {
+            endpoint: 'http://localhost:1337',
+            bucketName: 'artifacts',
+            client: {
+              async fetch() {
+                return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
+                  status: 200,
+                });
+              },
+            },
+          },
+        }),
         getRawStoreValue: (key: string) => map.get(key),
       });
 
@@ -396,7 +494,21 @@ describe('CDN Worker', () => {
       const map = new Map();
 
       const handleRequest = createRequestHandler({
-        isKeyValid: createIsKeyValid({ keyData: SECRET }),
+        isKeyValid: createIsKeyValid({
+          getCache: null,
+          waitUntil: null,
+          s3: {
+            endpoint: 'http://localhost:1337',
+            bucketName: 'artifacts',
+            client: {
+              async fetch() {
+                return new Response(null, {
+                  status: 404,
+                });
+              },
+            },
+          },
+        }),
         getRawStoreValue: (key: string) => map.get(key),
       });
 
@@ -415,7 +527,21 @@ describe('CDN Worker', () => {
 
     it('Should throw on invalid token hash', async () => {
       const handleRequest = createRequestHandler({
-        isKeyValid: createIsKeyValid({ keyData: '123456' }),
+        isKeyValid: createIsKeyValid({
+          getCache: null,
+          waitUntil: null,
+          s3: {
+            endpoint: 'http://localhost:1337',
+            bucketName: 'artifacts',
+            client: {
+              async fetch() {
+                return new Response(await bcrypt.hash('foobars', await bcrypt.genSalt()), {
+                  status: 200,
+                });
+              },
+            },
+          },
+        }),
         getRawStoreValue: (key: string) => new Map().get(key),
       });
 

--- a/packages/services/server/src/index.ts
+++ b/packages/services/server/src/index.ts
@@ -329,7 +329,7 @@ export async function main() {
       const artifactStorageReader = new ArtifactStorageReader(s3, env.s3.publicUrl);
 
       const artifactHandler = createArtifactRequestHandler({
-        isKeyValid: createIsKeyValid({ keyData: env.cdn.authPrivateKey }),
+        isKeyValid: createIsKeyValid({ s3, analytics: null, getCache: null, waitUntil: null }),
         async getArtifactAction(targetId, artifactType, eTag) {
           return artifactStorageReader.generateArtifactReadUrl(targetId, artifactType, eTag);
         },


### PR DESCRIPTION
### Background

Re-applies remaining changes from https://github.com/kamilkisiela/graphql-hive/pull/1005 for using the new s3 method for validating the CDN access tokens instead of using the old "static" method.

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [x] Testing
