### PR TITLE
Log errors in tRPC servers

### DIFF
--- a/packages/services/emails/src/api.ts
+++ b/packages/services/emails/src/api.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { handleTRPCError } from '@hive/service-common';
 import type { inferRouterInputs } from '@trpc/server';
 import { initTRPC } from '@trpc/server';
 import type { Context } from './context';
@@ -7,19 +8,20 @@ import { renderEmailVerificationEmail } from './templates/email-verification';
 import { renderPasswordResetEmail } from './templates/password-reset';
 
 const t = initTRPC.context<Context>().create();
+const procedure = t.procedure.use(t.middleware(handleTRPCError));
 
 export const emailsApiRouter = t.router({
-  schedule: t.procedure.input(EmailInputShape).mutation(async ({ ctx, input }) => {
+  schedule: procedure.input(EmailInputShape).mutation(async ({ ctx, input }) => {
     try {
       const job = await ctx.schedule(input);
 
       return { job: job.id ?? 'unknown' };
     } catch (error) {
-      ctx.errorHandler('Failed to schedule an email', error as Error, ctx.logger);
+      ctx.errorHandler('Failed to schedule an email', error as Error);
       throw error;
     }
   }),
-  sendEmailVerificationEmail: t.procedure
+  sendEmailVerificationEmail: procedure
     .input(
       z.object({
         user: z.object({
@@ -45,11 +47,11 @@ export const emailsApiRouter = t.router({
 
         return { job: job.id ?? 'unknown' };
       } catch (error) {
-        ctx.errorHandler('Failed to schedule an email', error as Error, ctx.logger);
+        ctx.errorHandler('Failed to schedule an email', error as Error);
         throw error;
       }
     }),
-  sendPasswordResetEmail: t.procedure
+  sendPasswordResetEmail: procedure
     .input(
       z.object({
         user: z.object({
@@ -74,7 +76,7 @@ export const emailsApiRouter = t.router({
         });
         return { job: job.id ?? 'unknown' };
       } catch (error) {
-        ctx.errorHandler('Failed to schedule an email', error as Error, ctx.logger);
+        ctx.errorHandler('Failed to schedule an email', error as Error);
         throw error;
       }
     }),

--- a/packages/services/emails/src/context.ts
+++ b/packages/services/emails/src/context.ts
@@ -1,9 +1,9 @@
 import type { Job } from 'bullmq';
-import type { FastifyLoggerInstance } from '@hive/service-common';
+import type { FastifyRequest } from '@hive/service-common';
 import type { EmailInput } from './shapes';
 
 export type Context = {
-  logger: FastifyLoggerInstance;
-  errorHandler(message: string, error: Error, logger?: FastifyLoggerInstance | undefined): void;
+  req: FastifyRequest;
+  errorHandler(message: string, error: Error): void;
   schedule(input: EmailInput): Promise<Job<any, any, string>>;
 };

--- a/packages/services/server/src/api.ts
+++ b/packages/services/server/src/api.ts
@@ -9,19 +9,23 @@ import {
   reservedOrganizationNames,
   TargetAccessScope,
 } from '@hive/api';
+import { FastifyRequest, handleTRPCError } from '@hive/service-common';
 import type { inferAsyncReturnType } from '@trpc/server';
 import { initTRPC } from '@trpc/server';
 
 export async function createContext({
   storage,
   crypto,
+  req,
 }: {
   storage: Storage;
   crypto: CryptoProvider;
+  req: FastifyRequest;
 }) {
   return {
     storage,
     crypto,
+    req,
   };
 }
 
@@ -35,9 +39,11 @@ const oidcDefaultScopes = [
 ];
 
 const t = initTRPC.context<Context>().create();
+const errorMiddleware = t.middleware(handleTRPCError);
+const procedure = t.procedure.use(errorMiddleware);
 
 export const internalApiRouter = t.router({
-  ensureUser: t.procedure
+  ensureUser: procedure
     .input(
       z
         .object({
@@ -62,7 +68,7 @@ export const internalApiRouter = t.router({
 
       return result;
     }),
-  getDefaultOrgForUser: t.procedure
+  getDefaultOrgForUser: procedure
     .input(
       z.object({
         superTokensUserId: z.string(),
@@ -118,7 +124,7 @@ export const internalApiRouter = t.router({
 
       return null;
     }),
-  getOIDCIntegrationById: t.procedure
+  getOIDCIntegrationById: procedure
     .input(
       z.object({
         oidcIntegrationId: z.string().min(1),

--- a/packages/services/server/src/index.ts
+++ b/packages/services/server/src/index.ts
@@ -13,13 +13,13 @@ import { createIsKeyValid } from '@hive/cdn-script/key-validation';
 import {
   createServer,
   registerShutdown,
+  registerTRPC,
   reportReadiness,
   startMetrics,
 } from '@hive/service-common';
 import { createConnectionString, createStorage as createPostgreSQLStorage } from '@hive/storage';
 import { Dedupe, ExtraErrorData } from '@sentry/integrations';
 import * as Sentry from '@sentry/node';
-import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
 import { createServerAdapter } from '@whatwg-node/server';
 import { createContext, internalApiRouter } from './api';
 import { asyncStorage } from './async-storage';
@@ -257,13 +257,10 @@ export async function main() {
 
     const crypto = new CryptoProvider(env.encryptionSecret);
 
-    await server.register(fastifyTRPCPlugin, {
-      prefix: '/trpc',
-      trpcOptions: {
-        router: internalApiRouter,
-        createContext() {
-          return createContext({ storage, crypto });
-        },
+    await registerTRPC(server, {
+      router: internalApiRouter,
+      createContext({ req }) {
+        return createContext({ storage, crypto, req });
       },
     });
 

--- a/packages/services/service-common/package.json
+++ b/packages/services/service-common/package.json
@@ -7,7 +7,8 @@
   "peerDependencies": {
     "@sentry/node": "^7.0.0",
     "@sentry/tracing": "^7.0.0",
-    "@sentry/utils": "^7.0.0"
+    "@sentry/utils": "^7.0.0",
+    "@trpc/server": "10.9.0"
   },
   "dependencies": {
     "@whatwg-node/fetch": "0.6.2",

--- a/packages/services/service-common/src/fastify.ts
+++ b/packages/services/service-common/src/fastify.ts
@@ -4,7 +4,7 @@ import * as Sentry from '@sentry/node';
 import { useRequestLogging } from './request-logs';
 import { useSentryTracing } from './sentry';
 
-export type { FastifyLoggerInstance } from 'fastify';
+export type { FastifyLoggerInstance, FastifyRequest } from 'fastify';
 
 export async function createServer(options: {
   tracing: boolean;

--- a/packages/services/service-common/src/index.ts
+++ b/packages/services/service-common/src/index.ts
@@ -1,7 +1,8 @@
 export { createServer } from './fastify';
-export type { FastifyLoggerInstance } from './fastify';
+export type { FastifyLoggerInstance, FastifyRequest } from './fastify';
 export * from './errors';
 export * from './metrics';
 export * from './heartbeats';
+export * from './trpc';
 export { registerShutdown } from './graceful-shutdown';
 export { cleanRequestId } from './helpers';

--- a/packages/services/service-common/src/trpc.ts
+++ b/packages/services/service-common/src/trpc.ts
@@ -1,0 +1,58 @@
+import type { FastifyInstance, FastifyRequest } from 'fastify';
+import * as Sentry from '@sentry/node';
+import type { AnyRouter } from '@trpc/server';
+import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
+import type { CreateFastifyContextOptions } from '@trpc/server/adapters/fastify';
+
+export function registerTRPC<TRouter extends AnyRouter, TContext>(
+  server: FastifyInstance,
+  {
+    router,
+    createContext,
+  }: {
+    router: TRouter;
+    createContext: (options: CreateFastifyContextOptions) => TContext;
+  },
+) {
+  return server.register(fastifyTRPCPlugin, {
+    prefix: '/trpc',
+    trpcOptions: {
+      router,
+      createContext,
+    },
+  });
+}
+
+export async function handleTRPCError<
+  TNextResult extends
+    | {
+        ok: false;
+        error: {
+          message: string;
+        };
+      }
+    | {
+        ok: true;
+      },
+  T extends {
+    next(): Promise<TNextResult>;
+    ctx: {
+      req: FastifyRequest;
+    };
+    path: string;
+  },
+>({ next, ctx, path }: T): Promise<TNextResult> {
+  const result = await next();
+
+  if (!result.ok) {
+    Sentry.captureException(result.error, {
+      tags: {
+        path,
+        request_id: ctx.req.id,
+      },
+    });
+    ctx.req.log.error(result.error.message);
+  }
+
+  return result;
+}

--- a/packages/services/stripe-billing/src/api.ts
+++ b/packages/services/stripe-billing/src/api.ts
@@ -1,6 +1,7 @@
 import { addDays, startOfMonth } from 'date-fns';
 import { Stripe } from 'stripe';
 import { z } from 'zod';
+import { FastifyRequest, handleTRPCError } from '@hive/service-common';
 import { createStorage } from '@hive/storage';
 import type { inferRouterInputs } from '@trpc/server';
 import { initTRPC } from '@trpc/server';
@@ -12,17 +13,20 @@ export type Context = {
     operationsPrice: Stripe.Price;
     basePrice: Stripe.Price;
   }>;
+  req: FastifyRequest;
 };
 
 export { Stripe as StripeTypes };
 
 const t = initTRPC.context<Context>().create();
+const errorMiddleware = t.middleware(handleTRPCError);
+const procedure = t.procedure.use(errorMiddleware);
 
 export const stripeBillingApiRouter = t.router({
-  availablePrices: t.procedure.query(async ({ ctx }) => {
+  availablePrices: procedure.query(async ({ ctx }) => {
     return await ctx.stripeData$;
   }),
-  invoices: t.procedure
+  invoices: procedure
     .input(
       z.object({
         organizationId: z.string().nonempty(),
@@ -44,7 +48,7 @@ export const stripeBillingApiRouter = t.router({
 
       return invoices.data;
     }),
-  upcomingInvoice: t.procedure
+  upcomingInvoice: procedure
     .input(
       z.object({
         organizationId: z.string().nonempty(),
@@ -70,7 +74,7 @@ export const stripeBillingApiRouter = t.router({
         return null;
       }
     }),
-  activeSubscription: t.procedure
+  activeSubscription: procedure
     .input(
       z.object({
         organizationId: z.string().nonempty(),
@@ -116,7 +120,7 @@ export const stripeBillingApiRouter = t.router({
         subscription: actualSubscription,
       };
     }),
-  syncOrganizationToStripe: t.procedure
+  syncOrganizationToStripe: procedure
     .input(
       z.object({
         organizationId: z.string().nonempty(),
@@ -175,7 +179,7 @@ export const stripeBillingApiRouter = t.router({
         );
       }
     }),
-  cancelSubscriptionForOrganization: t.procedure
+  cancelSubscriptionForOrganization: procedure
     .input(
       z.object({
         organizationId: z.string().nonempty(),
@@ -212,7 +216,7 @@ export const stripeBillingApiRouter = t.router({
 
       return response;
     }),
-  createSubscriptionForOrganization: t.procedure
+  createSubscriptionForOrganization: procedure
     .input(
       z.object({
         paymentMethodId: z.string().nullish(),

--- a/packages/services/usage-estimator/src/api.ts
+++ b/packages/services/usage-estimator/src/api.ts
@@ -1,4 +1,6 @@
 import { z } from 'zod';
+import { handleTRPCError } from '@hive/service-common';
+import type { FastifyRequest } from '@hive/service-common';
 import type { inferRouterInputs, inferRouterOutputs } from '@trpc/server';
 import { initTRPC } from '@trpc/server';
 import type { Estimator } from './estimator';
@@ -12,10 +14,19 @@ const TARGET_BASED_FILTER = {
   targetIds: z.array(z.string().nonempty()),
 };
 
-const t = initTRPC.context<Estimator>().create();
+export function createContext(estimator: Estimator, req: FastifyRequest) {
+  return {
+    estimator,
+    req,
+  };
+}
+
+const t = initTRPC.context<ReturnType<typeof createContext>>().create();
+const errorMiddleware = t.middleware(handleTRPCError);
+const procedure = t.procedure.use(errorMiddleware);
 
 export const usageEstimatorApiRouter = t.router({
-  estimateOperationsForTarget: t.procedure
+  estimateOperationsForTarget: procedure
     .input(
       z
         .object({
@@ -25,7 +36,7 @@ export const usageEstimatorApiRouter = t.router({
         .required(),
     )
     .query(async ({ ctx, input }) => {
-      const estimationResponse = await ctx.estimateCollectedOperationsForTargets({
+      const estimationResponse = await ctx.estimator.estimateCollectedOperationsForTargets({
         targets: input.targetIds,
         startTime: new Date(input.startTime),
         endTime: new Date(input.endTime),
@@ -35,10 +46,10 @@ export const usageEstimatorApiRouter = t.router({
         totalOperations: parseInt(estimationResponse.data[0].total),
       };
     }),
-  estimateOperationsForAllTargets: t.procedure
+  estimateOperationsForAllTargets: procedure
     .input(z.object(DATE_RANGE_VALIDATION).required())
     .query(async ({ ctx, input }) => {
-      const estimationResponse = await ctx.estimateOperationsForAllTargets({
+      const estimationResponse = await ctx.estimator.estimateOperationsForAllTargets({
         startTime: new Date(input.startTime),
         endTime: new Date(input.endTime),
       });

--- a/packages/services/webhooks/src/index.ts
+++ b/packages/services/webhooks/src/index.ts
@@ -3,13 +3,12 @@ import {
   createErrorHandler,
   createServer,
   registerShutdown,
+  registerTRPC,
   reportReadiness,
   startHeartbeats,
   startMetrics,
 } from '@hive/service-common';
 import * as Sentry from '@sentry/node';
-import type { CreateFastifyContextOptions } from '@trpc/server/adapters/fastify';
-import { fastifyTRPCPlugin } from '@trpc/server/adapters/fastify';
 import { webhooksApiRouter } from './api';
 import { env } from './environment';
 import { createScheduler } from './scheduler';
@@ -69,13 +68,10 @@ async function main() {
       },
     });
 
-    await server.register(fastifyTRPCPlugin, {
-      prefix: '/trpc',
-      trpcOptions: {
-        router: webhooksApiRouter,
-        createContext({ req }: CreateFastifyContextOptions): Context {
-          return { logger: req.log, errorHandler, schedule };
-        },
+    await registerTRPC(server, {
+      router: webhooksApiRouter,
+      createContext({ req }): Context {
+        return { req, errorHandler, schedule };
       },
     });
 

--- a/packages/services/webhooks/src/types.ts
+++ b/packages/services/webhooks/src/types.ts
@@ -1,5 +1,5 @@
 import type { Job } from 'bullmq';
-import type { FastifyLoggerInstance } from '@hive/service-common';
+import type { FastifyLoggerInstance, FastifyRequest } from '@hive/service-common';
 import type { WebhookInput } from './scheduler';
 
 export interface Config {
@@ -19,7 +19,7 @@ export interface Config {
 }
 
 export type Context = {
-  logger: FastifyLoggerInstance;
+  req: FastifyRequest;
   errorHandler(message: string, error: Error, logger?: FastifyLoggerInstance | undefined): void;
   schedule(webhook: WebhookInput): Promise<Job<any, any, string>>;
 };


### PR DESCRIPTION
Make sure we use `req.log` to get the `x-request-id` header value in the log line.
Share a function to register `/trpc` server (better type safety, less boilerplate).