### PR TITLE
feat: make sure legacy project records are not broken

### DIFF
--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -3427,50 +3427,52 @@ test.concurrent(
   },
 );
 
-test.concurrent('legacy service stitching with missing service', async ({ expect }) => {
-  const { createOrg } = await initSeed().createOwner();
-  const { createProject } = await createOrg();
-  const { /* project, target,*/ createToken } = await createProject(ProjectType.Stitching, {
-    useLegacyRegistryModels: true,
-  });
+test.concurrent(
+  'legacy stitching project service without url results in correct change when an url is added',
+  async ({ expect }) => {
+    const { createOrg } = await initSeed().createOwner();
+    const { createProject } = await createOrg();
+    const { /* project, target,*/ createToken } = await createProject(ProjectType.Stitching, {
+      useLegacyRegistryModels: true,
+    });
 
-  const writeToken = await createToken({
-    targetScopes: [TargetAccessScope.RegistryRead, TargetAccessScope.RegistryWrite],
-    projectScopes: [ProjectAccessScope.Settings, ProjectAccessScope.Read],
-    organizationScopes: [],
-  });
+    const writeToken = await createToken({
+      targetScopes: [TargetAccessScope.RegistryRead, TargetAccessScope.RegistryWrite],
+      projectScopes: [ProjectAccessScope.Settings, ProjectAccessScope.Read],
+      organizationScopes: [],
+    });
 
-  let result = await writeToken
-    .publishSchema({
-      sdl: 'type Query { ping: String! }',
-      author: 'Laurin',
-      commit: '123',
-      service: 'foo1',
-    })
-    .then(r => r.expectNoGraphQLErrors());
+    let result = await writeToken
+      .publishSchema({
+        sdl: 'type Query { ping: String! }',
+        author: 'Laurin',
+        commit: '123',
+        service: 'foo1',
+      })
+      .then(r => r.expectNoGraphQLErrors());
 
-  expect(result.schemaPublish.__typename).toEqual('SchemaPublishSuccess');
+    expect(result.schemaPublish.__typename).toEqual('SchemaPublishSuccess');
 
-  result = await writeToken
-    .publishSchema({
-      sdl: 'type Query { ping: String! }',
-      author: 'Laurin',
-      commit: '123',
-      service: 'foo1',
-      url: 'https://api.com/foo1',
-    })
-    .then(r => r.expectNoGraphQLErrors());
+    result = await writeToken
+      .publishSchema({
+        sdl: 'type Query { ping: String! }',
+        author: 'Laurin',
+        commit: '123',
+        service: 'foo1',
+        url: 'https://api.com/foo1',
+      })
+      .then(r => r.expectNoGraphQLErrors());
 
-  expect(result.schemaPublish.__typename).toEqual('SchemaPublishSuccess');
+    expect(result.schemaPublish.__typename).toEqual('SchemaPublishSuccess');
 
-  const newVersionId = (await writeToken.fetchLatestValidSchema())?.latestValidVersion?.id;
+    const newVersionId = (await writeToken.fetchLatestValidSchema())?.latestValidVersion?.id;
 
-  if (typeof newVersionId !== 'string') {
-    throw new Error('newVersionId is not a string');
-  }
+    if (typeof newVersionId !== 'string') {
+      throw new Error('newVersionId is not a string');
+    }
 
-  const compareResult = await writeToken.compareToPreviousVersion(newVersionId);
-  expect(compareResult).toMatchInlineSnapshot(`
+    const compareResult = await writeToken.compareToPreviousVersion(newVersionId);
+    expect(compareResult).toMatchInlineSnapshot(`
     {
       schemaCompareToPrevious: {
         changes: {
@@ -3486,7 +3488,8 @@ test.concurrent('legacy service stitching with missing service', async ({ expect
       },
     }
     `);
-});
+  },
+);
 
 test.concurrent(
   'service url change from legacy to legacy version is displayed correctly',

--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -3427,6 +3427,67 @@ test.concurrent(
   },
 );
 
+test.concurrent('legacy service stitching with missing service', async ({ expect }) => {
+  const { createOrg } = await initSeed().createOwner();
+  const { createProject } = await createOrg();
+  const { /* project, target,*/ createToken } = await createProject(ProjectType.Stitching, {
+    useLegacyRegistryModels: true,
+  });
+
+  const writeToken = await createToken({
+    targetScopes: [TargetAccessScope.RegistryRead, TargetAccessScope.RegistryWrite],
+    projectScopes: [ProjectAccessScope.Settings, ProjectAccessScope.Read],
+    organizationScopes: [],
+  });
+
+  let result = await writeToken
+    .publishSchema({
+      sdl: 'type Query { ping: String! }',
+      author: 'Laurin',
+      commit: '123',
+      service: 'foo1',
+    })
+    .then(r => r.expectNoGraphQLErrors());
+
+  expect(result.schemaPublish.__typename).toEqual('SchemaPublishSuccess');
+
+  result = await writeToken
+    .publishSchema({
+      sdl: 'type Query { ping: String! }',
+      author: 'Laurin',
+      commit: '123',
+      service: 'foo1',
+      url: 'https://api.com/foo1',
+    })
+    .then(r => r.expectNoGraphQLErrors());
+
+  expect(result.schemaPublish.__typename).toEqual('SchemaPublishSuccess');
+
+  const newVersionId = (await writeToken.fetchLatestValidSchema())?.latestValidVersion?.id;
+
+  if (typeof newVersionId !== 'string') {
+    throw new Error('newVersionId is not a string');
+  }
+
+  const compareResult = await writeToken.compareToPreviousVersion(newVersionId);
+  expect(compareResult).toMatchInlineSnapshot(`
+    {
+      schemaCompareToPrevious: {
+        changes: {
+          nodes: [
+            {
+              criticality: Dangerous,
+              message: [foo1] New service url: 'https://api.com/foo1' (previously: 'none'),
+            },
+          ],
+          total: 1,
+        },
+        initial: false,
+      },
+    }
+    `);
+});
+
 test.concurrent(
   'service url change from legacy to legacy version is displayed correctly',
   async ({ expect }) => {

--- a/packages/services/api/src/modules/schema/providers/registry-checks.ts
+++ b/packages/services/api/src/modules/schema/providers/registry-checks.ts
@@ -310,7 +310,7 @@ export class RegistryChecks {
               after: service.url,
               message: service.url
                 ? `New service url: ${service.url} (previously: ${existingService.url ?? 'none'})`
-                : `Service url removed (previously: ${existingService.url ?? 'none'}`,
+                : `Service url removed (previously: ${existingService.url ?? 'none'})`,
               status: 'modified' as const,
             }
           : {

--- a/packages/services/api/src/modules/schema/resolvers.ts
+++ b/packages/services/api/src/modules/schema/resolvers.ts
@@ -314,7 +314,7 @@ export const resolvers: SchemaModule.Resolvers = {
       const useLegacy = unstable_forceLegacyComparison ?? false;
 
       // Lord forgive me for my sins
-      if (useLegacy === false && project.type !== ProjectType.STITCHING) {
+      if (useLegacy === false) {
         const currentVersion = await schemaManager.getSchemaVersion({
           organization: organizationId,
           project: projectId,

--- a/packages/services/api/src/modules/schema/schema-change-from-meta.ts
+++ b/packages/services/api/src/modules/schema/schema-change-from-meta.ts
@@ -209,13 +209,13 @@ function buildRegistryServiceURLFromMeta(
 ): RegistryServiceUrlChangeChange {
   return {
     type: 'REGISTRY_SERVICE_URL_CHANGED',
-    message: change.meta.serviceUrls.old
+    message: change.meta.serviceUrls.new
       ? `[${change.meta.serviceName}] New service url: '${
           change.meta.serviceUrls.new
         }' (previously: '${change.meta.serviceUrls.old ?? 'none'}')`
       : `[${change.meta.serviceName}] Service url removed (previously: '${
           change.meta.serviceUrls.old ?? 'none'
-        }'`,
+        }')`,
     criticality: {
       level: CriticalityLevel.Dangerous,
       reason: 'The registry service url has changed',


### PR DESCRIPTION
- adds a test for the service url change construction altered in https://github.com/kamilkisiela/graphql-hive/pull/2149
- reenables serving schema URL changes from the database for stitching projects
- use correct message for schema URL changes loaded from the database