### PR TITLE
docs: add callout to have TLS1.2 or higher to install CLI

### DIFF
--- a/packages/web/docs/src/pages/features/publish-schema.mdx
+++ b/packages/web/docs/src/pages/features/publish-schema.mdx
@@ -21,6 +21,8 @@ Install [`@graphql-hive/cli`](https://www.npmjs.com/package/@graphql-hive/cli) p
 
 Install latest version:
 
+<Callout type="info">You need TLS v1.2 or higher to install this script.</Callout>
+
 ```bash
 curl -sSL https://graphql-hive.com/install.sh | sh
 ```

--- a/packages/web/docs/src/pages/features/publish-schema.mdx
+++ b/packages/web/docs/src/pages/features/publish-schema.mdx
@@ -21,7 +21,7 @@ Install [`@graphql-hive/cli`](https://www.npmjs.com/package/@graphql-hive/cli) p
 
 Install latest version:
 
-<Callout type="info">You need TLS v1.2 or higher to install this script.</Callout>
+<Callout type="warning">You need TLS v1.2 or higher to install this script.</Callout>
 
 ```bash
 curl -sSL https://graphql-hive.com/install.sh | sh


### PR DESCRIPTION
### Background

For security compliance we use `TSL v1.2` if users are running `1.1` then using `cUrl` they will not be able to install the CLI.

### Description

| Before | After | 
| ------|-------|
|![CleanShot 2023-03-02 at 15 41 48](https://user-images.githubusercontent.com/44710980/222547399-65702420-80f2-4cd8-a9ed-7aa776ca585d.png) | ![CleanShot 2023-03-02 at 15 41 23](https://user-images.githubusercontent.com/44710980/222547386-4c7c6cb5-0744-43d3-95ca-d535b1a81a0d.png)|