### PR TITLE
Add missing method property in Request Broker

### DIFF
--- a/integration-tests/docker-compose.integration.yaml
+++ b/integration-tests/docker-compose.integration.yaml
@@ -244,6 +244,12 @@ services:
     ports:
       - '3011:3011'
 
+  schema:
+    environment:
+      REQUEST_BROKER: '1'
+      REQUEST_BROKER_SIGNATURE: 'secretSignature'
+      REQUEST_BROKER_ENDPOINT: 'http://local_broker:3013'
+
   #
   # Awkwardly, we need to override some services for different reasons
   #

--- a/packages/services/broker-worker/src/dev.ts
+++ b/packages/services/broker-worker/src/dev.ts
@@ -19,7 +19,9 @@ function main() {
       }),
   );
 
-  app.all('*', (request: Request) => handleRequest(request, isSignatureValid));
+  app.all('*', (request: Request) =>
+    handleRequest(request, isSignatureValid, e => console.error(e)),
+  );
 
   const server = createServer(app);
 

--- a/packages/services/broker-worker/src/errors.ts
+++ b/packages/services/broker-worker/src/errors.ts
@@ -1,19 +1,26 @@
+type CaptureException = (exception: Error) => void;
+
 export class InvalidRequestFormat extends Response {
-  constructor(message: string) {
+  constructor(captureException: CaptureException, message: string) {
     super(
       JSON.stringify({
         code: 'INVALID_REQUEST_FORMAT',
-        error: `Invalid artifact type: "${message}"`,
+        error: `Invalid payload provided: "${message}"`,
       }),
       {
         status: 400,
       },
     );
+    captureException(
+      new Error(`INVALID_REQUEST_FORMAT`, {
+        cause: message,
+      }),
+    );
   }
 }
 
 export class MissingSignature extends Response {
-  constructor() {
+  constructor(captureException: CaptureException) {
     super(
       JSON.stringify({
         code: 'MISSING_SIGNATURE',
@@ -23,11 +30,12 @@ export class MissingSignature extends Response {
         status: 401,
       },
     );
+    captureException(new Error(`MISSING_SIGNATURE`));
   }
 }
 
 export class InvalidSignature extends Response {
-  constructor() {
+  constructor(captureException: CaptureException) {
     super(
       JSON.stringify({
         code: 'INVALID_SIGNATURE',
@@ -37,6 +45,7 @@ export class InvalidSignature extends Response {
         status: 403,
       },
     );
+    captureException(new Error(`INVALID_SIGNATURE`));
   }
 }
 
@@ -51,5 +60,6 @@ export class UnexpectedError extends Response {
         status: 500,
       },
     );
+    console.error(`UNEXPECTED_ERROR: ${errorId}`);
   }
 }

--- a/packages/services/broker-worker/src/handler.ts
+++ b/packages/services/broker-worker/src/handler.ts
@@ -19,8 +19,12 @@ async function gatherResponse(response: Response) {
   return response.text();
 }
 
-export async function handleRequest(request: Request, keyValidator: typeof isSignatureValid) {
-  const parsedRequest = await parseIncomingRequest(request, keyValidator);
+export async function handleRequest(
+  request: Request,
+  keyValidator: typeof isSignatureValid,
+  captureException: (exception: Error) => void,
+) {
+  const parsedRequest = await parseIncomingRequest(request, keyValidator, captureException);
 
   if ('error' in parsedRequest) {
     return parsedRequest.error;

--- a/packages/services/broker-worker/src/index.ts
+++ b/packages/services/broker-worker/src/index.ts
@@ -4,24 +4,28 @@ import { UnexpectedError } from './errors';
 import { handleRequest } from './handler';
 
 self.addEventListener('fetch', event => {
+  const sentry = new Toucan({
+    dsn: SENTRY_DSN,
+    environment: SENTRY_ENVIRONMENT,
+    release: SENTRY_RELEASE,
+    context: event,
+    allowedHeaders: [
+      'user-agent',
+      'cf-ipcountry',
+      'accept-encoding',
+      'accept',
+      'x-real-ip',
+      'cf-connecting-ip',
+    ],
+    allowedSearchParams: /(.*)/,
+  });
   try {
-    event.respondWith(handleRequest(event.request, isSignatureValid));
+    event.respondWith(
+      handleRequest(event.request, isSignatureValid, exception => {
+        sentry.captureException(exception);
+      }),
+    );
   } catch (error) {
-    const sentry = new Toucan({
-      dsn: SENTRY_DSN,
-      environment: SENTRY_ENVIRONMENT,
-      release: SENTRY_RELEASE,
-      context: event,
-      allowedHeaders: [
-        'user-agent',
-        'cf-ipcountry',
-        'accept-encoding',
-        'accept',
-        'x-real-ip',
-        'cf-connecting-ip',
-      ],
-      allowedSearchParams: /(.*)/,
-    });
     const eventId = sentry.captureException(error);
     event.respondWith(new UnexpectedError(eventId ?? 'unknown'));
   }

--- a/packages/services/broker-worker/tests/broker.spec.ts
+++ b/packages/services/broker-worker/tests/broker.spec.ts
@@ -26,6 +26,10 @@ function clearWorkerEnv() {
   });
 }
 
+function captureException() {
+  //
+}
+
 afterEach(clearWorkerEnv);
 afterEach(nock.cleanAll);
 
@@ -40,7 +44,7 @@ test('401 on missing signature', async () => {
     method: 'POST',
   });
 
-  const response = await handleRequest(request, SignatureValidators.Real);
+  const response = await handleRequest(request, SignatureValidators.Real, captureException);
   expect(response instanceof MissingSignature).toBeTruthy();
   expect(response.status).toBe(401);
 });
@@ -59,7 +63,7 @@ test('403 on non-matching signature', async () => {
     },
   });
 
-  const response = await handleRequest(request, SignatureValidators.Real);
+  const response = await handleRequest(request, SignatureValidators.Real, captureException);
   expect(response instanceof InvalidSignature).toBeTruthy();
   expect(response.status).toBe(403);
 });
@@ -78,7 +82,7 @@ test('405 allow only POST method', async () => {
     },
   });
 
-  let response = await handleRequest(request, SignatureValidators.Real);
+  let response = await handleRequest(request, SignatureValidators.Real, captureException);
   expect(response.status).toBe(405);
 
   request = new Request('https://fake-worker.com/', {
@@ -89,7 +93,7 @@ test('405 allow only POST method', async () => {
     body: JSON.stringify({}),
   });
 
-  response = await handleRequest(request, SignatureValidators.Real);
+  response = await handleRequest(request, SignatureValidators.Real, captureException);
   expect(response.status).toBe(405);
 });
 
@@ -108,7 +112,7 @@ test('400 on invalid request format', async () => {
     body: JSON.stringify({}),
   });
 
-  const response = await handleRequest(request, SignatureValidators.Real);
+  const response = await handleRequest(request, SignatureValidators.Real, captureException);
   expect(response instanceof InvalidRequestFormat).toBeTruthy();
   expect(response.status).toBe(400);
 });
