### PR TITLE
`rc` releases for Changesets release PR

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -101,10 +101,25 @@ jobs:
     secrets: inherit
 
   # Release alpha version on NPM for Hive libraries
-  release:
+  alpha:
     uses: the-guild-org/shared-config/.github/workflows/release-snapshot.yml@main
+    if: ${{ github.event.pull_request.title != 'Upcoming Release Changes' }}
     with:
       npmTag: alpha
+      buildScript: build:libraries
+      nodeVersion: 18
+      packageManager: pnpm
+    secrets:
+      githubToken: ${{ secrets.GITHUB_TOKEN }}
+      npmToken: ${{ secrets.NPM_TOKEN }}
+
+  # Release RC version on NPM for Hive libraries
+  release-candidate:
+    uses: the-guild-org/shared-config/.github/workflows/release-snapshot.yml@main
+    if: ${{ github.event.pull_request.title == 'Upcoming Release Changes' }}
+    with:
+      npmTag: rc
+      restoreDeletedChangesets: true
       buildScript: build:libraries
       nodeVersion: 18
       packageManager: pnpm

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -33,7 +33,7 @@ jobs:
           commit: 'chore(release): update monorepo packages versions'
           title: 'Upcoming Release Changes'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GUILD_BOT_TOKEN }}
 
       - name: extract published version
         if:


### PR DESCRIPTION
This one also fixes https://github.com/kamilkisiela/graphql-hive/issues/861 because the PAT has higher rate-limit 🤦 

- [x] Add `GUILD_BOT_TOKEN` to secrets @kamilkisiela 