### PR TITLE
Update get-started.mdx

### DIFF
--- a/packages/web/docs/src/pages/docs/self-hosting/get-started.mdx
+++ b/packages/web/docs/src/pages/docs/self-hosting/get-started.mdx
@@ -103,15 +103,15 @@ After setting the environment variables, pull the required images for GraphQL Hi
 going to take some time if you're doing it for the first time.
 
 ```bash
-docker compose -f docker-compose.community.yml pull
+docker-compose -f docker-compose.community.yml pull
 ```
 
-After it's done, you can start the GraphQL Hive services using `docker compose`.
+After it's done, you can start the GraphQL Hive services using `docker-compose`.
 
 ```bash
-docker compose -f docker-compose.community.yml up
-# or of you embedded the environment variables into your docker compose file and called it `docker-compose.with-env.yml`
-docker compose -f docker-compose.with-env.yml up
+docker-compose -f docker-compose.community.yml up
+# or of you embedded the environment variables into your docker-compose file and called it `docker-compose.with-env.yml`
+docker-compose -f docker-compose.with-env.yml up
 ```
 
 Wait until all the services are up and running.


### PR DESCRIPTION
Update non-existent command, `docker compose` to correct `docker-compose`

### Background

Can't run the commands for self-hosting by copying and pasting. `compose` is (by default at least) not an actual command under docker. The instructions should use `docker-compose`

### Description

Simple markdown change.

### Checklist

not applicable
