### PR TITLE
fix: skip visiting directive arguments when collecting usage

### DIFF
--- a/.changeset/many-jobs-perform.md
+++ b/.changeset/many-jobs-perform.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/client': minor
+---
+
+skip directive arguments during usage collection

--- a/packages/libraries/client/src/internal/usage.ts
+++ b/packages/libraries/client/src/internal/usage.ts
@@ -383,7 +383,7 @@ export function createCollector({
           return {
             ...node,
             arguments: [],
-          }
+          };
         },
         Argument(node) {
           const parent = typeInfo.getParentType()!;

--- a/packages/libraries/client/src/internal/usage.ts
+++ b/packages/libraries/client/src/internal/usage.ts
@@ -379,6 +379,12 @@ export function createCollector({
             collectInputType(resolveTypeName(inputType));
           }
         },
+        Directive(node) {
+          return {
+            ...node,
+            arguments: [],
+          }
+        },
         Argument(node) {
           const parent = typeInfo.getParentType()!;
           const field = typeInfo.getFieldDef()!;

--- a/packages/libraries/client/tests/usage-collector.spec.ts
+++ b/packages/libraries/client/tests/usage-collector.spec.ts
@@ -195,7 +195,7 @@ test('collect arguments', async () => {
   expect(info.fields).toContain(`Query.projects.filter`);
 });
 
-test('skip argument directives', async () => {
+test('skips argument directives', async () => {
   const collect = createCollector({
     schema,
     max: 1,

--- a/packages/libraries/client/tests/usage-collector.spec.ts
+++ b/packages/libraries/client/tests/usage-collector.spec.ts
@@ -195,6 +195,34 @@ test('collect arguments', async () => {
   expect(info.fields).toContain(`Query.projects.filter`);
 });
 
+test('skip argument directives', async () => {
+  const collect = createCollector({
+    schema,
+    max: 1,
+  });
+  const info = collect(
+    parse(/* GraphQL */ `
+      query getProjects($limit: Int!, $type: ProjectType!, $includeName: Boolean!) {
+        projects(filter: { pagination: { limit: $limit }, type: $type }) {
+          id
+          ...NestedFragment
+        }
+      }
+
+      fragment NestedFragment on Project {
+        ...IncludeNameFragment @include(if: $includeName)
+      }
+
+      fragment IncludeNameFragment on Project {
+        name
+      }
+    `),
+    {},
+  ).value;
+
+  expect(info.fields).toContain(`Query.projects.filter`);
+});
+
 test('collect used-only input fields', async () => {
   const collect = createCollector({
     schema,


### PR DESCRIPTION
### Background
fixes https://github.com/kamilkisiela/graphql-hive/issues/1220

GraphQL visitor `typeInfo.getFieldDef()` yields `undefined` when visiting arguments of a directive applied to a fragment spread within a fragment. 

### Description
When visiting a GraphQL operation, skip visiting the arguments of a directive - there is no value in visiting directive arguments (or even directives in general) in the context of determining field usage

Client side GraphQL directives on query documents don't affect the actual field usage of a schema.  i.e. it wouldn't matter if `@skip` or `@include` exclude a field for a particular operation - the execution of a query would fail if the schema didn't have the fields in the first place.

### Checklist