### PR TITLE
Add a timeout to external schema composition

### DIFF
--- a/packages/services/schema/package.json
+++ b/packages/services/schema/package.json
@@ -17,8 +17,8 @@
     "@sentry/tracing": "7.37.0",
     "@trpc/server": "10.9.1",
     "@whatwg-node/fetch": "0.7.1",
-    "async-retry": "1.3.3",
     "dotenv": "16.0.3",
+    "got": "12.5.3",
     "graphql": "16.6.0",
     "ioredis": "5.3.0",
     "zod": "3.20.5"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -613,9 +613,9 @@ importers:
       '@trpc/server': 10.9.1
       '@types/async-retry': 1.4.5
       '@whatwg-node/fetch': 0.7.1
-      async-retry: 1.3.3
       dotenv: 16.0.3
       fastify: 3.29.5
+      got: 12.5.3
       graphql: 16.6.0
       ioredis: 5.3.0
       pino-pretty: 9.1.1
@@ -628,8 +628,8 @@ importers:
       '@sentry/tracing': 7.37.0
       '@trpc/server': 10.9.1
       '@whatwg-node/fetch': 0.7.1
-      async-retry: 1.3.3
       dotenv: 16.0.3
+      got: 12.5.3
       graphql: 16.6.0
       ioredis: 5.3.0
       zod: 3.20.5


### PR DESCRIPTION
Make sure it runs no longer than 30 seconds, otherwise CF yells at us.
Oh and yes I did use `got` instead of the amazing `fetch`, to get shit done quickly and avoid creating yet another retry + timeout logic with `AbortController`.