### PR TITLE
Hive Cloud: drop trial for Pro plan

### DIFF
--- a/packages/services/stripe-billing/src/api.ts
+++ b/packages/services/stripe-billing/src/api.ts
@@ -305,7 +305,6 @@ export const stripeBillingApiRouter = t.router({
         coupon: input.couponCode || undefined,
         customer: customerId,
         default_payment_method: paymentMethodId,
-        trial_end: Math.floor(addDays(new Date(), 30).getTime() / 1000),
         backdate_start_date: Math.floor(startOfMonth(new Date()).getTime() / 1000),
         items: [
           {

--- a/packages/web/app/pages/[orgId]/view/subscription/manage.tsx
+++ b/packages/web/app/pages/[orgId]/view/subscription/manage.tsx
@@ -247,15 +247,7 @@ function Inner(props: {
 
           <div className="flex flex-col">
             <div>
-              <PlanSummary plan={selectedPlan} operationsRateLimit={operationsRateLimit}>
-                {selectedPlan.planType === BillingPlanType.Pro && (
-                  <Stat>
-                    <Stat.Label>Free Trial</Stat.Label>
-                    <Stat.Number>30</Stat.Number>
-                    <Stat.HelpText>days</Stat.HelpText>
-                  </Stat>
-                )}
-              </PlanSummary>
+              <PlanSummary plan={selectedPlan} operationsRateLimit={operationsRateLimit} />
             </div>
 
             {plan === BillingPlanType.Pro && (

--- a/packages/web/app/src/components/organization/billing/BillingPlanPicker.tsx
+++ b/packages/web/app/src/components/organization/billing/BillingPlanPicker.tsx
@@ -29,11 +29,6 @@ const planCollection: {
       '$10 per 1M operations',
       '90 days of usage data retention',
     ],
-    footer: (
-      <>
-        <div className="mb-2 text-sm font-bold">Free 30 days trial period</div>
-      </>
-    ),
   },
   [BillingPlanType.Enterprise]: {
     description: 'Custom plan for large companies',

--- a/packages/web/app/src/components/organization/billing/PlanSummary.tsx
+++ b/packages/web/app/src/components/organization/billing/PlanSummary.tsx
@@ -63,7 +63,7 @@ function PriceEstimationTable(props: {
         )}
       </TBody>
       <TFoot>
-        <Th>Total monthly (after trial ends)</Th>
+        <Th>Total monthly</Th>
         <Th align="right">{total === 0 ? 'FREE' : CurrencyFormatter.format(total)}</Th>
       </TFoot>
     </Table>
@@ -85,7 +85,7 @@ export function PlanSummary({
 }: {
   plan: FragmentType<typeof PlanSummary_PlanFragment>;
   operationsRateLimit: number;
-  children: ReactNode;
+  children?: ReactNode;
 }): ReactElement {
   const plan = useFragment(PlanSummary_PlanFragment, props.plan);
   if (plan.planType === BillingPlanType.Enterprise) {

--- a/packages/web/docs/src/components/pricing.tsx
+++ b/packages/web/docs/src/components/pricing.tsx
@@ -100,7 +100,6 @@ export function Pricing({ gradient }: { gradient: [string, string] }): ReactElem
                 90 days of usage data retention
               </Tooltip>,
             ]}
-            footer={<div className="mb-2 text-sm font-bold">Free 30 days trial period</div>}
           />
           <Plan
             name="Enterprise"


### PR DESCRIPTION
Since Hive Free plan provides access to all features, there is no real need for a trial period on the Pro plan. 
Users who wish to experiment and test Hive, can use the Free plan, and upgrade to Pro if they need more data to be stored. 
