### PR TITLE
Introduce sql template tag for clickhouse queries

### DIFF
--- a/packages/services/api/src/index.ts
+++ b/packages/services/api/src/index.ts
@@ -28,7 +28,7 @@ export type { AuthProvider } from './__generated__/types';
 export { HttpClient } from './modules/shared/providers/http-client';
 export { OperationsManager } from './modules/operations/providers/operations-manager';
 export { OperationsReader } from './modules/operations/providers/operations-reader';
-export { ClickHouse } from './modules/operations/providers/clickhouse-client';
+export { ClickHouse, sql } from './modules/operations/providers/clickhouse-client';
 export {
   organizationAdminScopes,
   reservedOrganizationNames,

--- a/packages/services/api/src/modules/operations/providers/clickhouse-client.ts
+++ b/packages/services/api/src/modules/operations/providers/clickhouse-client.ts
@@ -1,11 +1,19 @@
+import { createHash } from 'node:crypto';
 import Agent from 'agentkeepalive';
 import { Inject, Injectable } from 'graphql-modules';
 import type { Span } from '@sentry/types';
 import { atomic } from '../../../shared/helpers';
 import { HttpClient } from '../../shared/providers/http-client';
 import { Logger } from '../../shared/providers/logger';
+import { SqlStatement, toQueryParams } from './sql';
 import type { ClickHouseConfig } from './tokens';
 import { CLICKHOUSE_CONFIG } from './tokens';
+
+export { sql } from './sql';
+
+function hashQuery(query: SqlStatement): string {
+  return createHash('sha256').update(query.sql).update(JSON.stringify(query.values)).digest('hex');
+}
 
 export interface QueryResponse<T> {
   data: readonly T[];
@@ -48,14 +56,14 @@ export class ClickHouse {
     });
   }
 
