### PR TITLE
Add cdn:fetch to cli

### DIFF
--- a/.changeset/beige-poets-add.md
+++ b/.changeset/beige-poets-add.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': minor
+---
+
+Add cdn:fetch to Hive CLI

--- a/packages/libraries/cli/README.md
+++ b/packages/libraries/cli/README.md
@@ -322,12 +322,16 @@ You can use the `HIVE_CONFIG` environment variable to define the path to the JSO
 
 Note that the CLI args will override the values in config if both are specified.
 
+The configuration input priority is: CLI args > environment variables > hive.json configuration.
+
 This is how the structure of the config file should look like:
 
 ```json
 {
   "registry": "<yourRegistryURL>",
-  "token": "<yourtoken>"
+  "token": "<yourToken>",
+  "cdn.token": "<yourCdnURL>",
+  "cdn.endpoint": "<yourCdnToken>"
 }
 ```
 

--- a/packages/libraries/cli/hive.json
+++ b/packages/libraries/cli/hive.json
@@ -1,4 +1,6 @@
 {
   "registry": "http://localhost:8082/graphql",
-  "token": "f3b6afd4c6959809421f3099ef9b98aa"
+  "token": "f3b6afd4c6959809421f3099ef9b98aa",
+  "cdn.token": "your_token",
+  "cdn.endpoint": "your_cdn_endpoint"
 }

--- a/packages/libraries/cli/package.json
+++ b/packages/libraries/cli/package.json
@@ -55,6 +55,7 @@
     "@oclif/core": "^1.23.0",
     "@oclif/plugin-help": "5.2.2",
     "@oclif/plugin-update": "3.1.1",
+    "@whatwg-node/fetch": "^0.6.0",
     "colors": "1.4.0",
     "env-ci": "7.3.0",
     "git-parse": "3.0.1",

