### PR TITLE
Fix missing composition error message

### DIFF
--- a/packages/services/api/src/modules/schema/providers/schema-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-helper.ts
@@ -105,7 +105,7 @@ export async function ensureSDL(
     if (composeAndValidationResult.errors) {
       throw new SchemaBuildError(
         `Composition errors: \n` +
-          composeAndValidationResult.errors.map(err => ` - ${String(err)}`).join('\n'),
+          composeAndValidationResult.errors.map(err => ` - ${err.message}`).join('\n'),
       );
     }
 


### PR DESCRIPTION
The object from `composeAndValidationResult.errors` array is not `Error`, it's an object with two props: `message` and `source`.