### PR TITLE
fix renovate config and extract versions from files under deployment dir

### DIFF
--- a/deployment/services/database-cleanup.ts
+++ b/deployment/services/database-cleanup.ts
@@ -15,7 +15,7 @@ export function deployDatabaseCleanupJob(options: { deploymentEnv: DeploymentEnv
   const { job } = new ServiceDeployment(
     'db-cleanup',
     {
-      image: 'jbergknoff/postgresql-client',
+      image: 'jbergknoff/postgresql-client:latest',
       env: {
         PG_CONNECTION_STRING: rawConnectionString,
         // to make sure we can run this over and over

--- a/deployment/utils/botkube.ts
+++ b/deployment/utils/botkube.ts
@@ -1,5 +1,6 @@
 import * as k8s from '@pulumi/kubernetes';
 import { Output } from '@pulumi/pulumi';
+import { helmChart } from './helm';
 
 export class BotKube {
   deploy(config: {
@@ -17,12 +18,8 @@ export class BotKube {
     new k8s.helm.v3.Chart(
       'botkube',
       {
-        chart: 'botkube',
-        version: '0.12.4',
+        ...helmChart('https://infracloudio.github.io/charts', 'botkube', '0.12.4'),
         namespace: ns.metadata.name,
-        fetchOpts: {
-          repo: 'https://infracloudio.github.io/charts',
-        },
         values: {
           communications: {
             slack: {

--- a/deployment/utils/helm.ts
+++ b/deployment/utils/helm.ts
@@ -1,0 +1,15 @@
+import { ChartOpts } from '@pulumi/kubernetes/helm/v3';
+
+export function helmChart(
+  repo: string,
+  chart: string,
+  version: string,
+): Pick<ChartOpts, 'chart' | 'version' | 'fetchOpts'> {
+  return {
+    chart,
+    version,
+    fetchOpts: {
+      repo,
+    },
+  };
+}

--- a/deployment/utils/observability.ts
+++ b/deployment/utils/observability.ts
@@ -1,5 +1,6 @@
 import * as k8s from '@pulumi/kubernetes';
 import { interpolate, Output } from '@pulumi/pulumi';
+import { helmChart } from './helm';
 
 export type ObservabilityConfig = {
   loki: {
@@ -26,12 +27,12 @@ export class Observability {
     // We are using otel-collector to scrape metrics from Pods
     // dotansimha: once Vector supports scraping K8s metrics based on Prom, we can drop this.
     new k8s.helm.v3.Chart('metrics', {
-      chart: 'opentelemetry-collector',
+      ...helmChart(
+        'https://open-telemetry.github.io/opentelemetry-helm-charts',
+        'opentelemetry-collector',
+        '0.17.0',
+      ),
       namespace: ns.metadata.name,
-      version: '0.17.0',
-      fetchOpts: {
-        repo: 'https://open-telemetry.github.io/opentelemetry-helm-charts',
-      },
       // https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-collector/values.yaml
       values: {
         agentCollector: {
@@ -291,12 +292,8 @@ export class Observability {
     new k8s.helm.v3.Chart(
       'vector-logging',
       {
-        chart: 'vector',
-        version: '0.10.3',
+        ...helmChart('https://helm.vector.dev', 'vector', '0.10.3'),
         namespace: ns.metadata.name,
-        fetchOpts: {
-          repo: 'https://helm.vector.dev',
-        },
         // https://vector.dev/docs/reference/configuration/
         values: {
           role: 'Agent',

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -1,5 +1,6 @@
 import * as k8s from '@pulumi/kubernetes';
 import { Output } from '@pulumi/pulumi';
+import { helmChart } from './helm';
 
 export class Proxy {
   private lbService: Output<k8s.core.v1.Service> | null = null;
@@ -121,12 +122,8 @@ export class Proxy {
     });
 
     const proxyController = new k8s.helm.v3.Chart('contour-proxy', {
-      chart: 'contour',
-      version: '10.1.3',
+      ...helmChart('https://charts.bitnami.com/bitnami', 'contour', '10.1.3'),
       namespace: ns.metadata.name,
-      fetchOpts: {
-        repo: 'https://charts.bitnami.com/bitnami',
-      },
       // https://github.com/bitnami/charts/tree/master/bitnami/contour
       values: {
         configInline: {

--- a/renovate.json
+++ b/renovate.json
@@ -51,10 +51,17 @@
   ],
   "regexManagers": [
     {
-      "fileMatch": ["deployment/services/**/*.ts"],
-      "matchStrings": ["image: '(?<datasource>.*?)/(?<depName>.*?):(?<versioning>.*?)'"],
+      "fileMatch": ["deployment/.*?\\.ts$"],
+      "matchStrings": ["image: (?:'|\")(?<depName>.*?):(?<currentValue>.*?)(?:'|\")"],
       "datasourceTemplate": "docker",
-      "currentValueTemplate": "{{{currentValue}}}"
+      "versioningTemplate": "docker"
+    },
+    {
+      "fileMatch": ["deployment/.*?\\.ts$"],
+      "matchStrings": [
+        "helmChart\\((?:'|\")(?<registryUrl>.*?)(?:'|\"), (?:'|\")(?<depName>.*?)(?:'|\"), (?:'|\")(?<currentValue>.*?)(?:'|\")\\)"
+      ],
+      "datasourceTemplate": "helm"
     }
   ]
 }


### PR DESCRIPTION
Closes https://github.com/kamilkisiela/graphql-hive/issues/1510 

- [x] Extract Docker images from `image: "..."` under `deployment`
- [x] Extract Helm charts versions from `deployment`
- [x] Testing