--- a/packages/libraries/cli/src/base-command.ts
+++ b/packages/libraries/cli/src/base-command.ts
@@ -57,17 +57,23 @@ export default abstract class extends Command {
     TKey extends keyof TArgs,
   >({
     key,
+    path: inputPath,
     args,
     defaultValue,
     message,
     env,
   }: {
+    /** The cli configuration identifier, e.g `--token` */
     key: TKey;
+    /** The path to key in hive.json (optional, defaults to key) */
+    path?: TKey;
     args: TArgs;
     defaultValue?: TArgs[TKey] | null;
     message?: string;
     env?: string;
   }): NonNullable<TArgs[TKey]> | never {
+    const path: string = (inputPath ?? key) as string;
+
     if (args[key]) {
       return args[key];
     }
@@ -78,8 +84,8 @@ export default abstract class extends Command {
       return process.env[env] as TArgs[TKey];
     }
 
-    if (this._userConfig.has(key as string)) {
-      return this._userConfig.get(key as string);
+    if (this._userConfig.has(path)) {
+      return this._userConfig.get(path);
     }
 
     if (defaultValue) {

--- a/packages/libraries/cli/src/commands/cdn/fetch.ts
+++ b/packages/libraries/cli/src/commands/cdn/fetch.ts
@@ -1,0 +1,54 @@
+import { Errors, Flags } from '@oclif/core';
+import { fetch } from '@whatwg-node/fetch';
+import Command from '../../base-command';
+
+export default class CdnFetch extends Command {
+  static description = 'fetches the schema from CDN';
+  static flags = {
+    endpoint: Flags.string({
+      description: 'cdn endpoint',
+    }),
+    token: Flags.string({
+      description: 'cdn token',
+    }),
+  };
+
+  async run() {
+    const { flags } = await this.parse(CdnFetch);
+
+    const endpoint = this.ensure({
+      key: 'endpoint',
+      path: 'cdn.endpoint',
+      args: flags,
+      env: 'HIVE_CDN_ENDPOINT',
+    });
+    const token = this.ensure({
+      key: 'token',
+      path: 'cdn.token',
+      args: flags,
+      env: 'HIVE_CDN_TOKEN',
+    });
+
+    try {
+      const result = await fetch(endpoint + '/sdl.graphql', {
+        headers: {
+          'X-Hive-CDN-Key': token,
+        },
+      });
+
+      const response = await result.text();
+      if (result.status >= 300) {
+        throw new Error(response);
+      }
+
+      this.log(response);
+    } catch (error) {
+      if (error instanceof Errors.ExitError) {
+        throw error;
+      } else {
+        this.fail('Failed to fetch schema from CDN');
+        this.handleFetchError(error);
+      }
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -242,6 +242,7 @@ importers:
       '@oclif/plugin-update': 3.1.1
       '@types/env-ci': 3.1.1
       '@types/mkdirp': 1.0.2
+      '@whatwg-node/fetch': ^0.6.0
       colors: 1.4.0
       env-ci: 7.3.0
       git-parse: 3.0.1
@@ -266,6 +267,7 @@ importers:
       '@oclif/core': 1.23.0_zhte2hlj7lfobytjpalcwwo474
       '@oclif/plugin-help': 5.2.2
       '@oclif/plugin-update': 3.1.1
+      '@whatwg-node/fetch': 0.6.5
       colors: 1.4.0
       env-ci: 7.3.0
       git-parse: 3.0.1
@@ -7570,7 +7572,7 @@ packages:
       '@graphql-tools/utils': 9.1.4_graphql@16.6.0
       '@graphql-tools/wrap': 9.3.0_graphql@16.6.0
       '@types/ws': 8.5.3
-      '@whatwg-node/fetch': 0.6.2
+      '@whatwg-node/fetch': 0.6.5
       graphql: 16.6.0
       isomorphic-ws: 5.0.0_ws@8.12.0
       tslib: 2.5.0
@@ -7596,7 +7598,7 @@ packages:
       '@graphql-tools/utils': 9.1.4_graphql@16.6.0
       '@graphql-tools/wrap': 9.3.0_graphql@16.6.0
       '@types/ws': 8.5.3
-      '@whatwg-node/fetch': 0.6.2
+      '@whatwg-node/fetch': 0.6.5_@types+node@18.11.18
       graphql: 16.6.0
       isomorphic-ws: 5.0.0_ws@8.12.0
       tslib: 2.5.0
@@ -12022,6 +12024,18 @@ packages:
     transitivePeerDependencies:
       - '@types/node'
 
+  /@whatwg-node/fetch/0.6.5_@types+node@18.11.18:
+    resolution: {integrity: sha512-3XQ78RAMX8Az0LlUqMoGM3jbT+FE0S+IKr4yiTiqzQ5S/pNxD52K/kFLcLQiEbL+3rkk/glCHqjxF1QI5155Ig==}
+    dependencies:
+      '@peculiar/webcrypto': 1.4.0
+      '@whatwg-node/node-fetch': 0.0.1_@types+node@18.11.18
+      busboy: 1.6.0
+      urlpattern-polyfill: 6.0.2
+      web-streams-polyfill: 3.2.1
+    transitivePeerDependencies:
+      - '@types/node'
+    dev: true
+
   /@whatwg-node/node-fetch/0.0.1:
     resolution: {integrity: sha512-dMbh604yf2jl37IzvYGA6z3heQg3dMzlqoNsiNToe46SVmKusfJXGf4KYIuiJTzh9mEEu/uVF//QakUfsLJpwA==}
     peerDependencies:
@@ -12030,6 +12044,17 @@ packages:
       '@whatwg-node/events': 0.0.2
       busboy: 1.6.0
       tslib: 2.5.0
+
+  /@whatwg-node/node-fetch/0.0.1_@types+node@18.11.18:
+    resolution: {integrity: sha512-dMbh604yf2jl37IzvYGA6z3heQg3dMzlqoNsiNToe46SVmKusfJXGf4KYIuiJTzh9mEEu/uVF//QakUfsLJpwA==}
+    peerDependencies:
+      '@types/node': ^18.0.6
+    dependencies:
+      '@types/node': 18.11.18
+      '@whatwg-node/events': 0.0.2
+      busboy: 1.6.0
+      tslib: 2.5.0
+    dev: true
 
   /@whatwg-node/server/0.5.0:
     resolution: {integrity: sha512-zvtgGJhuwCtXM0nU/nqDPHjD4QxAl5HK708vJmGdYjETsmB9/JGJaCWjrUuojC14uN4ExoqGaJh34wNopr/jew==}


### PR DESCRIPTION
### Background

Fixes #678 

### Description

`hive cdn:fetch` will download schema from CDN.
It will look for env vars `HIVE_CDN_ENDPOINT` and `HIVE_CDN_KEY`. 
If not found, it will look in hive.json after `cdn.endpoint` and `cdn.token`. 
If not found, it will demand them as input using `--endpoint` and `--token` flags from the CLI.


### Checklist

- [x] Input validation
- [x] Output encoding
- [x] Authentication management
- [x] ~~Session management~~
- [x] Access control
- [x] ~~Cryptographic practices~~
- [x] Error handling and logging
- [x] ~~Data protection~~
- [x] ~~Communication security~~
- [x] ~~System configuration~~
- [x] ~~Database security~~
- [x] ~~File management~~
- [x] ~~Memory management~~
- [x] ~~Testing~~
