### PR TITLE
Fix port's default value in external-composition docker image

### DIFF
--- a/packages/services/external-composition/federation-2/package.json
+++ b/packages/services/external-composition/federation-2/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "bob runify --single",
-    "dev": "tsup-node src/dev.ts --format esm --shims --target node18 --watch --sourcemap --onSuccess 'node --enable-source-maps dist/dev.js' | pino-pretty --translateTime HH:MM:ss TT --ignore pid,hostname"
+    "dev": "tsup-node src/index.ts --format esm --shims --target node18 --watch --sourcemap --onSuccess 'node --enable-source-maps dist/index.js' | pino-pretty --translateTime HH:MM:ss TT --ignore pid,hostname"
   },
   "dependencies": {
     "@apollo/composition": "^2.2.2",

--- a/packages/services/external-composition/federation-2/src/environment.ts
+++ b/packages/services/external-composition/federation-2/src/environment.ts
@@ -11,7 +11,7 @@ const BaseSchema = zod.object({
   NODE_ENV: zod.string().default('production'),
   ENVIRONMENT: zod.string().default('production'),
   RELEASE: zod.string().default(''),
-  PORT: zod.coerce.number(),
+  PORT: zod.coerce.number().default(3069),
   SECRET: zod.string(),
 });
 
@@ -40,7 +40,7 @@ export function resolveEnv(env: Record<string, string | undefined>) {
     environment: base.ENVIRONMENT,
     release: base.RELEASE ?? 'local',
     http: {
-      port: base.PORT ?? 3069,
+      port: base.PORT,
     },
     secret: base.SECRET,
   };

--- a/packages/web/docs/src/pages/features/external-schema-composition.mdx
+++ b/packages/web/docs/src/pages/features/external-schema-composition.mdx
@@ -260,7 +260,7 @@ will be used as private key to hash the requests to your composition service.
 To run the container, you can use the following command:
 
 ```
-docker run -p 3069 -e SECRET="MY_SECRET_HERE" ghcr.io/kamilkisiela/graphql-hive/composition-federation-2
+docker run -p 3069:3069 -e SECRET="MY_SECRET_HERE" ghcr.io/kamilkisiela/graphql-hive/composition-federation-2
 ```
 
 You should make this service publicly available, and then configure it in Hive platform (see


### PR DESCRIPTION
It was `0` by default (when parsed by Zod) and then the `??` operator didn't do anything because `0` is not `null` or `undefined`.
Now it's `3069` by default if no value is provided.