### PR TITLE
Build Docker Image of Apollo Router using sparse-registry (nightly)

### DIFF
--- a/docker/router.dockerfile
+++ b/docker/router.dockerfile
@@ -21,15 +21,18 @@ RUN rm -rf /var/lib/apt/lists/*
 RUN update-ca-certificates
 RUN rustup component add rustfmt
 
+# Install nightly toolchain so we can use sparse-registry
+RUN rustup toolchain install nightly
+
 # Get the dependencies cached
-RUN cargo build --release
+RUN cargo +nightly build --release -Z sparse-registry
 
 COPY --from=pkg src ./src
 
 RUN touch ./src/main.rs
 
 # Real build this time
-RUN cargo build --release
+RUN cargo +nightly build --release -Z sparse-registry
 
 # Runtime
 FROM debian:bullseye-slim as runtime


### PR DESCRIPTION
It should fix:

```
> [linux/arm64 build 12/15] RUN cargo build --release:
#0 4.824     Updating git repository `[https://github.com/graphql-rust/graphql-parser.git`](https://github.com/graphql-rust/graphql-parser.git%60)
#0 5.862     Updating crates.io index
#52 272.5 Killed

ERROR: failed to solve: process "/bin/sh -c cargo build --release" did not complete successfully: exit code: 137
```

Another option to fix it and avoid using `nightly` is passing `--config net.git-fetch-with-cli=true` to `cargo build`.