### PR TITLE
docs: setting up codegen to use with Hive CDN

### DIFF
--- a/packages/web/docs/src/pages/integrations/_meta.json
+++ b/packages/web/docs/src/pages/integrations/_meta.json
@@ -9,5 +9,6 @@
   "graphql-ruby": "GraphQL-Ruby",
   "lighthouse": "Lighthouse (Laravel)",
   "ci-cd": "CI/CD Guide",
-  "code-first": "Code-First Frameworks"
+  "code-first": "Code-First Frameworks",
+  "graphql-code-generator": "GraphQL Code Generator"
 }

--- a/packages/web/docs/src/pages/integrations/graphql-code-generator.mdx
+++ b/packages/web/docs/src/pages/integrations/graphql-code-generator.mdx
@@ -1,0 +1,24 @@
+# GraphQL Code Generator
+
+[GraphQL Code Generator](https://the-guild.dev/graphql/codegen) is a tool that generates types from
+your GraphQL schema and operations. You can use
+[High-Availability CDN](/features/high-availability-cdn) to provide the schema.
+
+## Setting up the config
+
+You can configure codegen to use the Schema from the CDN:
+
+```ts {4-10} copy=false filename="codegen.ts"
+import { CodegenConfig } from '@graphql-codegen/cli'
+
+const config: CodegenConfig = {
+  schema: [
+    'https://cdn.graphql-hive.com/v1/artifacts/TARGET_ID/sdl.graphql': {
+      headers:{
+        'X-Hive-CDN-Key': "CDN_ACCESS_TOKEN"
+      },
+    }
+  ],
+  // Your existing config
+}
+```


### PR DESCRIPTION
Appending `.graphql` to SDL endpoint will return SDL which can be used in codegen and enables the [`handleAsSDL` option](https://the-guild.dev/graphql/codegen/docs/config-reference/schema-field#handleassdl) implicity.
