### PR TITLE
fix: exclude .env file from migrations container

### DIFF
--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -4,6 +4,10 @@
   "type": "module",
   "license": "MIT",
   "private": true,
+  "files": [
+    "src",
+    "tsconfig.json"
+  ],
   "scripts": {
     "build": "pnpm --filter=@hive/migrations deploy --prod ./dist/migrations/",
     "db:create": "node tools/create-db.mjs",


### PR DESCRIPTION
### Background

I had a lot of headaches debugging.

### Description

This uses the `files` key in the `package.json` for only copying specific files instead of everything [as described on the docs](https://pnpm.io/cli/deploy).

Closes https://github.com/kamilkisiela/graphql-hive/issues/1209

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [x] ~~Input validation~~
- [x] ~~Output encoding~~
- [x] ~~Authentication management~~
- [x] ~~Session management~~
- [x] ~~Access control~~
- [x] ~~Cryptographic practices~~
- [x] ~~Error handling and logging~~
- [x] ~~Data protection~~
- [x] ~~Communication security~~
- [x] ~~System configuration~~
- [x] ~~Database security~~
- [x] ~~File management~~
- [x] ~~Memory management~~
- [x] ~~Testing~~
