### PR TITLE
Set higher timeout when calling external composition service

### DIFF
--- a/packages/services/schema/src/cache.ts
+++ b/packages/services/schema/src/cache.ts
@@ -73,6 +73,7 @@ export function createCache(options: {
   }
 
   return {
+    timeoutMs,
     reuse<I, O>(groupKey: string, factory: (input: I) => Promise<O>): (input: I) => Promise<O> {
       async function reuseFactory(input: I, attempt = 0): Promise<O> {
         const id = `${prefix}:${groupKey}:${createChecksum(input)}`;


### PR DESCRIPTION
Equal to the timeout defined for redis cache, but not higher than 25s (CF has 30s timeout anyway).