### PR TITLE
Show status of external schema composition service

### DIFF
--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -1073,7 +1073,10 @@ export async function enableExternalSchemaComposition(
       mutation enableExternalSchemaComposition($input: EnableExternalSchemaCompositionInput!) {
         enableExternalSchemaComposition(input: $input) {
           ok {
-            endpoint
+            id
+            externalSchemaComposition {
+              endpoint
+            }
           }
           error {
             message

--- a/integration-tests/tests/api/schema/composition-federation-2.spec.ts
+++ b/integration-tests/tests/api/schema/composition-federation-2.spec.ts
@@ -49,9 +49,10 @@ test.concurrent('call an external service to compose and validate services', asy
     },
     writeToken.secret,
   ).then(r => r.expectNoGraphQLErrors());
-  expect(externalCompositionResult.enableExternalSchemaComposition.ok?.endpoint).toBe(
-    `http://${dockerAddress}/compose`,
-  );
+  expect(
+    externalCompositionResult.enableExternalSchemaComposition.ok?.externalSchemaComposition
+      ?.endpoint,
+  ).toBe(`http://${dockerAddress}/compose`);
 
   const productsServiceName = generateUnique();
   const publishProductsResult = await writeToken

--- a/integration-tests/tests/api/schema/external-composition.spec.ts
+++ b/integration-tests/tests/api/schema/external-composition.spec.ts
@@ -54,9 +54,10 @@ test.concurrent('call an external service to compose and validate services', asy
     },
     writeToken.secret,
   ).then(r => r.expectNoGraphQLErrors());
-  expect(externalCompositionResult.enableExternalSchemaComposition.ok?.endpoint).toBe(
-    `http://${dockerAddress}/compose`,
-  );
+  expect(
+    externalCompositionResult.enableExternalSchemaComposition.ok?.externalSchemaComposition
+      ?.endpoint,
+  ).toBe(`http://${dockerAddress}/compose`);
 
   const productsServiceName = generateUnique();
   const publishProductsResult = await writeToken
@@ -134,9 +135,10 @@ test.concurrent(
       },
       writeToken.secret,
     ).then(r => r.expectNoGraphQLErrors());
-    expect(externalCompositionResult.enableExternalSchemaComposition.ok?.endpoint).toBe(
-      `http://${dockerAddress}/fail_on_signature`,
-    );
+    expect(
+      externalCompositionResult.enableExternalSchemaComposition.ok?.externalSchemaComposition
+        ?.endpoint,
+    ).toBe(`http://${dockerAddress}/fail_on_signature`);
 
     const productsServiceName = generateUnique();
     const publishProductsResult = await writeToken
@@ -228,9 +230,10 @@ test.concurrent(
       },
       writeToken.secret,
     ).then(r => r.expectNoGraphQLErrors());
-    expect(externalCompositionResult.enableExternalSchemaComposition.ok?.endpoint).toBe(
-      `http://${dockerAddress}/non-existing-endpoint`,
-    );
+    expect(
+      externalCompositionResult.enableExternalSchemaComposition.ok?.externalSchemaComposition
+        ?.endpoint,
+    ).toBe(`http://${dockerAddress}/non-existing-endpoint`);
 
     const productsServiceName = generateUnique();
     const publishProductsResult = await writeToken

--- a/packages/services/api/src/modules/project/providers/project-manager.ts
+++ b/packages/services/api/src/modules/project/providers/project-manager.ts
@@ -6,7 +6,6 @@ import { ActivityManager } from '../../activity/providers/activity-manager';
 import { AuthManager } from '../../auth/providers/auth-manager';
 import { OrganizationAccessScope } from '../../auth/providers/organization-access';
 import { ProjectAccessScope } from '../../auth/providers/project-access';
-import { SchemaManager } from '../../schema/providers/schema-manager';
 import { Logger } from '../../shared/providers/logger';
 import { OrganizationSelector, ProjectSelector, Storage } from '../../shared/providers/storage';
 import { TokenStorage } from '../../token/providers/token-storage';
