### PR TITLE
Fix the cache logic in Tokens service

### DIFF
--- a/deployment/services/kafka.ts
+++ b/deployment/services/kafka.ts
@@ -1,68 +1,27 @@
 import * as pulumi from '@pulumi/pulumi';
-import { Kafka as KafkaDeployment } from '../utils/kafka';
-import { getLocalComposeConfig } from '../utils/local-config';
-import { serviceLocalHost } from '../utils/local-endpoint';
 
 export type Kafka = ReturnType<typeof deployKafka>;
 
 export function deployKafka() {
   const eventhubConfig = new pulumi.Config('eventhub');
 
-  if (!eventhubConfig.getBoolean('inCluster')) {
-    return {
-      connectionEnv: {
-        KAFKA_SSL: '1',
-        KAFKA_SASL_MECHANISM: 'plain',
-        KAFKA_CONCURRENCY: '1',
-        KAFKA_SASL_USERNAME: '$ConnectionString',
-        KAFKA_SASL_PASSWORD: eventhubConfig.requireSecret('key'),
-      } as Record<string, pulumi.Output<string> | string>,
-      config: {
-        endpoint: eventhubConfig.require('endpoint'),
-        bufferSize: eventhubConfig.require('bufferSize'),
-        bufferInterval: eventhubConfig.require('bufferInterval'),
-        bufferDynamic: eventhubConfig.require('bufferDynamic'),
-        topic: eventhubConfig.require('topic'),
-        consumerGroup: eventhubConfig.require('consumerGroup'),
-      },
-      service: null,
-      deployment: null,
-    };
-  }
-
-  const kafkaService = getLocalComposeConfig().service('broker');
-  const zookeeper = getLocalComposeConfig().service('zookeeper');
-  const usageService = getLocalComposeConfig().service('usage');
-  const usageIngestorService = getLocalComposeConfig().service('usage-ingestor');
-
-  const localKafka = new KafkaDeployment('kafka-broker', {
-    env: {
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true',
-      KAFKA_BROKER_ID: '1',
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: 'PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT',
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: '1',
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: '0',
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: '1',
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: '1',
-    },
-    zookeeperImage: zookeeper.image,
-    image: kafkaService.image,
-  }).deploy();
-
   return {
     connectionEnv: {
-      KAFKA_CONNECTION_MODE: 'docker',
+      KAFKA_SSL: '1',
+      KAFKA_SASL_MECHANISM: 'plain',
       KAFKA_CONCURRENCY: '1',
+      KAFKA_SASL_USERNAME: '$ConnectionString',
+      KAFKA_SASL_PASSWORD: eventhubConfig.requireSecret('key'),
     } as Record<string, pulumi.Output<string> | string>,
-    service: localKafka.service,
-    deployment: localKafka.deployment,
     config: {
-      endpoint: serviceLocalHost(localKafka.service).apply(v => `${v}:29092`),
-      bufferSize: String(usageService.environment['KAFKA_BUFFER_SIZE'] || ''),
-      bufferInterval: String(usageService.environment['KAFKA_BUFFER_INTERVAL'] || ''),
-      bufferDynamic: String(usageService.environment['KAFKA_BUFFER_DYNAMIC'] || ''),
-      topic: usageService.environment['KAFKA_TOPIC'],
-      consumerGroup: usageIngestorService.environment['KAFKA_CONSUMER_GROUP'] as string,
+      endpoint: eventhubConfig.require('endpoint'),
+      bufferSize: eventhubConfig.require('bufferSize'),
+      bufferInterval: eventhubConfig.require('bufferInterval'),
+      bufferDynamic: eventhubConfig.require('bufferDynamic'),
+      topic: eventhubConfig.require('topic'),
+      consumerGroup: eventhubConfig.require('consumerGroup'),
     },
+    service: null,
+    deployment: null,
   };
 }

