### PR TITLE
Update wget command to a correct url

### DIFF
--- a/packages/web/docs/src/pages/docs/self-hosting/get-started.mdx
+++ b/packages/web/docs/src/pages/docs/self-hosting/get-started.mdx
@@ -52,7 +52,7 @@ using `wget`. This's going to download the latest version available.
 > link below
 >
 > ```sh
-> bash wget https://raw.githubusercontent.com/kamilkisiela/graphql-hive/main/docker-compose.community.yml
+> bash wget https://raw.githubusercontent.com/kamilkisiela/graphql-hive/main/docker/docker-compose.community.yml
 > ```
 
 After downloading the `docker-compose.community.yml` file, this includes all the services required


### PR DESCRIPTION
### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->
It seems the docker-compose.community.yml file is elsewhere than on example wget command.

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
The change is only to the documentation in getting started tutorial with self-hosting Hive.