### PR TITLE
Small improvements to the schema publishing flow

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -13,6 +13,7 @@ __generated__/
 /packages/web/app/src/graphql/index.ts
 /packages/web/app/next.config.mjs
 /packages/migrations/test/utils/testkit.ts
+/packages/web/app/storybook-static
 
 # test fixtures
 integration-tests/fixtures/init-invalid-schema.graphql

--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -624,6 +624,31 @@ export function deleteSchema(
       mutation schemaDelete($input: SchemaDeleteInput!) {
         schemaDelete(input: $input) {
           __typename
+          ... on SchemaDeleteSuccess {
+            valid
+            changes {
+              nodes {
+                criticality
+                message
+              }
+              total
+            }
+            errors {
+              nodes {
+                message
+              }
+              total
+            }
+          }
+          ... on SchemaDeleteError {
+            valid
+            errors {
+              nodes {
+                message
+              }
+              total
+            }
+          }
         }
       }
     `),

--- a/integration-tests/tests/api/schema/composite.spec.ts
+++ b/integration-tests/tests/api/schema/composite.spec.ts
@@ -97,9 +97,9 @@ describe.each`
       ).then(r => r.expectNoGraphQLErrors()),
     ).resolves.toEqual(
       expect.objectContaining({
-        schemaDelete: {
+        schemaDelete: expect.objectContaining({
           __typename: 'SchemaDeleteSuccess',
-        },
+        }),
       }),
     );
 