@@ -26,7 +25,6 @@ export class ProjectManager {
     logger: Logger,
     private storage: Storage,
     private authManager: AuthManager,
-    private schemaManager: SchemaManager,
     private tokenStorage: TokenStorage,
     private activityManager: ActivityManager,
   ) {

--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -40,6 +40,9 @@ export default gql`
     Requires API Token
     """
     latestValidVersion: SchemaVersion
+    testExternalSchemaComposition(
+      selector: TestExternalSchemaCompositionInput!
+    ): TestExternalSchemaCompositionResult!
   }
 
   input DisableExternalSchemaCompositionInput {
@@ -51,7 +54,7 @@ export default gql`
   @oneOf
   """
   type DisableExternalSchemaCompositionResult {
-    ok: Boolean
+    ok: Project
     error: String
   }
 
@@ -66,12 +69,29 @@ export default gql`
   @oneOf
   """
   type EnableExternalSchemaCompositionResult {
-    ok: ExternalSchemaComposition
+    ok: Project
     error: EnableExternalSchemaCompositionError
   }
 
   type ExternalSchemaComposition {
     endpoint: String!
+  }
+
+  input TestExternalSchemaCompositionInput {
+    organization: ID!
+    project: ID!
+  }
+
+  """
+  @oneOf
+  """
+  type TestExternalSchemaCompositionResult {
+    ok: Project
+    error: TestExternalSchemaCompositionError
+  }
+
+  type TestExternalSchemaCompositionError implements Error {
+    message: String!
   }
 
   input UpdateProjectRegistryModelInput {

--- a/packages/services/api/src/modules/schema/resolvers.ts
+++ b/packages/services/api/src/modules/schema/resolvers.ts
@@ -410,6 +410,32 @@ export const resolvers: SchemaModule.Resolvers = {
         target: target.id,
       });
     },
