### PR TITLE
Testing for Vector upgrade 

### DIFF
--- a/deployment/utils/observability.ts
+++ b/deployment/utils/observability.ts
@@ -290,7 +290,7 @@ export class Observability {
       'vector-logging',
       {
         // prettier-ignore
-        ...helmChart('https://helm.vector.dev', 'vector', '0.13.0'),
+        ...helmChart('https://helm.vector.dev', 'vector', '0.15.1'),
         namespace: ns.metadata.name,
         // https://vector.dev/docs/reference/configuration/
         values: {

--- a/deployment/utils/observability.ts
+++ b/deployment/utils/observability.ts
@@ -290,7 +290,7 @@ export class Observability {
       'vector-logging',
       {
         // prettier-ignore
-        ...helmChart('https://helm.vector.dev', 'vector', '0.10.3'),
+        ...helmChart('https://helm.vector.dev', 'vector', '0.13.0'),
         namespace: ns.metadata.name,
         // https://vector.dev/docs/reference/configuration/
         values: {

--- a/deployment/utils/observability.ts
+++ b/deployment/utils/observability.ts
@@ -290,7 +290,7 @@ export class Observability {
       'vector-logging',
       {
         // prettier-ignore
-        ...helmChart('https://helm.vector.dev', 'vector', '0.15.1'),
+        ...helmChart('https://helm.vector.dev', 'vector', '0.20.1'),
         namespace: ns.metadata.name,
         // https://vector.dev/docs/reference/configuration/
         values: {


### PR DESCRIPTION
related: https://github.com/kamilkisiela/graphql-hive/pull/1532

- [x] 0.13.0 (https://vector.dev/highlights/2022-05-03-0-22-0-upgrade-guide/)
- [x] 0.15.1 (https://vector.dev/highlights/2022-07-07-0-23-0-upgrade-guide)
- [ ] 0.16.3 (https://vector.dev/highlights/2022-08-16-0-24-0-upgrade-guide/)
- [ ] 0.17.1 (https://vector.dev/highlights/2022-10-04-0-25-0-upgrade-guide/)
- [ ] 0.18.0 (https://vector.dev/highlights/2022-11-07-0-26-0-upgrade-guide/)
- [ ] 0.19.2 (https://vector.dev/highlights/2023-01-17-0-27-0-upgrade-guide/)
- [x] 0.20.1 (https://vector.dev/highlights/2023-02-28-0-28-0-upgrade-guide/)