### PR TITLE
Add user-agent and content-type headers to response from Broker

### DIFF
--- a/packages/services/broker-worker/src/handler.ts
+++ b/packages/services/broker-worker/src/handler.ts
@@ -40,8 +40,11 @@ export async function handleRequest(request: Request, keyValidator: typeof isSig
   const response = await fetch(parsedRequest.url, init);
   const text = await gatherResponse(response);
   return new Response(text, {
-    ...init,
     status: response.status,
     statusText: response.statusText,
+    headers: {
+      'content-type': 'text/plain',
+      'user-agent': 'Hive Broker',
+    },
   });
 }

--- a/packages/services/webhooks/src/jobs.ts
+++ b/packages/services/webhooks/src/jobs.ts
@@ -35,7 +35,7 @@ export function createWebhookJob({ config }: { config: Config }) {
       config.logger.debug(
         'Calling webhook (job=%s, attempt=%d of %d)',
         job.name,
-        job.attemptsMade + 1,
+        job.attemptsMade,
         config.maxAttempts,
       );
 


### PR DESCRIPTION
Makes sure we use the correct content-type header value and give us some indicator that the request was proxied through Broker.