### PR TITLE
chore: group supertokens?

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -53,7 +53,12 @@
     },
     {
       "groupName": "supertokens",
-      "matchPackagePrefixes": ["supertokens"]
+      "matchPackageNames": [
+        "supertokens-node",
+        "supertokens-website",
+        "supertokens-auth-react",
+        "supertokens-js-override"
+      ]
     }
   ]
 }


### PR DESCRIPTION
### Background

For some reason renovate creates two PRs instead of a single one...

- https://github.com/kamilkisiela/graphql-hive/pull/1246
- https://github.com/kamilkisiela/graphql-hive/pull/1193


### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