@@ -178,9 +178,9 @@ describe.each`
 
       await expect(deleteSchema('service-b').then(r => r.expectNoGraphQLErrors())).resolves.toEqual(
         expect.objectContaining({
-          schemaDelete: {
+          schemaDelete: expect.objectContaining({
             __typename: 'SchemaDeleteSuccess',
-          },
+          }),
         }),
       );
 

--- a/packages/services/api/src/modules/lab/resolvers.ts
+++ b/packages/services/api/src/modules/lab/resolvers.ts
@@ -1,7 +1,7 @@
 import { AuthManager } from '../auth/providers/auth-manager';
 import { TargetAccessScope } from '../auth/providers/target-access';
 import { ProjectManager } from '../project/providers/project-manager';
-import { SchemaHelper } from '../schema/providers/schema-helper';
+import { ensureSDL, SchemaHelper } from '../schema/providers/schema-helper';
 import { SchemaManager } from '../schema/providers/schema-manager';
 import { IdTranslator } from '../shared/providers/id-translator';
 import type { LabModule } from './__generated__/types';
@@ -51,9 +51,11 @@ export const resolvers: LabModule.Resolvers = {
       const orchestrator = schemaManager.matchOrchestrator(type);
       const helper = injector.get(SchemaHelper);
 
-      const schema = await orchestrator.build(
-        schemas.map(s => helper.createSchemaObject(s)),
-        externalComposition,
+      const schema = await ensureSDL(
+        orchestrator.composeAndValidate(
+          schemas.map(s => helper.createSchemaObject(s)),
+          externalComposition,
+        ),
       );
 
       return {

--- a/packages/services/api/src/modules/schema/providers/models/composite-legacy.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite-legacy.ts
@@ -333,7 +333,8 @@ export class CompositeLegacyModel {
           compositionErrors,
           schema: incoming,
           schemas,
-          orchestrator,
+          supergraph: compositionCheck.result?.supergraph ?? null,
+          fullSchemaSdl: compositionCheck.result?.fullSchemaSdl ?? null,
         },
       };
     }

--- a/packages/services/api/src/modules/schema/providers/models/composite.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite.ts
@@ -338,7 +338,8 @@ export class CompositeModel {
         compositionErrors: null,
         schema: incoming,
         schemas,
-        orchestrator,
+        supergraph: compositionCheck.result?.supergraph ?? null,
+        fullSchemaSdl: compositionCheck.result?.fullSchemaSdl ?? null,
       },
     };
   }

--- a/packages/services/api/src/modules/schema/providers/models/shared.ts
+++ b/packages/services/api/src/modules/schema/providers/models/shared.ts
@@ -1,5 +1,4 @@
 import { PushedCompositeSchema, SingleSchema } from 'packages/services/api/src/shared/entities';
-import { Orchestrator } from './../../../../shared/entities';
 import type { SchemaModule } from './../../__generated__/types';
 
 export const SchemaPublishConclusion = {
@@ -153,7 +152,8 @@ type SchemaPublishSuccess = {
     }> | null;
     schema: SingleSchema | PushedCompositeSchema;
     schemas: [SingleSchema] | PushedCompositeSchema[];
-    orchestrator: Orchestrator;
+    supergraph: string | null;
+    fullSchemaSdl: string | null;
   };
 };
 

--- a/packages/services/api/src/modules/schema/providers/models/single-legacy.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single-legacy.ts
@@ -257,7 +257,8 @@ export class SingleLegacyModel {
           compositionErrors,
           schema: incoming,
           schemas,
-          orchestrator: this.orchestrator,
+          supergraph: null,
+          fullSchemaSdl: compositionCheck.result?.fullSchemaSdl ?? null,
         },
       };
     }

--- a/packages/services/api/src/modules/schema/providers/models/single.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single.ts
@@ -250,7 +250,8 @@ export class SingleModel {
         compositionErrors: null,
         schema: incoming,
         schemas,
-        orchestrator: this.orchestrator,
+        supergraph: null,
+        fullSchemaSdl: compositionCheck.result?.fullSchemaSdl ?? null,
       },
     };
   }

--- a/packages/services/api/src/modules/schema/providers/orchestrators/errors.ts
+++ b/packages/services/api/src/modules/schema/providers/orchestrators/errors.ts
@@ -1,7 +1,3 @@
 import { HiveError } from '../../../../shared/errors';
 
-export class SchemaBuildError extends HiveError {
-  constructor(error: Error) {
-    super(`Failed to build schema: ${error.message}`);
-  }
-}
+export class SchemaBuildError extends HiveError {}

--- a/packages/services/api/src/modules/schema/providers/schema-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-helper.ts
@@ -1,8 +1,9 @@
 import { createHash } from 'crypto';
-import { print } from 'graphql';
+import { parse, print } from 'graphql';
 import { Injectable, Scope } from 'graphql-modules';
 import objectHash from 'object-hash';
 import type {
+  ComposeAndValidateResult,
   CompositeSchema,
   PushedCompositeSchema,
   Schema,
@@ -12,6 +13,7 @@ import type {
 import { createSchemaObject } from '../../../shared/entities';
 import { cache } from '../../../shared/helpers';
 import { sortDocumentNode } from '../../../shared/schema';
+import { SchemaBuildError } from './orchestrators/errors';
 
 export function isSingleSchema(schema: Schema): schema is SingleSchema {
   return schema.kind === 'single';
@@ -92,13 +94,41 @@ export function extendWithBase(
   });
 }
 
+type CreateSchemaObjectInput = Parameters<typeof createSchemaObject>[0];
+
+export async function ensureSDL(
+  composeAndValidationResultPromise: Promise<ComposeAndValidateResult>,
+) {
+  const composeAndValidationResult = await composeAndValidationResultPromise;
+
+  if (!composeAndValidationResult.sdl) {
+    if (composeAndValidationResult.errors) {
+      throw new SchemaBuildError(
+        `Composition errors: \n` +
+          composeAndValidationResult.errors.map(err => ` - ${String(err)}`).join('\n'),
+      );
+    }
+
+    throw new Error('Expected to find SDL');
+  }
+
+  try {
+    return {
+      document: parse(composeAndValidationResult.sdl),
+      raw: composeAndValidationResult.sdl,
+    };
+  } catch (error) {
+    throw new SchemaBuildError(`Failed to parse schema: ${String(error)}`);
+  }
+}
+
 @Injectable({
   scope: Scope.Operation,
   global: true,
 })
 export class SchemaHelper {
-  @cache<SingleSchema | PushedCompositeSchema>(schema => JSON.stringify(schema))
-  createSchemaObject(schema: SingleSchema | PushedCompositeSchema): SchemaObject {
+  @cache<CreateSchemaObjectInput>(schema => JSON.stringify(schema))
+  createSchemaObject(schema: CreateSchemaObjectInput): SchemaObject {
     return createSchemaObject(schema);
   }
 

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -2,7 +2,6 @@ import { Injectable } from 'graphql-modules';
 import type {
   AddAlertChannelInput,
   AddAlertInput,
-  ProjectType,
   RegistryModel,
 } from '../../../__generated__/types';
 import type {
@@ -289,18 +288,6 @@ export interface Storage {
   >;
   getVersion(_: TargetSelector & { version: string }): Promise<SchemaVersion | never>;
 
-  insertSchema(
-    _: {
-      schema: string;
-      commit: string;
-      author: string;
-      service?: string | null;
-      url?: string | null;
-      metadata: string | null;
-      projectType: ProjectType;
-    } & TargetSelector,
-  ): Promise<Schema | never>;
-
   deleteSchema(
     _: {
       serviceName: string;
@@ -310,11 +297,16 @@ export interface Storage {
 
   createVersion(
     _: {
+      schema: string;
+      author: string;
+      service?: string | null;
+      metadata: string | null;
       valid: boolean;
       url?: string | null;
       commit: string;
-      commits: string[];
+      logIds: string[];
       base_schema: string | null;
+      actionFn(): Promise<void>;
     } & TargetSelector,
   ): Promise<SchemaVersion | never>;
 

--- a/packages/services/api/src/shared/entities.ts
+++ b/packages/services/api/src/shared/entities.ts
@@ -98,7 +98,11 @@ export class GraphQLDocumentStringInvalidError extends Error {
   }
 }
 
-export function createSchemaObject(schema: SingleSchema | PushedCompositeSchema): SchemaObject {
+export function createSchemaObject(
+  schema:
+    | Pick<SingleSchema, 'sdl'>
+    | Pick<PushedCompositeSchema, 'sdl' | 'service_name' | 'service_url'>,
+): SchemaObject {
   let document: DocumentNode;
 
   try {
@@ -247,16 +251,17 @@ export interface TargetSettings {
   };
 }
 
+export interface ComposeAndValidateResult {
+  supergraph: string | null;
+  errors: CompositionFailureError[];
+  sdl: string | null;
+}
+
 export interface Orchestrator {
-  validate(
+  composeAndValidate(
     schemas: SchemaObject[],
     config: Project['externalComposition'],
-  ): Promise<CompositionFailureError[]>;
-  build(schemas: SchemaObject[], config: Project['externalComposition']): Promise<SchemaObject>;
-  supergraph(
-    schemas: SchemaObject[],
-    config: Project['externalComposition'],
-  ): Promise<string | null>;
+  ): Promise<ComposeAndValidateResult>;
 }
 
 export interface ActivityObject {

--- a/packages/services/api/src/shared/mappers.ts
+++ b/packages/services/api/src/shared/mappers.ts
@@ -116,14 +116,15 @@ export type SchemaVersionConnection = {
   nodes: readonly SchemaVersion[];
   hasMore: boolean;
 };
+type SchemaOnlyObject = Pick<SchemaObject, 'document' | 'raw'>;
 export type SchemaComparePayload =
   | SchemaCompareResult
   | {
       message: string;
     };
 export type SchemaCompareResult =
-  | readonly [SchemaObject, SchemaObject]
-  | readonly [undefined | null, SchemaObject];
+  | readonly [SchemaOnlyObject, SchemaOnlyObject]
+  | readonly [undefined | null, SchemaOnlyObject];
 
 export type SingleSchema = SingleSchemaEntity;
 export type PushedCompositeSchema = PushedCompositeSchemaEntity;

--- a/packages/services/api/src/shared/schema.ts
+++ b/packages/services/api/src/shared/schema.ts
@@ -29,7 +29,7 @@ export function hashSchema(schema: SchemaObject): string {
  * Builds GraphQLSchema without validation of SDL
  */
 export function buildSchema(
-  schema: SchemaObject,
+  schema: Pick<SchemaObject, 'document'>,
   transformError = (error: unknown) => error,
 ): GraphQLSchema {
   try {

--- a/packages/services/schema/src/metrics.ts
+++ b/packages/services/schema/src/metrics.ts
@@ -1,19 +1,7 @@
 import { metrics } from '@hive/service-common';
 
-export const validateCounter = new metrics.Counter({
-  name: 'schema_validate_total',
-  help: 'Number of call to validate schema',
-  labelNames: ['type'],
-});
-
-export const buildCounter = new metrics.Counter({
-  name: 'schema_build_total',
-  help: 'Number of call to build schema',
-  labelNames: ['type'],
-});
-
-export const supergraphCounter = new metrics.Counter({
-  name: 'schema_supergraph_total',
-  help: 'Number of call to build supergraph',
+export const composeAndValidateCounter = new metrics.Counter({
+  name: 'schema_compose_and_validate_total',
+  help: 'Number of call to compose and validate schemas',
   labelNames: ['type'],
 });

--- a/packages/services/schema/src/types.ts
+++ b/packages/services/schema/src/types.ts
@@ -2,35 +2,18 @@ import type { CompositionErrorSource } from './orchestrators';
 
 export type SchemaType = 'single' | 'federation' | 'stitching';
 
-export type BuildInput = Array<{
-  raw: string;
-  source: string;
-}>;
-
-export interface BuildOutput {
-  source: string;
-  raw: string;
-}
-
-export type ValidationInput = Array<{
-  raw: string;
-  source: string;
-}>;
-
-export interface ValidationOutput {
-  errors: Array<{
-    message: string;
-    source: CompositionErrorSource;
-  }>;
-}
-
-export type SupergraphInput = Array<{
+export type ComposeAndValidateInput = Array<{
   raw: string;
   source: string;
   url?: string | null;
 }>;
 
-export type SupergraphOutput = {
+export type ComposeAndValidateOutput = {
+  errors: Array<{
+    message: string;
+    source: CompositionErrorSource;
+  }>;
+  sdl: string | null;
   supergraph: string | null;
 };
 


### PR DESCRIPTION
- Uploading artifacts to CDN is now done as part of transaction
- Schema is published only after all artifacts are uploaded
- Only `composeAndValidate` procedure in the schema service
- Less calls to the schema service (SDLs of full schema and supegraph are passed as arguments)
- `schema_validate_total`, `schema_build_total` and `schema_supergraph_total` counter metrics are now replaced by `schema_compose_and_validate_total` counter metric