### PR TITLE
Refactor `tsup` configurations and fix watch mode

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -42,8 +42,9 @@ module.exports = {
     'packages/web/app/src/graphql/index.ts',
     'packages/libraries/cli/src/sdk.ts',
     'packages/services/storage/src/db/types.ts',
-    'codegen.cjs',
     'packages/web/app/src/gql/**/*',
+    'codegen.cjs',
+    'tsup',
   ],
   parserOptions: {
     ecmaVersion: 2020,

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@graphql-codegen/typescript-operations": "3.0.1",
     "@graphql-codegen/typescript-resolvers": "3.1.0",
     "@graphql-inspector/cli": "3.4.6",
+    "@manypkg/get-packages": "2.1.0",
     "@next/eslint-plugin-next": "13.2.1",
     "@sentry/cli": "2.13.0",
     "@swc/core": "1.3.36",

--- a/packages/services/broker-worker/package.json
+++ b/packages/services/broker-worker/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "node build.mjs",
-    "dev": "tsup-node src/dev.ts --target node18 --sourcemap --watch --onSuccess \"node --enable-source-maps dist/dev.js\"",
+    "dev": "tsup-node --config ../../../tsup/dev.config.worker.ts src/dev.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/services/cdn-worker/package.json
+++ b/packages/services/cdn-worker/package.json
@@ -1,12 +1,11 @@
 {
   "name": "@hive/cdn-script",
   "version": "0.0.0",
-  "type": "module",
   "license": "MIT",
   "private": true,
   "scripts": {
     "build": "node build.mjs",
-    "dev": "tsup-node src/dev.ts --target node18 --sourcemap --format esm --watch --onSuccess  \"node --enable-source-maps dist/dev.js\"",
+    "dev": "tsup-node --config ../../../tsup/dev.config.worker.ts src/dev.ts",
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {

--- a/packages/services/emails/package.json
+++ b/packages/services/emails/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "build": "bob runify --single",
-    "dev": "tsup-node src/dev.ts --format esm --shims --target node18 --watch --sourcemap --onSuccess 'node --enable-source-maps dist/dev.js' | pino-pretty --translateTime HH:MM:ss TT --ignore pid,hostname",
+    "dev": "tsup-node --config ../../../tsup/dev.config.node.ts src/dev.ts",
     "postbuild": "copyfiles -f \"node_modules/bullmq/dist/esm/commands/*.lua\" dist && copyfiles -f \"node_modules/bullmq/dist/esm/commands/includes/*.lua\" dist/includes",
     "typecheck": "tsc --noEmit"
   },

--- a/packages/services/external-composition/federation-2/package.json
+++ b/packages/services/external-composition/federation-2/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "build": "bob runify --single",
-    "dev": "tsup-node src/index.ts --format esm --shims --target node18 --watch --sourcemap --onSuccess 'node --enable-source-maps dist/index.js' | pino-pretty --translateTime HH:MM:ss TT --ignore pid,hostname"
+    "dev": "tsup-node --config ../../../tsup/dev.config.node.ts src/index.ts"
   },
   "dependencies": {
     "@apollo/composition": "^2.2.2",

--- a/packages/services/rate-limit/package.json
+++ b/packages/services/rate-limit/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "build": "bob runify --single",
-    "dev": "tsup-node src/dev.ts --watch --format esm --shims --target node18 --onSuccess 'node dist/dev.js' | pino-pretty --translateTime HH:MM:ss TT --ignore pid,hostname",
+    "dev": "tsup-node --config ../../../tsup/dev.config.node.ts src/dev.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/services/schema/package.json
+++ b/packages/services/schema/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "build": "bob runify --single",
-    "dev": "tsup-node src/dev.ts --format esm --shims --target node18 --watch --sourcemap --onSuccess 'node --enable-source-maps dist/dev.js' | pino-pretty --translateTime HH:MM:ss TT --ignore pid,hostname",
+    "dev": "tsup-node --config ../../../tsup/dev.config.node.ts src/dev.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/services/server/package.json
+++ b/packages/services/server/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "build": "bob runify --single",
-    "dev": "tsup-node src/dev.ts --format esm --shims --target node18 --watch --sourcemap --onSuccess 'node --enable-source-maps dist/dev.js' | pino-pretty --translateTime HH:MM:ss TT --ignore pid,hostname",
+    "dev": "tsup-node --config ../../../tsup/dev.config.node.ts src/dev.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/services/stripe-billing/package.json
+++ b/packages/services/stripe-billing/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "build": "bob runify --single",
-    "dev": "tsup-node src/dev.ts --format esm --shims --target node18 --watch --sourcemap --onSuccess 'node --enable-source-maps dist/dev.js' | pino-pretty --translateTime HH:MM:ss TT --ignore pid,hostname",
+    "dev": "tsup-node --config ../../../tsup/dev.config.node.ts src/dev.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/services/tokens/package.json
+++ b/packages/services/tokens/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "build": "bob runify --single",
-    "dev": "tsup-node src/dev.ts --format esm --shims --target node18 --watch --sourcemap --onSuccess 'node --enable-source-maps dist/dev.js' | pino-pretty --translateTime HH:MM:ss TT --ignore pid,hostname",
+    "dev": "tsup-node --config ../../../tsup/dev.config.node.ts src/dev.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/services/usage-estimator/package.json
+++ b/packages/services/usage-estimator/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "scripts": {
     "build": "bob runify --single",
-    "dev": "tsup-node src/dev.ts --format esm --shims --target node18 --watch --sourcemap --onSuccess 'node --enable-source-maps dist/dev.js' | pino-pretty --translateTime HH:MM:ss TT --ignore pid,hostname",
+    "dev": "tsup-node --config ../../../tsup/dev.config.node.ts src/dev.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/services/usage-ingestor/package.json
+++ b/packages/services/usage-ingestor/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "build": "bob runify --single",
-    "dev": "tsup-node src/dev.ts --watch --format esm --target node18 --onSuccess 'node dist/dev.js' | pino-pretty --translateTime HH:MM:ss TT --ignore pid,hostname",
+    "dev": "tsup-node --config ../../../tsup/dev.config.node.ts src/dev.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/services/usage/package.json
+++ b/packages/services/usage/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "build": "bob runify --single",
-    "dev": "tsup-node src/dev.ts --format esm --shims --target node18 --watch --sourcemap --onSuccess 'node --enable-source-maps dist/dev.js' | pino-pretty --translateTime HH:MM:ss TT --ignore pid,hostname",
+    "dev": "tsup-node --config ../../../tsup/dev.config.node.ts src/dev.ts",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/services/webhooks/package.json
+++ b/packages/services/webhooks/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "build": "bob runify --single",
-    "dev": "tsup-node src/dev.ts --format esm --shims --target node18 --watch --sourcemap --onSuccess 'node --enable-source-maps dist/dev.js' | pino-pretty --translateTime HH:MM:ss TT --ignore pid,hostname",
+    "dev": "tsup-node --config ../../../tsup/dev.config.node.ts src/dev.ts",
     "postbuild": "copyfiles -f \"node_modules/bullmq/dist/esm/commands/*.lua\" dist && copyfiles -f \"node_modules/bullmq/dist/esm/commands/includes/*.lua\" dist/includes",
     "typecheck": "tsc --noEmit"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,39 +5,39 @@ overrides:
   tsup: 6.5.0
 
 patchedDependencies:
-  '@theguild/buddy@0.1.0':
-    hash: ryylgra5xglhidfoiaxehn22hq
-    path: patches/@theguild__buddy@0.1.0.patch
-  slonik@30.1.2:
-    hash: wg2hxbo7txnklmvja4aeqnygfi
-    path: patches/slonik@30.1.2.patch
-  '@tgriesser/schemats@7.0.1':
-    hash: u3kbucfchakklx3sci2vh6wjau
-    path: patches/@tgriesser__schemats@7.0.1.patch
   '@oclif/core@1.23.0':
     hash: zhte2hlj7lfobytjpalcwwo474
     path: patches/@oclif__core@1.23.0.patch
-  bullmq@3.7.2:
-    hash: xbmkiyyfti7h6orsfs6pdmi4s4
-    path: patches/bullmq@3.7.2.patch
+  '@tgriesser/schemats@7.0.1':
+    hash: u3kbucfchakklx3sci2vh6wjau
+    path: patches/@tgriesser__schemats@7.0.1.patch
   mjml-core@4.13.0:
     hash: zxxsxbqejjmcwuzpigutzzq6wa
     path: patches/mjml-core@4.13.0.patch
+  '@theguild/buddy@0.1.0':
+    hash: ryylgra5xglhidfoiaxehn22hq
+    path: patches/@theguild__buddy@0.1.0.patch
+  '@graphql-inspector/core@4.0.0':
+    hash: wf35oaq7brzyeva5aoncxac66a
+    path: patches/@graphql-inspector__core@4.0.0.patch
+  bullmq@3.7.2:
+    hash: xbmkiyyfti7h6orsfs6pdmi4s4
+    path: patches/bullmq@3.7.2.patch
   oclif@3.7.0:
     hash: rxmtqiusuyruv7tkwux5gvotbm
     path: patches/oclif@3.7.0.patch
   '@slonik/migrator@0.8.5':
     hash: yfpv2xzdmnkrtu2wvaktxf5mmq
     path: patches/@slonik__migrator@0.8.5.patch
-  '@graphql-inspector/core@4.0.0':
-    hash: wf35oaq7brzyeva5aoncxac66a
-    path: patches/@graphql-inspector__core@4.0.0.patch
-  '@octokit/webhooks-methods@3.0.1':
-    hash: ckboo4crezw7uvstxm24ozngtq
-    path: patches/@octokit__webhooks-methods@3.0.1.patch
   '@apollo/federation@0.38.1':
     hash: rjgakkkphrejw6qrtph4ar24zq
     path: patches/@apollo__federation@0.38.1.patch
+  slonik@30.1.2:
+    hash: wg2hxbo7txnklmvja4aeqnygfi
+    path: patches/slonik@30.1.2.patch
+  '@octokit/webhooks-methods@3.0.1':
+    hash: ckboo4crezw7uvstxm24ozngtq
+    path: patches/@octokit__webhooks-methods@3.0.1.patch
 
 importers:
 
@@ -54,6 +54,7 @@ importers:
       '@graphql-codegen/typescript-operations': 3.0.1
       '@graphql-codegen/typescript-resolvers': 3.1.0
       '@graphql-inspector/cli': 3.4.6
+      '@manypkg/get-packages': 2.1.0
       '@next/eslint-plugin-next': 13.2.1
       '@sentry/cli': 2.13.0
       '@swc/core': 1.3.36
@@ -94,6 +95,7 @@ importers:
       '@graphql-codegen/typescript-operations': 3.0.1_graphql@16.6.0
       '@graphql-codegen/typescript-resolvers': 3.1.0_graphql@16.6.0
       '@graphql-inspector/cli': 3.4.6_3747hjkprpk6cot33bkmfwepnm
+      '@manypkg/get-packages': 2.1.0
       '@next/eslint-plugin-next': 13.2.1
       '@sentry/cli': 2.13.0
       '@swc/core': 1.3.36
@@ -6615,7 +6617,6 @@ packages:
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
-    dev: false
 
   /@manypkg/get-packages/1.1.3:
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
@@ -6634,7 +6635,6 @@ packages:
     dependencies:
       '@manypkg/find-root': 2.1.0
       '@manypkg/tools': 1.0.0
-    dev: false
 
   /@manypkg/tools/1.0.0:
     resolution: {integrity: sha512-W8uDMhDGtwNyXYr6A+MWggxdL3spOQ8rfMNYpNph1GDJ0v084MnBFdpF1jvcPZ0okHAeYccV7le8AUs+fzwsAQ==}
@@ -6644,7 +6644,6 @@ packages:
       globby: 11.1.0
       jju: 1.4.0
       read-yaml-file: 1.1.0
-    dev: false
 
   /@mdx-js/mdx/2.2.1:
     resolution: {integrity: sha512-hZ3ex7exYLJn6FfReq8yTvA6TE53uW9UHJQM9IlSauOuS55J9y8RtA7W+dzp6Yrzr00/U1sd7q+Wf61q6SfiTQ==}
@@ -16549,7 +16548,6 @@ packages:
 
   /jju/1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
-    dev: false
 
   /jmespath/0.16.0:
     resolution: {integrity: sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -59,7 +59,7 @@
       "@/*": ["./packages/web/app/src/*"]
     }
   },
-  "include": ["packages"],
+  "include": ["packages", "tsup.config.node.ts"],
   "exclude": [
     "**/node_modules/**",
     "**/dist",

--- a/tsup/dev.config.node.ts
+++ b/tsup/dev.config.node.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'tsup';
+import {
+  commonWatchList,
+  monorepoWatchList,
+  targetFromNodeVersion,
+  watchEntryPlugin,
+} from './utils';
+
+export default defineConfig({
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  shims: true,
+  format: 'esm',
+  watch: [...commonWatchList(), ...monorepoWatchList()],
+  target: targetFromNodeVersion(),
+  plugins: [watchEntryPlugin()],
+});

--- a/tsup/dev.config.worker.ts
+++ b/tsup/dev.config.worker.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsup';
+import {
+  commonWatchList,
+  monorepoWatchList,
+  targetFromNodeVersion,
+  watchEntryPlugin,
+} from './utils';
+
+export default defineConfig({
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  watch: [...commonWatchList(), ...monorepoWatchList()],
+  target: targetFromNodeVersion(),
+  plugins: [watchEntryPlugin()],
+});

--- a/tsup/utils.ts
+++ b/tsup/utils.ts
@@ -1,0 +1,70 @@
+import { readFileSync } from 'fs';
+import { join, resolve } from 'path';
+import { getPackagesSync } from '@manypkg/get-packages';
+
+const rootDir = resolve(__dirname, '../');
+const libDir = process.cwd();
+const packagesMetadata = getPackagesSync(rootDir);
+const currentPackage = packagesMetadata.packages.find(p => p.dir === libDir);
+
+export const commonWatchList = () => {
+  return [
+    libDir + '/src/**/*',
+    libDir + '/tsconfig.json',
+    rootDir + '/tsconfig.json',
+    rootDir + '/tsup.config.*',
+  ];
+};
+
+export const monorepoWatchList = () => {
+  if (!currentPackage) {
+    return [];
+  }
+
+  const internalDeps = Object.entries({
+    ...(currentPackage.packageJson.dependencies || {}),
+    ...(currentPackage.packageJson.devDependencies || {}),
+    ...(currentPackage.packageJson.peerDependencies || {}),
+  }).reduce((prev, [name, version]) => {
+    if (version === 'workspace:*') {
+      return [...prev, name];
+    }
+
+    return prev;
+  }, [] as string[]);
+
+  return internalDeps.reduce((prev, dep) => {
+    const found = packagesMetadata.packages.find(p => p.packageJson.name === dep);
+
+    if (!found) {
+      return prev;
+    }
+
+    return [...prev, join(found.dir, '/src/**/*')];
+  }, [] as string[]);
+};
+
+const nodeVersion = readFileSync(join(rootDir, '/.node-version')).toString();
+
+export const targetFromNodeVersion = () => {
+  const clean = nodeVersion.trim().split('.');
+
+  return `node${clean[0]}`;
+};
+
+export const watchEntryPlugin = () => {
+  return {
+    name: 'node-watch-entry',
+    esbuildOptions(options) {
+      const entries = (options.entryPoints as string[]) || [];
+      const entry = entries[0];
+
+      if (!entry) {
+        throw new Error('No entry point found');
+      }
+
+      const outFile = entry.replace('src/', 'dist/').replace('.ts', '.js');
+      this.options.onSuccess = `node --enable-source-maps ${outFile} | pino-pretty --translateTime HH:MM:ss TT --ignore pid,hostname`;
+    },
+  };
+};


### PR DESCRIPTION
- [x] Unify all tsup configurations into files 
- [x] Use the shared config files instead of tons of flags
- [x] Improve watch mode by inferring directories to watch based on `package.json` deps 

Now when you change something in api/common/service-common, you'll get all dependant packages reloaded 