+    async testExternalSchemaComposition(_, { selector }, { injector }) {
+      const translator = injector.get(IdTranslator);
+      const [organizationId, projectId] = await Promise.all([
+        translator.translateOrganizationId(selector),
+        translator.translateProjectId(selector),
+      ]);
+
+      const schemaManager = injector.get(SchemaManager);
+
+      const result = await schemaManager.testExternalSchemaComposition({
+        organizationId,
+        projectId,
+      });
+
+      if (result.kind === 'success') {
+        return {
+          ok: result.project,
+        };
+      }
+
+      return {
+        error: {
+          message: result.error,
+        },
+      };
+    },
   },
   Target: {
     latestSchemaVersion(target, _, { injector }) {

--- a/packages/web/app/src/components/project/settings/external-composition.tsx
+++ b/packages/web/app/src/components/project/settings/external-composition.tsx
@@ -59,7 +59,6 @@ const ExternalCompositionStatus = ({
   projectId,
   organizationId,
 }: {
-  endpoint: string;
   projectId: string;
   organizationId: string;
 }) => {

--- a/packages/web/app/src/components/project/settings/external-composition.tsx
+++ b/packages/web/app/src/components/project/settings/external-composition.tsx
@@ -2,15 +2,35 @@ import { useCallback, useState } from 'react';
 import { useFormik } from 'formik';
 import { useMutation, useQuery } from 'urql';
 import * as Yup from 'yup';
-import { Button, Card, Heading, Input, Spinner, Switch } from '@/components/v2';
+import { Button, Card, Heading, Input, Spinner, Switch, Tooltip } from '@/components/v2';
 import { FragmentType, graphql, useFragment } from '@/gql';
 import { useNotifications } from '@/lib/hooks';
+import { CheckIcon, Cross2Icon, UpdateIcon } from '@radix-ui/react-icons';
+
+export const ExternalCompositionStatus_TestQuery = graphql(`
+  query ExternalCompositionStatus_TestQuery($selector: TestExternalSchemaCompositionInput!) {
+    testExternalSchemaComposition(selector: $selector) {
+      ok {
+        id
+        externalSchemaComposition {
+          endpoint
+        }
+      }
+      error {
+        message
+      }
+    }
+  }
+`);
 
 export const ExternalCompositionForm_EnableMutation = graphql(`
   mutation ExternalCompositionForm_EnableMutation($input: EnableExternalSchemaCompositionInput!) {
     enableExternalSchemaComposition(input: $input) {
       ok {
-        endpoint
+        id
+        externalSchemaComposition {
+          endpoint
+        }
       }
       error {
         message
@@ -35,6 +55,48 @@ const ExternalCompositionForm_ProjectFragment = graphql(`
   }
 `);
 
+const ExternalCompositionStatus = ({
+  projectId,
+  organizationId,
+}: {
+  endpoint: string;
+  projectId: string;
+  organizationId: string;
+}) => {
+  const [query] = useQuery({
+    query: ExternalCompositionStatus_TestQuery,
+    variables: {
+      selector: {
+        project: projectId,
+        organization: organizationId,
+      },
+    },
+    requestPolicy: 'network-only',
+  });
+
+  const error = query.error?.message ?? query.data?.testExternalSchemaComposition?.error?.message;
+
+  return (
+    <Tooltip.Provider delayDuration={100}>
+      {query.fetching ? (
+        <Tooltip content="Connecting..." contentProps={{ side: 'right' }}>
+          <UpdateIcon className="animate-spin h-5 w-5 text-gray-500" />
+        </Tooltip>
+      ) : null}
+      {error ? (
+        <Tooltip content={error} contentProps={{ side: 'right' }}>
+          <Cross2Icon className="h-5 w-5 text-red-500" />
+        </Tooltip>
+      ) : null}
+      {query.data?.testExternalSchemaComposition?.ok?.externalSchemaComposition?.endpoint ? (
+        <Tooltip content="Service is available" contentProps={{ side: 'right' }}>
+          <CheckIcon className="h-5 w-5 text-green-500" />
+        </Tooltip>
+      ) : null}
+    </Tooltip.Provider>
+  );
+};
+
 const ExternalCompositionForm = ({
   endpoint,
   ...props
@@ -50,98 +112,128 @@ const ExternalCompositionForm = ({
   );
   const notify = useNotifications();
   const [mutation, enable] = useMutation(ExternalCompositionForm_EnableMutation);
-  const { handleSubmit, values, handleChange, handleBlur, isSubmitting, errors, touched } =
-    useFormik({
-      enableReinitialize: true,
-      initialValues: {
-        endpoint: endpoint ?? '',
-        secret: '',
-      },
-      validationSchema: Yup.object().shape({
-        endpoint: Yup.string().required(),
-        secret: Yup.string().required(),
+  const {
+    handleSubmit,
+    values,
+    handleChange,
+    handleBlur,
+    isSubmitting,
+    errors,
+    touched,
+    dirty,
+    resetForm,
+  } = useFormik({
+    enableReinitialize: true,
+    initialValues: {
+      endpoint: endpoint ?? '',
+      secret: '',
+    },
+    validationSchema: Yup.object().shape({
+      endpoint: Yup.string().required(),
+      secret: Yup.string().required(),
+    }),
+    onSubmit: values =>
+      enable({
+        input: {
+          project: project.cleanId,
+          organization: organization.cleanId,
+          endpoint: values.endpoint,
+          secret: values.secret,
+        },
+      }).then(result => {
+        resetForm();
+        if (result.data?.enableExternalSchemaComposition?.ok) {
+          notify('External composition enabled', 'success');
+        }
       }),
-      onSubmit: values =>
-        enable({
-          input: {
-            project: project.cleanId,
-            organization: organization.cleanId,
-            endpoint: values.endpoint,
-            secret: values.secret,
-          },
-        }).then(result => {
-          if (result.data?.enableExternalSchemaComposition?.ok) {
-            notify('External composition enabled', 'success');
-          }
-        }),
-    });
+  });
 
   const mutationError = mutation.data?.enableExternalSchemaComposition.error;
 
   return (
-    <form onSubmit={handleSubmit} className="flex flex-col gap-4">
-      <div>
-        <span>HTTP endpoint</span>
-        <p className="pb-2 text-xs text-gray-300">A POST request will be sent to that endpoint</p>
-        <Input
-          placeholder="Endpoint"
-          name="endpoint"
-          value={values.endpoint}
-          onChange={handleChange}
-          onBlur={handleBlur}
-          disabled={isSubmitting}
-          isInvalid={touched.endpoint && !!errors.endpoint}
-          className="w-96"
-        />
-        {touched.endpoint && (errors.endpoint || mutationError?.inputErrors?.endpoint) && (
-          <div className="mt-2 text-xs text-red-500">
-            {errors.endpoint ?? mutationError?.inputErrors?.endpoint}
+    <div className="flex justify-between">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <div>
+          <span>HTTP endpoint</span>
+          <p className="pb-2 text-xs text-gray-300">A POST request will be sent to that endpoint</p>
+          <div className="flex gap-2 items-center">
+            <Input
+              placeholder="Endpoint"
+              name="endpoint"
+              value={values.endpoint}
+              onChange={handleChange}
+              onBlur={handleBlur}
+              disabled={isSubmitting}
+              isInvalid={touched.endpoint && !!errors.endpoint}
+              className="w-96"
+            />
+            {!dirty &&
+            (endpoint ||
+              mutation.data?.enableExternalSchemaComposition.ok?.externalSchemaComposition
+                ?.endpoint) ? (
+              <ExternalCompositionStatus
+                projectId={project.cleanId}
+                organizationId={organization.cleanId}
+              />
+            ) : null}
           </div>
-        )}
-      </div>
+          {touched.endpoint && (errors.endpoint || mutationError?.inputErrors?.endpoint) && (
+            <div className="mt-2 text-xs text-red-500">
+              {errors.endpoint ?? mutationError?.inputErrors?.endpoint}
+            </div>
+          )}
+        </div>
 
-      <div>
-        <span>Secret</span>
-        <p className="pb-2 text-xs text-gray-300">
-          The secret is needed to sign and verify the request.
-        </p>
-        <Input
-          placeholder="Secret"
-          name="secret"
-          type="password"
-          value={values.secret}
-          onChange={handleChange}
-          onBlur={handleBlur}
-          disabled={isSubmitting}
-          isInvalid={touched.secret && !!errors.secret}
-          className="w-96"
-        />
-        {touched.secret && (errors.secret || mutationError?.inputErrors?.secret) && (
-          <div className="mt-2 text-xs text-red-500">
-            {errors.secret ?? mutationError?.inputErrors?.secret}
-          </div>
+        <div>
+          <span>Secret</span>
+          <p className="pb-2 text-xs text-gray-300">
+            The secret is needed to sign and verify the request.
+          </p>
+          <Input
+            placeholder="Secret"
+            name="secret"
+            type="password"
+            value={values.secret}
+            onChange={handleChange}
+            onBlur={handleBlur}
+            disabled={isSubmitting}
+            isInvalid={touched.secret && !!errors.secret}
+            className="w-96"
+          />
+          {touched.secret && (errors.secret || mutationError?.inputErrors?.secret) && (
+            <div className="mt-2 text-xs text-red-500">
+              {errors.secret ?? mutationError?.inputErrors?.secret}
+            </div>
+          )}
+        </div>
+        {mutation.error && (
+          <div className="mt-2 text-xs text-red-500">{mutation.error.message}</div>
         )}
-      </div>
-      {mutation.error && <div className="mt-2 text-xs text-red-500">{mutation.error.message}</div>}
-      <div>
-        <Button
-          type="submit"
-          variant="primary"
-          size="large"
-          className="px-10"
-          disabled={isSubmitting}
-        >
-          Save
-        </Button>
-      </div>
-    </form>
+        <div>
+          <Button
+            type="submit"
+            variant="primary"
+            size="large"
+            className="px-10"
+            disabled={isSubmitting}
+          >
+            Save
+          </Button>
+        </div>
+      </form>
+    </div>
   );
 };
 
 export const ExternalComposition_DisableMutation = graphql(`
   mutation ExternalComposition_DisableMutation($input: DisableExternalSchemaCompositionInput!) {
     disableExternalSchemaComposition(input: $input) {
-      ok
+      ok {
+        id
+        externalSchemaComposition {
+          endpoint
+        }
+      }
       error
     }
   }

--- a/packages/web/app/src/components/v2/tooltip.tsx
+++ b/packages/web/app/src/components/v2/tooltip.tsx
@@ -1,13 +1,28 @@
-import { ReactElement, ReactNode } from 'react';
+import { ComponentProps, ReactElement, ReactNode } from 'react';
 import { clsx } from 'clsx';
 import * as T from '@radix-ui/react-tooltip';
 
-function Wrapper({ children, content }: { children: ReactNode; content: ReactNode }): ReactElement {
+function Wrapper({
+  children,
+  content,
+  contentProps = {},
+}: {
+  children: ReactNode;
+  content: ReactNode;
+  contentProps?: ComponentProps<typeof T.Content>;
+}): ReactElement {
   return (
     <T.Root>
-      <T.Trigger>{children}</T.Trigger>
+      <T.Trigger
+        onClick={e => {
+          e.preventDefault();
+        }}
+      >
+        {children}
+      </T.Trigger>
       <T.Content
         sideOffset={4}
+        {...contentProps}
         className={clsx(
           'radix-side-top:animate-slide-down-fade',
           'radix-side-right:animate-slide-left-fade',

--- a/packages/web/app/src/lib/urql-cache.ts
+++ b/packages/web/app/src/lib/urql-cache.ts
@@ -1,11 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import produce from 'immer';
 import { getOperationName, TypedDocumentNode } from 'urql';
-import {
-  ExternalComposition_DisableMutation,
-  ExternalComposition_ProjectConfigurationQuery,
-  ExternalCompositionForm_EnableMutation,
-} from '@/components/project/settings/external-composition';
 import { ResultOf, VariablesOf } from '@graphql-typed-document-node/core';
 import { Cache, QueryInput, UpdateResolver } from '@urql/exchange-graphcache';
 import {
@@ -356,71 +351,6 @@ const deleteGitHubIntegration: TypedDocumentNodeUpdateResolver<
   );
 };
 
-const enableExternalSchemaComposition: TypedDocumentNodeUpdateResolver<
-  typeof ExternalCompositionForm_EnableMutation
-> = ({ enableExternalSchemaComposition }, args, cache) => {
-  if (enableExternalSchemaComposition.ok) {
-    cache.updateQuery(
-      {
-        query: ExternalComposition_ProjectConfigurationQuery,
-        variables: {
-          selector: {
-            organization: args.input.organization,
-            project: args.input.project,
-          },
-        },
-      },
-      data => {
-        if (data === null) {
-          return null;
-        }
-
-        const { ok } = enableExternalSchemaComposition;
-
-        if (ok && data.project?.externalSchemaComposition) {
-          data.project.externalSchemaComposition = {
-            __typename: 'ExternalSchemaComposition',
-            endpoint: ok.endpoint,
-          };
-        }
-
-        return data;
-      },
-    );
-  }
-};
-
-const disableExternalSchemaComposition: TypedDocumentNodeUpdateResolver<
-  typeof ExternalComposition_DisableMutation
-> = ({ disableExternalSchemaComposition }, args, cache) => {
-  if (disableExternalSchemaComposition.ok) {
-    cache.updateQuery(
-      {
-        query: ExternalComposition_ProjectConfigurationQuery,
-        variables: {
-          selector: {
-            organization: args.input.organization,
-            project: args.input.project,
-          },
-        },
-      },
-      data => {
-        if (data === null) {
-          return null;
-        }
-
-        const { ok } = disableExternalSchemaComposition;
-
-        if (ok && data.project?.externalSchemaComposition) {
-          data.project.externalSchemaComposition = null;
-        }
-
-        return data;
-      },
-    );
-  }
-};
-
 // UpdateResolver
 export const Mutation = {
   createOrganization,
@@ -438,6 +368,4 @@ export const Mutation = {
   deleteAlertChannels,
   addAlert,
   deletePersistedOperation,
-  enableExternalSchemaComposition,
-  disableExternalSchemaComposition,
 };


### PR DESCRIPTION
On hold - I will do a button with 3 states (success, in progress, failure) and let users test the endpoint + secret they provided but also the already existing endpoint (with already existing secret).