### PR TITLE
chore: move integration-tests to use the client preset

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -143,6 +143,6 @@ generates:
       - typescript-operations
 
   # Integration tests
-  ./integration-tests/testkit/gql:
+  ./integration-tests/testkit/gql/:
     documents: ./integration-tests/(testkit|tests)/**/*.ts
-    preset: gql-tag-operations-preset
+    preset: client-preset

--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -1,5 +1,5 @@
-import { gql } from '@app/gql';
 import { fetch } from '@whatwg-node/fetch';
+import { graphql } from './gql';
 import type {
   AnswerOrganizationTransferRequestInput,
   CreateOrganizationInput,
@@ -38,7 +38,7 @@ export function waitFor(ms: number) {
 
 export function createOrganization(input: CreateOrganizationInput, authToken: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation createOrganization($input: CreateOrganizationInput!) {
         createOrganization(input: $input) {
           ok {
@@ -74,7 +74,7 @@ export function createOrganization(input: CreateOrganizationInput, authToken: st
 
 export function getOrganization(organizationId: string, authToken: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       query getOrganization($organizationId: ID!) {
         organization(selector: { organization: $organizationId }) {
           organization {
@@ -103,7 +103,7 @@ export function getOrganization(organizationId: string, authToken: string) {
 
 export function inviteToOrganization(input: InviteToOrganizationByEmailInput, authToken: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation inviteToOrganization($input: InviteToOrganizationByEmailInput!) {
         inviteToOrganizationByEmail(input: $input) {
           ok {
@@ -128,7 +128,7 @@ export function inviteToOrganization(input: InviteToOrganizationByEmailInput, au
 
 export function renameOrganization(input: UpdateOrganizationNameInput, authToken: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation updateOrganizationName($input: UpdateOrganizationNameInput!) {
         updateOrganizationName(input: $input) {
           ok {
@@ -158,7 +158,7 @@ export function renameOrganization(input: UpdateOrganizationNameInput, authToken
 
 export function joinOrganization(code: string, authToken: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation joinOrganization($code: String!) {
         joinOrganization(code: $code) {
           __typename
@@ -190,7 +190,7 @@ export function joinOrganization(code: string, authToken: string) {
 
 export function getOrganizationMembers(selector: OrganizationSelectorInput, authToken: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       query getOrganizationMembers($selector: OrganizationSelectorInput!) {
         organization(selector: $selector) {
           organization {
@@ -221,7 +221,7 @@ export function getOrganizationTransferRequest(
   authToken: string,
 ) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       query getOrganizationTransferRequest($selector: OrganizationTransferRequestSelector!) {
         organizationTransferRequest(selector: $selector) {
           organization {
@@ -242,7 +242,7 @@ export function requestOrganizationTransfer(
   authToken: string,
 ) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation requestOrganizationTransfer($input: RequestOrganizationTransferInput!) {
         requestOrganizationTransfer(input: $input) {
           ok {
@@ -267,7 +267,7 @@ export function answerOrganizationTransferRequest(
   authToken: string,
 ) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation answerOrganizationTransferRequest($input: AnswerOrganizationTransferRequestInput!) {
         answerOrganizationTransferRequest(input: $input) {
           ok {
@@ -288,7 +288,7 @@ export function answerOrganizationTransferRequest(
 
 export function createProject(input: CreateProjectInput, authToken: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation createProject($input: CreateProjectInput!) {
         createProject(input: $input) {
           ok {
@@ -314,7 +314,7 @@ export function createProject(input: CreateProjectInput, authToken: string) {
 
 export function renameProject(input: UpdateProjectNameInput, authToken: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation updateProjectName($input: UpdateProjectNameInput!) {
         updateProjectName(input: $input) {
           ok {
@@ -343,7 +343,7 @@ export function renameProject(input: UpdateProjectNameInput, authToken: string) 
 
 export function createTarget(input: CreateTargetInput, authToken: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation createTarget($input: CreateTargetInput!) {
         createTarget(input: $input) {
           ok {
@@ -367,7 +367,7 @@ export function createTarget(input: CreateTargetInput, authToken: string) {
 
 export function renameTarget(input: UpdateTargetNameInput, authToken: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation updateTargetName($input: UpdateTargetNameInput!) {
         updateTargetName(input: $input) {
           ok {
@@ -397,7 +397,7 @@ export function renameTarget(input: UpdateTargetNameInput, authToken: string) {
 
 export function createToken(input: CreateTokenInput, authToken: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation createToken($input: CreateTokenInput!) {
         createToken(input: $input) {
           ok {
@@ -418,7 +418,7 @@ export function createToken(input: CreateTokenInput, authToken: string) {
 
 export function deleteTokens(input: DeleteTokensInput, authToken: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation deleteTokens($input: DeleteTokensInput!) {
         deleteTokens(input: $input) {
           deletedTokens
@@ -434,7 +434,7 @@ export function deleteTokens(input: DeleteTokensInput, authToken: string) {
 
 export function readTokenInfo(token: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       query readTokenInfo {
         tokenInfo {
           __typename
@@ -470,7 +470,7 @@ export function readTokenInfo(token: string) {
 
 export function updateMemberAccess(input: OrganizationMemberAccessInput, authToken: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation updateOrganizationMemberAccess($input: OrganizationMemberAccessInput!) {
         updateOrganizationMemberAccess(input: $input) {
           organization {
@@ -503,7 +503,7 @@ export function publishSchema(
   authHeader?: 'x-api-token' | 'authorization',
 ) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation schemaPublish($input: SchemaPublishInput!) {
         schemaPublish(input: $input) {
           __typename
@@ -550,7 +550,7 @@ export function publishSchema(
 
 export function checkSchema(input: SchemaCheckInput, token: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation schemaCheck($input: SchemaCheckInput!) {
         schemaCheck(input: $input) {
           ... on SchemaCheckSuccess {
@@ -602,7 +602,7 @@ export function setTargetValidation(
       },
 ) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation setTargetValidation($input: SetTargetValidationInput!) {
         setTargetValidation(input: $input) {
           enabled
@@ -630,7 +630,7 @@ export function updateTargetValidationSettings(
       },
 ) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation updateTargetValidationSettings($input: UpdateTargetValidationSettingsInput!) {
         updateTargetValidationSettings(input: $input) {
           ok {
@@ -664,7 +664,7 @@ export function updateTargetValidationSettings(
 
 export function updateBaseSchema(input: UpdateBaseSchemaInput, token: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation updateBaseSchema($input: UpdateBaseSchemaInput!) {
         updateBaseSchema(input: $input) {
           __typename
@@ -680,7 +680,7 @@ export function updateBaseSchema(input: UpdateBaseSchemaInput, token: string) {
 
 export function readOperationsStats(input: OperationsStatsSelectorInput, token: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       query readOperationsStats($input: OperationsStatsSelectorInput!) {
         operationsStats(selector: $input) {
           totalOperations
@@ -712,7 +712,7 @@ export function readOperationsStats(input: OperationsStatsSelectorInput, token: 
 
 export function readOperationBody(selector: OperationBodyByHashInput, token: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       query readOperationBody($selector: OperationBodyByHashInput!) {
         operationBodyByHash(selector: $selector)
       }
@@ -726,7 +726,7 @@ export function readOperationBody(selector: OperationBodyByHashInput, token: str
 
 export function fetchLatestSchema(token: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       query latestVersion {
         latestVersion {
           baseSchema
@@ -751,7 +751,7 @@ export function fetchLatestSchema(token: string) {
 
 export function fetchLatestValidSchema(token: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       query latestValidVersion {
         latestValidVersion {
           id
@@ -776,7 +776,7 @@ export function fetchLatestValidSchema(token: string) {
 
 export function fetchVersions(selector: SchemaVersionsInput, limit: number, token: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       query schemaVersions($limit: Int!, $selector: SchemaVersionsInput!) {
         schemaVersions(selector: $selector, limit: $limit) {
           nodes {
@@ -808,7 +808,7 @@ export function fetchVersions(selector: SchemaVersionsInput, limit: number, toke
 
 export function publishPersistedOperations(input: PublishPersistedOperationInput[], token: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation publishPersistedOperations($input: [PublishPersistedOperationInput!]!) {
         publishPersistedOperations(input: $input) {
           summary {
@@ -834,7 +834,7 @@ export function publishPersistedOperations(input: PublishPersistedOperationInput
 
 export function updateSchemaVersionStatus(input: SchemaVersionUpdateInput, token: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation updateSchemaVersionStatus($input: SchemaVersionUpdateInput!) {
         updateSchemaVersionStatus(input: $input) {
           id
@@ -856,7 +856,7 @@ export function updateSchemaVersionStatus(input: SchemaVersionUpdateInput, token
 
 export function schemaSyncCDN(input: SchemaSyncCdnInput, token: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation schemaSyncCDN($input: SchemaSyncCDNInput!) {
         schemaSyncCDN(input: $input) {
           __typename
@@ -878,7 +878,7 @@ export function schemaSyncCDN(input: SchemaSyncCdnInput, token: string) {
 
 export function createCdnAccess(selector: TargetSelectorInput, token: string) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation createCdnAccessToken($input: CreateCdnAccessTokenInput!) {
         createCdnAccessToken(input: $input) {
           ok {
@@ -965,7 +965,7 @@ export async function updateOrgRateLimit(
   authToken: string,
 ) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation updateOrgRateLimit(
         $selector: OrganizationSelectorInput!
         $monthlyLimits: RateLimitInput!
@@ -988,7 +988,7 @@ export async function enableExternalSchemaComposition(
   token: string,
 ) {
   return execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       mutation enableExternalSchemaComposition($input: EnableExternalSchemaCompositionInput!) {
         enableExternalSchemaComposition(input: $input) {
           ok {

--- a/integration-tests/testkit/seed.ts
+++ b/integration-tests/testkit/seed.ts
@@ -1,4 +1,3 @@
-import { gql } from '@app/gql';
 import {
   OrganizationAccessScope,
   OrganizationType,
@@ -34,6 +33,7 @@ import {
   updateMemberAccess,
   updateSchemaVersionStatus,
 } from './flow';
+import { graphql } from './gql';
 import { execute } from './graphql';
 import { collect, CollectedOperation } from './usage';
 import { generateUnique } from './utils';
@@ -51,7 +51,7 @@ export function initSeed() {
         ownerToken,
         async createPersonalProject(projectType: ProjectType) {
           const orgs = await execute({
-            document: gql(/* GraphQL */ `
+            document: graphql(/* GraphQL */ `
               query myOrganizations {
                 organizations {
                   total

--- a/integration-tests/tests/api/artifacts-cdn.spec.ts
+++ b/integration-tests/tests/api/artifacts-cdn.spec.ts
@@ -13,7 +13,7 @@ import {
 } from '@aws-sdk/client-s3';
 import { createSupergraphManager } from '@graphql-hive/client';
 import { fetch } from '@whatwg-node/fetch';
-import { gql } from '../../testkit/gql';
+import { graphql } from '../../testkit/gql';
 import { execute } from '../../testkit/graphql';
 import { initSeed } from '../../testkit/seed';
 import { getServiceHost } from '../../testkit/utils';
@@ -468,7 +468,7 @@ runArtifactsCDNTests('API Mirror', { service: 'server', port: 8082, path: '/arti
 // runArtifactsCDNTests('Local CDN Mock', 'http://127.0.0.1:3004/artifacts/v1/');
 
 describe('CDN token', () => {
-  const TargetCDNAccessTokensQuery = gql(/* GraphQL */ `
+  const TargetCDNAccessTokensQuery = graphql(/* GraphQL */ `
     query TargetCDNAccessTokens($selector: TargetSelectorInput!, $after: String, $first: Int = 2) {
       target(selector: $selector) {
         cdnAccessTokens(first: $first, after: $after) {
@@ -490,7 +490,7 @@ describe('CDN token', () => {
     }
   `);
 
-  const DeleteCDNAccessTokenMutation = gql(/* GraphQL */ `
+  const DeleteCDNAccessTokenMutation = graphql(/* GraphQL */ `
     mutation DeleteCDNAccessToken($input: DeleteCdnAccessTokenInput!) {
       deleteCdnAccessToken(input: $input) {
         error {

--- a/integration-tests/tests/api/oidc-integrations/crud.spec.ts
+++ b/integration-tests/tests/api/oidc-integrations/crud.spec.ts
@@ -1,8 +1,8 @@
-import { gql } from '@app/gql';
+import { graphql } from '../../../testkit/gql';
 import { execute } from '../../../testkit/graphql';
 import { initSeed } from '../../../testkit/seed';
 
-const OrganizationWithOIDCIntegration = gql(/* GraphQL */ `
+const OrganizationWithOIDCIntegration = graphql(/* GraphQL */ `
   query OrganizationWithOIDCIntegration($organizationId: ID!) {
     organization(selector: { organization: $organizationId }) {
       organization {
@@ -15,7 +15,7 @@ const OrganizationWithOIDCIntegration = gql(/* GraphQL */ `
   }
 `);
 
-const CreateOIDCIntegrationMutation = gql(/* GraphQL */ `
+const CreateOIDCIntegrationMutation = graphql(/* GraphQL */ `
   mutation CreateOIDCIntegrationMutation($input: CreateOIDCIntegrationInput!) {
     createOIDCIntegration(input: $input) {
       ok {
@@ -393,7 +393,7 @@ describe('create', () => {
   });
 });
 
-const DeleteOIDCIntegrationMutation = gql(/* GraphQL */ `
+const DeleteOIDCIntegrationMutation = graphql(/* GraphQL */ `
   mutation DeleteOIDCIntegrationMutation($input: DeleteOIDCIntegrationInput!) {
     deleteOIDCIntegration(input: $input) {
       ok {
@@ -560,7 +560,7 @@ describe('delete', () => {
 
         const oidcIntegrationId = createResult.createOIDCIntegration.ok!.createdOIDCIntegration.id;
 
-        const MeQuery = gql(/* GraphQL */ `
+        const MeQuery = graphql(/* GraphQL */ `
           query Me {
             me {
               id
@@ -619,7 +619,7 @@ describe('delete', () => {
   });
 });
 
-const UpdateOIDCIntegrationMutation = gql(/* GraphQL */ `
+const UpdateOIDCIntegrationMutation = graphql(/* GraphQL */ `
   mutation UpdateOIDCIntegrationMutation($input: UpdateOIDCIntegrationInput!) {
     updateOIDCIntegration(input: $input) {
       ok {

--- a/integration-tests/tests/api/sign-up.spec.ts
+++ b/integration-tests/tests/api/sign-up.spec.ts
@@ -1,4 +1,3 @@
-import { gql } from '@app/gql';
 import { ProjectType } from '@app/gql/graphql';
 import type { RateLimitApi } from '@hive/rate-limit';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
@@ -8,6 +7,7 @@ import { waitFor } from '../../testkit/flow';
 import { execute } from '../../testkit/graphql';
 import { initSeed } from '../../testkit/seed';
 import { getServiceHost } from '../../testkit/utils';
+import { graphql } from './../../testkit/gql';
 
 const { fetch } = createFetch({
   useNodeFetch: true,
@@ -16,7 +16,7 @@ const { fetch } = createFetch({
 test.concurrent('should auto-create an organization for freshly signed-up user', async () => {
   const { ownerToken } = await initSeed().createOwner();
   const result = await execute({
-    document: gql(/* GraphQL */ `
+    document: graphql(/* GraphQL */ `
       query organizations {
         organizations {
           total
@@ -38,7 +38,7 @@ test.concurrent(
   async () => {
     const { ownerToken, createPersonalProject } = await initSeed().createOwner();
     const result = await execute({
-      document: gql(/* GraphQL */ `
+      document: graphql(/* GraphQL */ `
         query organizations {
           organizations {
             total
@@ -81,7 +81,7 @@ test.concurrent(
   async () => {
     const { ownerToken } = await initSeed().createOwner();
     const query1 = execute({
-      document: gql(/* GraphQL */ `
+      document: graphql(/* GraphQL */ `
         query organizations {
           organizations {
             total
@@ -95,7 +95,7 @@ test.concurrent(
       authToken: ownerToken,
     }).then(r => r.expectNoGraphQLErrors());
     const query2 = execute({
-      document: gql(/* GraphQL */ `
+      document: graphql(/* GraphQL */ `
         query organizations {
           organizations {
             total

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "@changesets/cli": "2.26.0",
     "@graphql-codegen/add": "3.2.3",
     "@graphql-codegen/cli": "2.16.2",
+    "@graphql-codegen/client-preset": "1.2.6",
     "@graphql-codegen/gql-tag-operations-preset": "1.7.3",
     "@graphql-codegen/graphql-modules-preset": "2.5.10",
     "@graphql-codegen/typed-document-node": "2.3.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,7 @@ importers:
       '@changesets/cli': 2.26.0
       '@graphql-codegen/add': 3.2.3
       '@graphql-codegen/cli': 2.16.2
+      '@graphql-codegen/client-preset': 1.2.6
       '@graphql-codegen/gql-tag-operations-preset': 1.7.3
       '@graphql-codegen/graphql-modules-preset': 2.5.10
       '@graphql-codegen/typed-document-node': 2.3.11
@@ -93,6 +94,7 @@ importers:
       '@changesets/cli': 2.26.0
       '@graphql-codegen/add': 3.2.3_graphql@16.6.0
       '@graphql-codegen/cli': 2.16.2_t5elcape4kbapibqctlhvvztse
+      '@graphql-codegen/client-preset': 1.2.6_graphql@16.6.0
       '@graphql-codegen/gql-tag-operations-preset': 1.7.3_graphql@16.6.0
       '@graphql-codegen/graphql-modules-preset': 2.5.10_graphql@16.6.0
       '@graphql-codegen/typed-document-node': 2.3.11_graphql@16.6.0
@@ -3158,6 +3160,7 @@ packages:
   /@babel/helper-plugin-utils/7.19.0:
     resolution: {integrity: sha512-40Ryx7I8mT+0gaNxm8JGTZFUITNqdLAgdg0hXzeVZxVD6nFsdhQvip6v8dqkRHzsz1VFpFAaOCHNn0vKBL7Czw==}
     engines: {node: '>=6.9.0'}
+    dev: true
 
   /@babel/helper-plugin-utils/7.20.2:
     resolution: {integrity: sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==}
@@ -3700,7 +3703,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-arrow-functions/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-9S9X9RUefzrsHZmKMbDXxweEH+YlE8JJEuat9FdvW9Qh1cw7W64jELCtWNkPBPX5En45uy28KGvA/AySqUh8CQ==}
@@ -4084,7 +4087,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.20.12
-      '@babel/helper-plugin-utils': 7.19.0
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-typescript': 7.18.6_@babel+core@7.20.12
     transitivePeerDependencies:
       - supports-color
@@ -6205,6 +6208,29 @@ packages:
       - utf-8-validate
     dev: true
 
+  /@graphql-codegen/client-preset/1.2.6_graphql@16.6.0:
+    resolution: {integrity: sha512-oOfcRicx2SZQAxsU4eNqlyxHxFUpo11lvQ5mkZFbttstxIRGBKQOg6d2INMtiHJ4YkpFhW41IpMWze1siJTq7w==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/template': 7.20.7
+      '@graphql-codegen/add': 3.2.3_graphql@16.6.0
+      '@graphql-codegen/gql-tag-operations': 1.6.1_graphql@16.6.0
+      '@graphql-codegen/plugin-helpers': 3.1.2_graphql@16.6.0
+      '@graphql-codegen/typed-document-node': 2.3.12_graphql@16.6.0
+      '@graphql-codegen/typescript': 2.8.7_graphql@16.6.0
+      '@graphql-codegen/typescript-operations': 2.5.12_graphql@16.6.0
+      '@graphql-codegen/visitor-plugin-common': 2.13.7_graphql@16.6.0
+      '@graphql-tools/utils': 9.1.4_graphql@16.6.0
+      '@graphql-typed-document-node/core': 3.1.1_graphql@16.6.0
+      graphql: 16.6.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
   /@graphql-codegen/core/2.6.8_graphql@16.6.0:
     resolution: {integrity: sha512-JKllNIipPrheRgl+/Hm/xuWMw9++xNQ12XJR/OHHgFopOg4zmN3TdlRSyYcv/K90hCFkkIwhlHFUQTfKrm8rxQ==}
     peerDependencies:
@@ -6246,6 +6272,22 @@ packages:
     dependencies:
       '@graphql-codegen/plugin-helpers': 3.1.2_graphql@16.6.0
       '@graphql-codegen/visitor-plugin-common': 2.13.6_graphql@16.6.0
+      '@graphql-tools/utils': 9.1.4_graphql@16.6.0
+      auto-bind: 4.0.0
+      graphql: 16.6.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
+  /@graphql-codegen/gql-tag-operations/1.6.1_graphql@16.6.0:
+    resolution: {integrity: sha512-d9u/WYdXBCGV0zL0wE6p/SQn6CiGdfhNcOIFfRCcYpbWTe9jpjyZ2VDYnNlQ5CiAPKNdly5hHTyBSfwJpcny9A==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 3.1.2_graphql@16.6.0
+      '@graphql-codegen/visitor-plugin-common': 2.13.7_graphql@16.6.0
       '@graphql-tools/utils': 9.1.4_graphql@16.6.0
       auto-bind: 4.0.0
       graphql: 16.6.0
@@ -6327,6 +6369,22 @@ packages:
       - supports-color
     dev: true
 
+  /@graphql-codegen/typed-document-node/2.3.12_graphql@16.6.0:
+    resolution: {integrity: sha512-0yoJIF7PhbgptSY48KMpTHzS5Abgks7ovxQB8yOQEE0IixCr1tSszkghiyvnNZou+YtqvlkgXLR1DA/v+HOdUg==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 3.1.2_graphql@16.6.0
+      '@graphql-codegen/visitor-plugin-common': 2.13.7_graphql@16.6.0
+      auto-bind: 4.0.0
+      change-case-all: 1.0.15
+      graphql: 16.6.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
   /@graphql-codegen/typescript-graphql-request/4.5.8_f45c35xnr66et7kv43kezet7ie:
     resolution: {integrity: sha512-XsuAA35Ou03LsklNgnIWXZ5HOHsJ5w1dBuDKtvqM9rD0cAI8x0f4TY0n6O1EraSBSvyHLP3npb1lOTPZzG2TjA==}
     peerDependencies:
@@ -6354,6 +6412,22 @@ packages:
       '@graphql-codegen/plugin-helpers': 3.1.2_graphql@16.6.0
       '@graphql-codegen/typescript': 2.8.6_graphql@16.6.0
       '@graphql-codegen/visitor-plugin-common': 2.13.6_graphql@16.6.0
+      auto-bind: 4.0.0
+      graphql: 16.6.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
+  /@graphql-codegen/typescript-operations/2.5.12_graphql@16.6.0:
+    resolution: {integrity: sha512-/w8IgRIQwmebixf514FOQp2jXOe7vxZbMiSFoQqJgEgzrr42joPsgu4YGU+owv2QPPmu4736OcX8FSavb7SLiA==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 3.1.2_graphql@16.6.0
+      '@graphql-codegen/typescript': 2.8.7_graphql@16.6.0
+      '@graphql-codegen/visitor-plugin-common': 2.13.7_graphql@16.6.0
       auto-bind: 4.0.0
       graphql: 16.6.0
       tslib: 2.4.1
@@ -6395,6 +6469,22 @@ packages:
       - supports-color
     dev: true
 
+  /@graphql-codegen/typescript/2.8.7_graphql@16.6.0:
+    resolution: {integrity: sha512-Nm5keWqIgg/VL7fivGmglF548tJRP2ttSmfTMuAdY5GNGTJTVZOzNbIOfnbVEDMMWF4V+quUuSyeUQ6zRxtX1w==}
+    peerDependencies:
+      graphql: ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 3.1.2_graphql@16.6.0
+      '@graphql-codegen/schema-ast': 2.6.1_graphql@16.6.0
+      '@graphql-codegen/visitor-plugin-common': 2.13.7_graphql@16.6.0
+      auto-bind: 4.0.0
+      graphql: 16.6.0
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
   /@graphql-codegen/visitor-plugin-common/2.13.1_graphql@16.6.0:
     resolution: {integrity: sha512-mD9ufZhDGhyrSaWQGrU1Q1c5f01TeWtSWy/cDwXYjJcHIj1Y/DG2x0tOflEfCvh5WcnmHNIw4lzDsg1W7iFJEg==}
     peerDependencies:
@@ -6418,6 +6508,27 @@ packages:
 
   /@graphql-codegen/visitor-plugin-common/2.13.6_graphql@16.6.0:
     resolution: {integrity: sha512-jDxbS8CZIu3KPqku1NzkVkCvPy4UUxhmtRz+yyG3W6go/3hq/VG/yx3ljhI7jYT08W9yaFCUzczimS9fM+Qanw==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@graphql-codegen/plugin-helpers': 3.1.2_graphql@16.6.0
+      '@graphql-tools/optimize': 1.3.1_graphql@16.6.0
+      '@graphql-tools/relay-operation-optimizer': 6.5.6_graphql@16.6.0
+      '@graphql-tools/utils': 9.1.4_graphql@16.6.0
+      auto-bind: 4.0.0
+      change-case-all: 1.0.15
+      dependency-graph: 0.11.0
+      graphql: 16.6.0
+      graphql-tag: 2.12.6_graphql@16.6.0
+      parse-filepath: 1.0.2
+      tslib: 2.4.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
+  /@graphql-codegen/visitor-plugin-common/2.13.7_graphql@16.6.0:
+    resolution: {integrity: sha512-xE6iLDhr9sFM1qwCGJcCXRu5MyA0moapG2HVejwyAXXLubYKYwWnoiEigLH2b5iauh6xsl6XP8hh9D1T1dn5Cw==}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:


### PR DESCRIPTION
### Background

Client preset is now our recommended way of doing codegen.

### Description

See https://the-guild.dev/graphql/codegen/docs/guides/api-testing

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [x] Testing
