### PR TITLE
Remove Query._entities when extracting original SDL from Fed v2

### DIFF
--- a/.changeset/long-cherries-invite.md
+++ b/.changeset/long-cherries-invite.md
@@ -1,0 +1,5 @@
+---
+"@graphql-hive/client": patch
+---
+
+Remove `Query._entities` when extracting original SDL from Fed v2

--- a/packages/libraries/client/src/internal/reporting.ts
+++ b/packages/libraries/client/src/internal/reporting.ts
@@ -209,7 +209,7 @@ const federationV2 = {
     'tag',
   ]),
   types: new Set(['_Service']),
-  queryFields: new Set(['_service']),
+  queryFields: new Set(['_service', '_entities']),
 };
 
 /**


### PR DESCRIPTION
Fixes #1350