--- a/packages/services/cdn-worker/src/dev-polyfill.ts
+++ b/packages/services/cdn-worker/src/dev-polyfill.ts
@@ -18,7 +18,6 @@ if (!globalThis.crypto) {
 
 export const devStorage = new Map<string, string>();
 
-// eslint-disable-next-line no-process-env
 (globalThis as any).HIVE_DATA = devStorage;
 // eslint-disable-next-line no-process-env
 (globalThis as any).S3_ENDPOINT = process.env.S3_ENDPOINT || '';

--- a/packages/services/tokens/src/index.ts
+++ b/packages/services/tokens/src/index.ts
@@ -98,19 +98,9 @@ export async function main() {
       await shutdown();
     });
 
-    const tokenReadFailuresCache = LRU<
-      | {
-          type: 'error';
-          error: string;
-          checkAt: number;
-        }
-      | {
-          type: 'not-found';
-          checkAt: number;
-        }
-    >(200);
     // Cache failures for 1 minute
     const errorCachingInterval = ms('1m');
+    const tokenReadFailuresCache = LRU<string>(1000, errorCachingInterval);
 
     registerShutdown({
       logger: server.log,
@@ -123,7 +113,6 @@ export async function main() {
         router: tokensApiRouter,
         createContext({ req }: CreateFastifyContextOptions): Context {
           return {
-            errorCachingInterval,
             logger: req.log,
             errorHandler,
             getStorage,

--- a/packages/services/tokens/src/metrics.ts
+++ b/packages/services/tokens/src/metrics.ts
@@ -1,0 +1,16 @@
+import { metrics } from '@hive/service-common';
+
+export const cacheHits = new metrics.Counter({
+  name: 'tokens_cache_hits',
+  help: 'Number of cache hits',
+});
+
+export const cacheMisses = new metrics.Counter({
+  name: 'tokens_cache_misses',
+  help: 'Number of cache misses',
+});
+
+export const cacheInvalidations = new metrics.Counter({
+  name: 'tokens_cache_invalidations',
+  help: 'Number of cache invalidations',
+});

--- a/packages/services/tokens/src/storage.ts
+++ b/packages/services/tokens/src/storage.ts
@@ -15,8 +15,8 @@ export interface StorageItem {
 
 export interface Storage {
   destroy(): Promise<void>;
-  readTarget(targetId: string, res?: FastifyReply): Promise<StorageItem[]>;
-  readToken(token: string, res?: FastifyReply): Promise<StorageItem | null>;
+  readTarget(targetId: string): Promise<StorageItem[]>;
+  readToken(token: string): Promise<StorageItem | null>;
   writeToken(item: Omit<StorageItem, 'date' | 'lastUsedAt'>): Promise<StorageItem>;
   deleteToken(token: string): Promise<void>;
   touchTokens(tokens: Array<{ token: string; date: Date }>): Promise<void>;

--- a/packages/services/tokens/src/storage.ts
+++ b/packages/services/tokens/src/storage.ts
@@ -15,9 +15,9 @@ export interface StorageItem {
 export interface Storage {
   destroy(): Promise<void>;
   readTarget(targetId: string): Promise<StorageItem[]>;
-  readToken(token: string): Promise<StorageItem | null>;
+  readToken(hashedToken: string): Promise<StorageItem | null>;
   writeToken(item: Omit<StorageItem, 'date' | 'lastUsedAt'>): Promise<StorageItem>;
-  deleteToken(token: string): Promise<void>;
+  deleteToken(hashedToken: string): Promise<void>;
   touchTokens(tokens: Array<{ token: string; date: Date }>): Promise<void>;
 }
 

--- a/packages/services/tokens/src/storage.ts
+++ b/packages/services/tokens/src/storage.ts
@@ -1,4 +1,3 @@
-import type { FastifyReply } from 'fastify';
 import { createConnectionString, createTokenStorage, tokens } from '@hive/storage';
 
 export interface StorageItem {


### PR DESCRIPTION
- An LRU cache for exceptions no longer stores 404.
- cache hit/miss metrics cover exceptions as well
- fix incorrect ttl in the in-memory cache (it was 60ms)