### PR TITLE
Use latest `buildx` 

### DIFF
--- a/.github/workflows/build-and-dockerize.yaml
+++ b/.github/workflows/build-and-dockerize.yaml
@@ -85,11 +85,6 @@ jobs:
       - name: configure docker buildx
         if: ${{ inputs.dockerize }}
         uses: docker/setup-buildx-action@v2
-        with:
-          # needed because of https://github.com/docker/build-push-action/issues/761
-          # it's better to pin to a version that works for us
-          driver-opts: |
-            image=moby/buildkit:v0.10.6
 
       - name: login to docker registry
         if: ${{ inputs.dockerize }}


### PR DESCRIPTION
https://github.com/docker/build-push-action/issues/761 was fixed, so we can drop the versioning pinning 