### PR TITLE
Fix Clients block in Operations page

### DIFF
--- a/packages/web/app/src/components/target/operations/Stats.tsx
+++ b/packages/web/app/src/components/target/operations/Stats.tsx
@@ -430,7 +430,7 @@ function ClientsStats({
       <Section.Subtitle>Top 5 - GraphQL API consumers</Section.Subtitle>
       <AutoSizer disableHeight className="mt-5 w-full">
         {size => {
-          if (!size.width || !size.height) {
+          if (!size.width) {
             return <></>;
           }
 


### PR DESCRIPTION
Because of `Autosize disableHeight` and `!size.height` combo, the child element never renders.