-  @atomic(({ query }: { query: string }) => query)
+  @atomic(({ query }: { query: SqlStatement }) => hashQuery(query))
   async query<T>({
     query,
     queryId,
     timeout,
     span: parentSpan,
   }: {
-    query: string;
+    query: SqlStatement;
     queryId: string;
     timeout: number;
     span?: Span;
@@ -75,13 +83,14 @@ export class ClickHouse {
           context: {
             description: `ClickHouse - ${queryId}`,
           },
-          body: query,
+          body: query.sql,
           headers: {
             'Accept-Encoding': 'gzip',
             Accept: 'application/json',
           },
           searchParams: {
             default_format: 'JSON',
+            ...toQueryParams(query),
           },
           username: this.config.username,
           password: this.config.password,

--- a/packages/services/api/src/modules/operations/providers/operations-reader.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-reader.ts
@@ -45,22 +45,22 @@ function ensureNumber(value: number | string): number {
   return parseFloat(value);
 }
 
-function pickQueryByPeriod<Q extends string | SqlValue>(
+function pickQueryByPeriod(
   queryMap: {
     hourly: {
-      query: Q;
+      query: SqlValue;
       queryId: string;
       timeout: number;
       span?: Span | undefined;
     };
     daily: {
-      query: Q;
+      query: SqlValue;
       queryId: string;
       timeout: number;
       span?: Span | undefined;
     };
     regular: {
-      query: Q;
+      query: SqlValue;
       queryId: string;
       timeout: number;
       span?: Span | undefined;

--- a/packages/services/api/src/modules/operations/providers/operations-reader.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-reader.ts
@@ -4,8 +4,9 @@ import type { Span } from '@sentry/types';
 import { batch } from '@theguild/buddy';
 import type { DateRange } from '../../../shared/entities';
 import { sentry } from '../../../shared/sentry';
-import { ClickHouse, RowOf } from './clickhouse-client';
+import { ClickHouse, RowOf, sql } from './clickhouse-client';
 import { calculateTimeWindow } from './helpers';
+import { SqlValue } from './sql';
 
 function formatDate(date: Date): string {
   return format(addMinutes(date, date.getTimezoneOffset()), 'yyyy-MM-dd HH:mm:ss');
@@ -44,22 +45,22 @@ function ensureNumber(value: number | string): number {
   return parseFloat(value);
 }
 
-function pickQueryByPeriod(
+function pickQueryByPeriod<Q extends string | SqlValue>(
   queryMap: {
     hourly: {
-      query: string;
+      query: Q;
       queryId: string;
       timeout: number;
       span?: Span | undefined;
     };
     daily: {
-      query: string;
+      query: Q;
       queryId: string;
       timeout: number;
       span?: Span | undefined;
     };
     regular: {
-      query: string;
+      query: Q;
       queryId: string;
       timeout: number;
       span?: Span | undefined;
@@ -148,18 +149,18 @@ export class OperationsReader {
     span?: Span,
   ): Promise<Record<string, number>> {
     const coordinates = fields.map(selector => this.makeId(selector));
-    const conditions = [`( coordinate IN ('${coordinates.join(`', '`)}') )`];
+    const conditions = [sql`(coordinate IN (${sql.array(coordinates, 'String')}))`];
 
     if (Array.isArray(excludedClients) && excludedClients.length > 0) {
       // Eliminate coordinates fetched by excluded clients.
       // We can connect a coordinate to a client by using the hash column.
       // The hash column is basically a unique identifier of a GraphQL operation.
-      conditions.push(`
+      conditions.push(sql`
         hash NOT IN (
           SELECT hash FROM clients_daily ${this.createFilter({
             target,
             period,
-            extra: [`client_name IN ('${excludedClients.join(`', '`)}')`],
+            extra: [sql`client_name IN (${sql.array(excludedClients, 'String')})`],
           })} GROUP BY hash
         )
       `);
@@ -169,7 +170,7 @@ export class OperationsReader {
       total: string;
       coordinate: string;
     }>({
-      query: `
+      query: sql`
             SELECT
               coordinate,
               sum(total) as total
@@ -223,7 +224,7 @@ export class OperationsReader {
     const query = pickQueryByPeriod(
       {
         daily: {
-          query: `SELECT sum(total) as total, sum(total_ok) as totalOk FROM operations_daily ${this.createFilter(
+          query: sql`SELECT sum(total) as total, sum(total_ok) as totalOk FROM operations_daily ${this.createFilter(
             {
               target,
               period,
@@ -235,7 +236,7 @@ export class OperationsReader {
           span,
         },
         hourly: {
-          query: `SELECT sum(total) as total, sum(total_ok) as totalOk FROM operations_hourly ${this.createFilter(
+          query: sql`SELECT sum(total) as total, sum(total_ok) as totalOk FROM operations_hourly ${this.createFilter(
             {
               target,
               period,
@@ -247,11 +248,13 @@ export class OperationsReader {
           span,
         },
         regular: {
-          query: `SELECT count() as total, sum(ok) as totalOk FROM operations ${this.createFilter({
-            target,
-            period,
-            operations,
-          })}`,
+          query: sql`SELECT count() as total, sum(ok) as totalOk FROM operations ${this.createFilter(
+            {
+              target,
+              period,
+              operations,
+            },
+          )}`,
           queryId: 'count_operations_regular',
           timeout: 30_000,
           span,
@@ -304,7 +307,7 @@ export class OperationsReader {
     const query = pickQueryByPeriod(
       {
         daily: {
-          query: `
+          query: sql`
             SELECT count(distinct hash) as total
             FROM operations_daily
             ${this.createFilter({
@@ -318,7 +321,7 @@ export class OperationsReader {
           span,
         },
         hourly: {
-          query: `
+          query: sql`
             SELECT count(distinct hash) as total
             FROM operations_hourly
             ${this.createFilter({
@@ -332,7 +335,7 @@ export class OperationsReader {
           span,
         },
         regular: {
-          query: `
+          query: sql`
             SELECT count(distinct hash) as total
             FROM operations
             ${this.createFilter({
@@ -381,7 +384,7 @@ export class OperationsReader {
     const query = pickQueryByPeriod(
       {
         daily: {
-          query: `
+          query: sql`
             SELECT sum(total) as total, sum(total_ok) as totalOk, hash 
             FROM operations_daily
             ${this.createFilter({
@@ -396,7 +399,7 @@ export class OperationsReader {
           span,
         },
         hourly: {
-          query: `
+          query: sql`
             SELECT 
               sum(total) as total,
               sum(total_ok) as totalOk,
@@ -414,7 +417,7 @@ export class OperationsReader {
           span,
         },
         regular: {
-          query: `
+          query: sql`
             SELECT count() as total, sum(ok) as totalOk, hash
             FROM operations
             ${this.createFilter({
@@ -443,7 +446,7 @@ export class OperationsReader {
         hash: string;
         operation_kind: string;
       }>({
-        query: `
+        query: sql`
           SELECT 
             name,
             hash,
@@ -503,13 +506,13 @@ export class OperationsReader {
     const result = await this.clickHouse.query<{
       body: string;
     }>({
-      query: `
+      query: sql`
         SELECT 
           body
         FROM operation_collection
           ${this.createFilter({
             target,
-            extra: [`hash = '${hash}'`],
+            extra: [sql`hash = ${hash}`],
           })}
         LIMIT 1
       `,
@@ -553,7 +556,7 @@ export class OperationsReader {
       pickQueryByPeriod(
         {
           daily: {
-            query: `
+            query: sql`
               SELECT 
                 sum(total) as total,
                 client_name,
@@ -571,7 +574,7 @@ export class OperationsReader {
             span,
           },
           hourly: {
-            query: `
+            query: sql`
               SELECT 
                 count(*) as total,
                 client_name,
@@ -589,7 +592,7 @@ export class OperationsReader {
             span,
           },
           regular: {
-            query: `
+            query: sql`
               SELECT 
                 count(*) as total,
                 client_name,
@@ -682,7 +685,7 @@ export class OperationsReader {
       count: string;
       client_name: string;
     }>({
-      query: `
+      query: sql`
         SELECT 
           sum(total) as count,
           client_name
@@ -691,7 +694,7 @@ export class OperationsReader {
           target,
           period,
           operations,
-          extra: ['notEmpty(client_name)'],
+          extra: [sql`notEmpty(client_name)`],
         })}
         GROUP BY client_name
       `,
@@ -805,7 +808,7 @@ export class OperationsReader {
       latency: number;
       total: number;
     }>({
-      query: `
+      query: sql`
         WITH histogram(90)(logDuration) AS hist
         SELECT
             arrayJoin(hist).1 as latency,
@@ -850,7 +853,7 @@ export class OperationsReader {
       pickQueryByPeriod(
         {
           daily: {
-            query: `
+            query: sql`
               SELECT 
                 quantilesMerge(0.75, 0.90, 0.95, 0.99)(duration_quantiles) as percentiles
               FROM operations_daily
@@ -861,7 +864,7 @@ export class OperationsReader {
             span,
           },
           hourly: {
-            query: `
+            query: sql`
               SELECT 
                 quantilesMerge(0.75, 0.90, 0.95, 0.99)(duration_quantiles) as percentiles
               FROM operations_hourly
@@ -872,7 +875,7 @@ export class OperationsReader {
             span,
           },
           regular: {
-            query: `
+            query: sql`
               SELECT 
                 quantiles(0.75, 0.90, 0.95, 0.99)(duration) as percentiles
               FROM operations
@@ -910,7 +913,7 @@ export class OperationsReader {
       pickQueryByPeriod(
         {
           daily: {
-            query: `
+            query: sql`
               SELECT 
                 hash,
                 quantilesMerge(0.75, 0.90, 0.95, 0.99)(duration_quantiles) as percentiles
@@ -923,7 +926,7 @@ export class OperationsReader {
             span,
           },
           hourly: {
-            query: `
+            query: sql`
               SELECT 
                 hash,
                 quantilesMerge(0.75, 0.90, 0.95, 0.99)(duration_quantiles) as percentiles
@@ -936,7 +939,7 @@ export class OperationsReader {
             span,
           },
           regular: {
-            query: `
+            query: sql`
               SELECT 
                 hash,
                 quantiles(0.75, 0.90, 0.95, 0.99)(duration) as percentiles
@@ -973,7 +976,7 @@ export class OperationsReader {
       client_name: string;
     }>({
       queryId: 'client_names_per_target_v2',
-      query: `SELECT client_name FROM clients_daily ${this.createFilter({
+      query: sql`SELECT client_name FROM clients_daily ${this.createFilter({
         target,
         period,
       })} GROUP BY client_name`,
@@ -1008,7 +1011,7 @@ export class OperationsReader {
       pickQueryByPeriod(
         {
           daily: {
-            query: `
+            query: sql`
               SELECT 
                 multiply(
                   toUnixTimestamp(
@@ -1030,7 +1033,7 @@ export class OperationsReader {
             span,
           },
           hourly: {
-            query: `
+            query: sql`
               SELECT 
                 multiply(
                   toUnixTimestamp(
@@ -1052,7 +1055,7 @@ export class OperationsReader {
             span,
           },
           regular: {
-            query: `
+            query: sql`
               SELECT 
                 multiply(
                   toUnixTimestamp(
@@ -1094,9 +1097,10 @@ export class OperationsReader {
       total: string;
     }>({
       // TODO: use the operations_daily table once the FF_CLICKHOUSE_V2_TABLES is available for everyone
-      query: `SELECT sum(total) as total from operations_hourly WHERE target IN ('${targets.join(
-        `', '`,
-      )}')`,
+      query: sql`SELECT sum(total) as total from operations_hourly WHERE target IN (${sql.array(
+        targets,
+        'String',
+      )})`,
       queryId: 'count_operations_for_targets',
       timeout: 15_000,
     });
@@ -1202,19 +1206,19 @@ export class OperationsReader {
     period: DateRange;
     typenames: string[];
   }) {
-    const typesFilter = typenames
-      .map(t => `coordinate = '${t}' OR coordinate LIKE '${t}.%'`)
-      .join(' OR ');
+    const typesConditions = typenames.map(
+      t => sql`coordinate = ${t} OR coordinate LIKE ${t + '.%'}`,
+    );
     const result = await this.clickHouse.query<{
       coordinate: string;
       total: number;
     }>({
-      query: `
+      query: sql`
         SELECT coordinate, sum(total) as total FROM coordinates_daily
         ${this.createFilter({
           target,
           period,
-          extra: [`(${typesFilter})`],
+          extra: [sql`(${sql.join(typesConditions, ' OR ')})`],
         })}
         GROUP BY coordinate`,
       queryId: 'coordinates_per_types',
@@ -1232,7 +1236,7 @@ export class OperationsReader {
       coordinate: string;
       total: number;
     }>({
-      query: `
+      query: sql`
         SELECT coordinate, sum(total) as total FROM coordinates_daily
         ${this.createFilter({
           target,
@@ -1258,17 +1262,17 @@ export class OperationsReader {
       to: Date;
     };
   }) {
-    const dateRangeFilter = `
+    const dateRangeFilter = sql.raw(`
       timestamp >= FROM_UNIXTIME(${Math.floor(period.from.getTime() / 1000)})
       AND
       timestamp < FROM_UNIXTIME(${Math.floor(period.to.getTime() / 1000)})
-    `;
+    `);
 
     const result = await this.clickHouse.query<{
       total: string;
       target: string;
     }>({
-      query: `SELECT sum(total) as total, target from operations_daily WHERE ${dateRangeFilter} GROUP BY target`,
+      query: sql`SELECT sum(total) as total, target from operations_daily WHERE ${dateRangeFilter} GROUP BY target`,
       queryId: 'admin_operations_per_target',
       timeout: 15_000,
     });
@@ -1289,16 +1293,16 @@ export class OperationsReader {
   }) {
     const days = differenceInDays(period.to, period.from);
     const resolution = 90;
-    const dateRangeFilter = `
+    const dateRangeFilter = sql.raw(`
       timestamp >= FROM_UNIXTIME(${Math.floor(period.from.getTime() / 1000)})
       AND
       timestamp < FROM_UNIXTIME(${Math.floor(period.to.getTime() / 1000)})
-    `;
+    `);
     const result = await this.clickHouse.query<{
       date: number;
       total: string;
     }>({
-      query: `
+      query: sql`
         SELECT 
           multiply(
             toUnixTimestamp(
@@ -1311,7 +1315,7 @@ export class OperationsReader {
             'UTC'),
           1000) as date,
           sum(total) as total
-        FROM ${days > 1 && days >= resolution ? 'operations_daily' : 'operations_hourly'}
+        FROM ${sql.raw(days > 1 && days >= resolution ? 'operations_daily' : 'operations_hourly')}
         WHERE ${dateRangeFilter}
         GROUP BY date
         ORDER BY date
@@ -1335,34 +1339,34 @@ export class OperationsReader {
     target?: string | readonly string[];
     period?: DateRange;
     operations?: readonly string[];
-    extra?: string[];
-  }) {
-    const where: string[] = [];
+    extra?: SqlValue[];
+  }): SqlValue {
+    const where: SqlValue[] = [];
 
     if (target) {
       if (Array.isArray(target)) {
-        where.push(`target IN (${target.map(t => `'${t}'`).join(', ')})`);
+        where.push(sql`target IN (${sql.array(target, 'String')})`);
       } else {
-        where.push(`target = '${target}'`);
+        where.push(sql`target = ${target as string}`);
       }
     }
 
     if (period) {
       where.push(
-        `timestamp >= toDateTime('${formatDate(period.from)}', 'UTC')`,
-        `timestamp <= toDateTime('${formatDate(period.to)}', 'UTC')`,
+        sql`timestamp >= toDateTime(${formatDate(period.from)}, 'UTC')`,
+        sql`timestamp <= toDateTime(${formatDate(period.to)}, 'UTC')`,
       );
     }
 
     if (operations?.length) {
-      where.push(`(hash) IN (${operations.map(op => `'${op}'`).join(',')})`);
+      where.push(sql`(hash) IN (${sql.array(operations, 'String')})`);
     }
 
     if (extra.length) {
       where.push(...extra);
     }
 
-    const statement = where.length ? ` PREWHERE ${where.join(' AND ')} ` : ' ';
+    const statement = where.length ? sql` PREWHERE ${sql.join(where, ' AND ')} ` : sql``;
 
     return statement;
   }

--- a/packages/services/api/src/modules/operations/providers/sql.ts
+++ b/packages/services/api/src/modules/operations/providers/sql.ts
@@ -109,7 +109,7 @@ export const createJoinSqlFragment = (
   let placeholderIndex = greatestParameterPosition;
 
   if (token.values.length === 0) {
-    throw new Error('Value list must have at least 1 member.');
+    throw new Error('sql.join: must have at least 1 member.');
   }
 
   for (const value of token.values) {
@@ -124,7 +124,7 @@ export const createJoinSqlFragment = (
       values.push(value);
     } else {
       throw new Error(
-        'Invalid list member type. Must be a SQL token or a primitive value expression.',
+        'sql.join: Invalid list member type. Must be a SQL token or a primitive value expression.',
       );
     }
   }
@@ -171,7 +171,7 @@ const createSqlQuery = (parts: readonly string[], values: readonly ValueExpressi
       rawSql += createParamPlaceholder(parameterValues.length + 1, 'String');
       parameterValues.push(token);
     } else {
-      throw new TypeError('Unexpected value expression.');
+      throw new TypeError('sql: Unexpected value expression.');
     }
   }
 
@@ -240,5 +240,5 @@ function stringifyValue(value: Value): string {
     return `[${value.map(v => `'${v}'`).join(', ')}]`;
   }
 
-  throw new Error('Unexpected value. Expected a string or an array of strings.');
+  throw new Error('sql: Unexpected value. Expected a string or an array of strings.');
 }

--- a/packages/services/api/src/modules/operations/providers/sql.ts
+++ b/packages/services/api/src/modules/operations/providers/sql.ts
@@ -1,0 +1,244 @@
+type Value = string | readonly string[];
+
+type ArrayValue = {
+  readonly kind: 'array';
+  readonly dataType: string;
+  readonly values: readonly string[];
+};
+
+type JoinValue = {
+  readonly kind: 'join';
+  readonly separator: string;
+  readonly values: ReadonlyArray<SqlValue | string>;
+};
+
+type RawValue = {
+  readonly kind: 'raw';
+  readonly sql: string;
+};
+
+export type SqlValue = {
+  readonly kind: 'sql';
+  readonly sql: string;
+  readonly values: readonly Value[];
+};
+
+type ValueExpression = string | SpecialValues;
+type SpecialValues = SqlValue | ArrayValue | JoinValue | RawValue;
+
+type SqlTaggedTemplate = {
+  (template: TemplateStringsArray, ...values: ValueExpression[]): SqlValue;
+  array: (values: Value, memberType: string) => ArrayValue;
+  join: (values: readonly SqlValue[], separator: string) => JoinValue;
+  raw: (sql: string) => RawValue;
+};
+
+export type SqlStatement = Pick<SqlValue, 'sql' | 'values'>;
+
+function isOfKind<T extends SpecialValues>(value: unknown, kind: T['kind']): value is T {
+  return !!value && typeof value === 'object' && 'kind' in value && value.kind === kind;
+}
+
+function isSqlValue(value: unknown): value is SqlValue {
+  return isOfKind<SqlValue>(value, 'sql');
+}
+
+function isArrayValue(value: unknown): value is ArrayValue {
+  return isOfKind<ArrayValue>(value, 'array');
+}
+
+function isJoinValue(value: unknown): value is JoinValue {
+  return isOfKind<JoinValue>(value, 'join');
+}
+
+function isRawValue(value: unknown): value is RawValue {
+  return isOfKind<RawValue>(value, 'raw');
+}
+
+function createParamPlaceholder(index: number, dataType: string) {
+  return `{p${index}: ${dataType}}`;
+}
+
+const createSqlFragment = (token: SqlValue, greatestParameterPosition: number): SqlValue => {
+  let sql = '';
+
+  let leastMatchedParameterPosition = Number.POSITIVE_INFINITY;
+  let greatestMatchedParameterPosition = 0;
+
+  sql += token.sql.replace(/\{p(\d+)/gu, (_, g1) => {
+    const parameterPosition = Number.parseInt(g1, 10);
+
+    if (parameterPosition > greatestMatchedParameterPosition) {
+      greatestMatchedParameterPosition = parameterPosition;
+    }
+
+    if (parameterPosition < leastMatchedParameterPosition) {
+      leastMatchedParameterPosition = parameterPosition;
+    }
+
+    return '{p' + String(parameterPosition + greatestParameterPosition);
+  });
+
+  if (greatestMatchedParameterPosition > token.values.length) {
+    throw new Error(
+      'The greatest parameter position is greater than the number of parameter values.',
+    );
+  }
+
+  if (
+    leastMatchedParameterPosition !== Number.POSITIVE_INFINITY &&
+    leastMatchedParameterPosition !== 1
+  ) {
+    throw new Error('Parameter position must start at 1.');
+  }
+
+  return {
+    kind: 'sql',
+    sql,
+    values: token.values,
+  };
+};
+
+export const createJoinSqlFragment = (
+  token: JoinValue,
+  greatestParameterPosition: number,
+): SqlValue => {
+  const values: Value[] = [];
+  const placeholders: Array<Value | null> = [];
+
+  let placeholderIndex = greatestParameterPosition;
+
+  if (token.values.length === 0) {
+    throw new Error('Value list must have at least 1 member.');
+  }
+
+  for (const value of token.values) {
+    if (isSqlValue(value)) {
+      const sqlFragment = createSqlFragment(value, placeholderIndex);
+
+      placeholders.push(sqlFragment.sql);
+      placeholderIndex += sqlFragment.values.length;
+      values.push(...sqlFragment.values);
+    } else if (typeof value === 'string') {
+      placeholders.push(createParamPlaceholder(++placeholderIndex, 'String'));
+      values.push(value);
+    } else {
+      throw new Error(
+        'Invalid list member type. Must be a SQL token or a primitive value expression.',
+      );
+    }
+  }
+
+  return {
+    kind: 'sql',
+    sql: placeholders.join(token.separator),
+    values: values,
+  };
+};
+
+const createSqlQuery = (parts: readonly string[], values: readonly ValueExpression[]) => {
+  let rawSql = '';
+  const parameterValues: Value[] = [];
+
+  let index = 0;
+
+  for (const part of parts) {
+    const token = values[index++];
+
+    rawSql += part;
+
+    if (index >= parts.length) {
+      continue;
+    }
+
+    if (token === undefined) {
+      throw new Error('SQL tag cannot be bound an undefined value.');
+    } else if (isSqlValue(token)) {
+      const sqlFragment = createSqlFragment(token, parameterValues.length);
+
+      rawSql += sqlFragment.sql;
+      parameterValues.push(...sqlFragment.values);
+    } else if (isArrayValue(token)) {
+      rawSql += createParamPlaceholder(parameterValues.length + 1, 'Array(String)');
+      parameterValues.push(token.values);
+    } else if (isJoinValue(token)) {
+      const sqlFragment = createJoinSqlFragment(token, parameterValues.length);
+      rawSql += sqlFragment.sql;
+      parameterValues.push(...sqlFragment.values);
+    } else if (isRawValue(token)) {
+      rawSql += token.sql;
+    } else if (typeof token === 'string') {
+      rawSql += createParamPlaceholder(parameterValues.length + 1, 'String');
+      parameterValues.push(token);
+    } else {
+      throw new TypeError('Unexpected value expression.');
+    }
+  }
+
+  return {
+    sql: rawSql,
+    values: parameterValues,
+  };
+};
+
+function sqlTag(rawStrings: TemplateStringsArray, ...rawValues: ValueExpression[]) {
+  const { sql, values } = createSqlQuery(rawStrings, rawValues);
+
+  return {
+    kind: 'sql',
+    sql,
+    values,
+  } as SqlValue;
+}
+
+sqlTag.array = (values: Value, memberType: string): ArrayValue => {
+  return {
+    kind: 'array',
+    dataType: memberType,
+    values: Array.isArray(values) ? values : [values],
+  };
+};
+
+sqlTag.join = (values: readonly SqlValue[], separator: string): JoinValue => {
+  return {
+    kind: 'join',
+    separator,
+    values,
+  };
+};
+
+sqlTag.raw = (sql: string): RawValue => {
+  return {
+    kind: 'raw',
+    sql,
+  };
+};
+
+const createSqlTag = () => {
+  return sqlTag as SqlTaggedTemplate;
+};
+
+export const sql = createSqlTag();
+
+export function toQueryParams(statement: SqlStatement): Record<string, string> {
+  const params: Record<string, string> = {};
+
+  for (let i = 0; i < statement.values.length; i++) {
+    // Params are 1-indexed
+    params[`param_p${i + 1}`] = stringifyValue(statement.values[i]);
+  }
+
+  return params;
+}
+
+function stringifyValue(value: Value): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    return `[${value.map(v => `'${v}'`).join(', ')}]`;
+  }
+
+  throw new Error('Unexpected value. Expected a string or an array of strings.');
+}

--- a/packages/services/usage-estimator/src/estimator.ts
+++ b/packages/services/usage-estimator/src/estimator.ts
@@ -1,4 +1,4 @@
-import { ClickHouse, HttpClient, OperationsReader } from '@hive/api';
+import { ClickHouse, HttpClient, OperationsReader, sql } from '@hive/api';
 import type { FastifyLoggerInstance } from '@hive/service-common';
 
 export type Estimator = ReturnType<typeof createEstimator>;
@@ -47,14 +47,14 @@ export function createEstimator(config: {
         total: string;
         target: string;
       }>({
-        query: `
-      SELECT
-        target,
-        sum(total) as total
-      FROM operations_hourly
-       ${filter}
-      GROUP BY target
-    `,
+        query: sql`
+          SELECT
+            target,
+            sum(total) as total
+          FROM operations_hourly
+          ${filter}
+          GROUP BY target
+        `,
         queryId: 'usage_estimator_count_operations_all',
         timeout: 60_000,
       });
@@ -75,12 +75,12 @@ export function createEstimator(config: {
       return await clickhouse.query<{
         total: string;
       }>({
-        query: `
-      SELECT 
-        sum(total) as total
-      FROM operations_hourly
-      ${filter}
-    `,
+        query: sql`
+          SELECT 
+            sum(total) as total
+          FROM operations_hourly
+          ${filter}
+        `,
         queryId: 'usage_estimator_count_operations',
         timeout: 15_000,
       });


### PR DESCRIPTION
Regarding the "primitive" values, it supports only strings (but we only need strings so... no need to support other values).
There's `sql.raw` function but it's applied only on the `admin-only` queries.