@@ -142,7 +146,7 @@ test('GET text/plain', async () => {
     }),
   });
 
-  const response = await handleRequest(request, SignatureValidators.Real);
+  const response = await handleRequest(request, SignatureValidators.Real, captureException);
   expect(response.status).toBe(200);
   expect(await response.text()).toBe('OK');
 });
@@ -178,7 +182,7 @@ test('GET application/json', async () => {
     }),
   });
 
-  const response = await handleRequest(request, SignatureValidators.Real);
+  const response = await handleRequest(request, SignatureValidators.Real, captureException);
   expect(response.status).toBe(200);
   expect(await response.text()).toBe(
     JSON.stringify({
@@ -216,7 +220,7 @@ test('POST text/plain', async () => {
     }),
   });
 
-  const response = await handleRequest(request, SignatureValidators.Real);
+  const response = await handleRequest(request, SignatureValidators.Real, captureException);
   expect(response.status).toBe(200);
   expect(await response.text()).toBe('OK');
 });
@@ -252,7 +256,7 @@ test('POST application/json', async () => {
     }),
   });
 
-  const response = await handleRequest(request, SignatureValidators.Real);
+  const response = await handleRequest(request, SignatureValidators.Real, captureException);
   expect(response.status).toBe(200);
   expect(await response.text()).toBe(
     JSON.stringify({
@@ -298,7 +302,7 @@ test('POST application/json + body', async () => {
     }),
   });
 
-  const response = await handleRequest(request, SignatureValidators.Real);
+  const response = await handleRequest(request, SignatureValidators.Real, captureException);
   expect(response.status).toBe(200);
   expect(await response.text()).toBe(
     JSON.stringify({
@@ -333,7 +337,7 @@ test('passthrough errors', async () => {
     }),
   });
 
-  const response = await handleRequest(request, SignatureValidators.Real);
+  const response = await handleRequest(request, SignatureValidators.Real, captureException);
   expect(response.status).toBe(500);
   expect(await response.text()).toBe('Internal Server Error');
 });


### PR DESCRIPTION
The schema service couldn't make calls to external services due to a missing method property
This Pull Request fixes it and connects the Schema service with the Request Broker in the integration tests.
It also captures exceptions via Sentry now.
The request to the broker is now strongly typed.