### PR TITLE
feat: supergraph field information in explorer

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -49,6 +49,8 @@ We have a script to feed your local instance of Hive.
 > Note: You can set `STAGING=1` in order to target staging env and seed a target there. Same for
 > development env, you can use `DEV=1`
 
+> Note: You can set `FEDERATION=1` in order to publish multiple subgraphs.
+
 > To send more operations and test heavy load on Hive instance, you can also set `OPERATIONS`
 > (amount of operations in each interval round, default is `1`) and `INTERVAL` (frequency of sending
 > operations, default: `1000`ms). For example, using `INTERVAL=1000 OPERATIONS=1000` will send 1000

--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -3062,11 +3062,15 @@ test('Composition Network Failure (Federation 2)', async () => {
 
       directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
-      directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+      directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
 
-      directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+      directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
       directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+      directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+      directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
       enum link__Purpose {
         """
@@ -3100,11 +3104,15 @@ test('Composition Network Failure (Federation 2)', async () => {
 
       directive @join__graph(name: String!, url: String!) on ENUM_VALUE
 
-      directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+      directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
 
-      directive @join__field(graph: join__Graph!, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+      directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
 
       directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
+
+      directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+      directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
 
       enum link__Purpose {
         """

--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -3002,7 +3002,6 @@ test('Composition Network Failure (Federation 2)', async () => {
     await enableExternalSchemaComposition(
       {
         endpoint: `http://${dockerAddress}/no_compose`,
-        // eslint-disable-next-line no-process-env
         secret: process.env.EXTERNAL_COMPOSITION_SECRET!,
         project: project.cleanId,
         organization: organization.cleanId,

--- a/packages/migrations/src/actions/2023.05.12T08.29.06.store-supergraph-on-schema-versions.sql
+++ b/packages/migrations/src/actions/2023.05.12T08.29.06.store-supergraph-on-schema-versions.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "public"."schema_versions"
+  ADD COLUMN "supergraph_sdl" text
+;

--- a/packages/migrations/src/actions/down/2023.05.12T08.29.06.store-supergraph-on-schema-versions.sql
+++ b/packages/migrations/src/actions/down/2023.05.12T08.29.06.store-supergraph-on-schema-versions.sql
@@ -1,0 +1,1 @@
+raise 'down migration not implemented'

--- a/packages/services/api/src/modules/schema/lib/__tests__/federation-super-graph.spec.ts
+++ b/packages/services/api/src/modules/schema/lib/__tests__/federation-super-graph.spec.ts
@@ -185,205 +185,205 @@ describe('extractSuperGraphInformation', () => {
     const result = extractSuperGraphInformation(ast);
     expect(result).toMatchInlineSnapshot(`
       {
-        schemaCoordinateOwner: Map {
-          DeliveryEstimates => Set {
+        schemaCoordinateServicesMappings: Map {
+          DeliveryEstimates => [
             inventory,
-          },
-          DeliveryEstimates.estimatedDelivery => Set {
+          ],
+          DeliveryEstimates.estimatedDelivery => [
             inventory,
-          },
-          DeliveryEstimates.fastestDelivery => Set {
+          ],
+          DeliveryEstimates.fastestDelivery => [
             inventory,
-          },
-          Panda => Set {
+          ],
+          Panda => [
             pandas,
-          },
-          Panda.name => Set {
+          ],
+          Panda.name => [
             pandas,
-          },
-          Panda.favoriteFood => Set {
+          ],
+          Panda.favoriteFood => [
             pandas,
-          },
-          Product => Set {
+          ],
+          Product => [
             inventory,
             products,
             reviews,
-          },
-          Product.id => Set {
+          ],
+          Product.id => [
             inventory,
             products,
             reviews,
-          },
-          Product.dimensions => Set {
+          ],
+          Product.dimensions => [
             inventory,
-          },
-          Product.delivery => Set {
+          ],
+          Product.delivery => [
             inventory,
-          },
-          Product.sku => Set {
+          ],
+          Product.sku => [
             products,
-          },
-          Product.name => Set {
+          ],
+          Product.name => [
             products,
-          },
-          Product.package => Set {
+          ],
+          Product.package => [
             products,
-          },
-          Product.variation => Set {
+          ],
+          Product.variation => [
             products,
-          },
-          Product.createdBy => Set {
+          ],
+          Product.createdBy => [
             products,
-          },
-          Product.hidden => Set {
+          ],
+          Product.hidden => [
             products,
-          },
-          Product.reviewsScore => Set {
+          ],
+          Product.reviewsScore => [
             reviews,
-          },
-          Product.oldField => Set {
+          ],
+          Product.oldField => [
             products,
-          },
-          Product.reviewsCount => Set {
+          ],
+          Product.reviewsCount => [
             reviews,
-          },
-          Product.reviews => Set {
+          ],
+          Product.reviews => [
             reviews,
-          },
-          ProductDimension => Set {
+          ],
+          ProductDimension => [
             inventory,
             products,
-          },
-          ProductDimension.size => Set {
+          ],
+          ProductDimension.size => [
             inventory,
             products,
-          },
-          ProductDimension.weight => Set {
+          ],
+          ProductDimension.weight => [
             inventory,
             products,
-          },
-          ProductItf => Set {
-            inventory,
-            products,
-            reviews,
-          },
-          ProductItf.id => Set {
+          ],
+          ProductItf => [
             inventory,
             products,
             reviews,
-          },
-          ProductItf.dimensions => Set {
+          ],
+          ProductItf.id => [
             inventory,
-          },
-          ProductItf.delivery => Set {
+            products,
+            reviews,
+          ],
+          ProductItf.dimensions => [
             inventory,
-          },
-          ProductItf.sku => Set {
+          ],
+          ProductItf.delivery => [
+            inventory,
+          ],
+          ProductItf.sku => [
             products,
-          },
-          ProductItf.name => Set {
+          ],
+          ProductItf.name => [
             products,
-          },
-          ProductItf.package => Set {
+          ],
+          ProductItf.package => [
             products,
-          },
-          ProductItf.variation => Set {
+          ],
+          ProductItf.variation => [
             products,
-          },
-          ProductItf.createdBy => Set {
+          ],
+          ProductItf.createdBy => [
             products,
-          },
-          ProductItf.hidden => Set {
+          ],
+          ProductItf.hidden => [
             products,
-          },
-          ProductItf.oldField => Set {
+          ],
+          ProductItf.oldField => [
             products,
-          },
-          ProductItf.reviewsCount => Set {
+          ],
+          ProductItf.reviewsCount => [
             reviews,
-          },
-          ProductItf.reviewsScore => Set {
+          ],
+          ProductItf.reviewsScore => [
             reviews,
-          },
-          ProductItf.reviews => Set {
+          ],
+          ProductItf.reviews => [
             reviews,
-          },
-          ProductVariation => Set {
+          ],
+          ProductVariation => [
             products,
-          },
-          ProductVariation.id => Set {
+          ],
+          ProductVariation.id => [
             products,
-          },
-          ProductVariation.name => Set {
+          ],
+          ProductVariation.name => [
             products,
-          },
-          Query => Set {
+          ],
+          Query => [
             inventory,
             pandas,
             products,
             reviews,
             users,
-          },
-          Query.allPandas => Set {
+          ],
+          Query.allPandas => [
             pandas,
-          },
-          Query.panda => Set {
+          ],
+          Query.panda => [
             pandas,
-          },
-          Query.allProducts => Set {
+          ],
+          Query.allProducts => [
             products,
-          },
-          Query.product => Set {
+          ],
+          Query.product => [
             products,
-          },
-          Query.review => Set {
+          ],
+          Query.review => [
             reviews,
-          },
-          Review => Set {
+          ],
+          Review => [
             reviews,
-          },
-          Review.id => Set {
+          ],
+          Review.id => [
             reviews,
-          },
-          Review.body => Set {
+          ],
+          Review.body => [
             reviews,
-          },
-          ShippingClass => Set {
+          ],
+          ShippingClass => [
             inventory,
             products,
-          },
-          ShippingClass.STANDARD => Set {
+          ],
+          ShippingClass.STANDARD => [
             inventory,
             products,
-          },
-          ShippingClass.EXPRESS => Set {
+          ],
+          ShippingClass.EXPRESS => [
             inventory,
             products,
-          },
-          ShippingClass.OVERNIGHT => Set {
+          ],
+          ShippingClass.OVERNIGHT => [
             inventory,
-          },
-          SkuItf => Set {
+          ],
+          SkuItf => [
             products,
-          },
-          SkuItf.sku => Set {
+          ],
+          SkuItf.sku => [
             products,
-          },
-          User => Set {
-            products,
-            users,
-          },
-          User.email => Set {
+          ],
+          User => [
             products,
             users,
-          },
-          User.totalProductsCreated => Set {
+          ],
+          User.email => [
             products,
             users,
-          },
-          User.name => Set {
+          ],
+          User.totalProductsCreated => [
+            products,
             users,
-          },
+          ],
+          User.name => [
+            users,
+          ],
         },
       }
     `);

--- a/packages/services/api/src/modules/schema/lib/__tests__/federation-super-graph.spec.ts
+++ b/packages/services/api/src/modules/schema/lib/__tests__/federation-super-graph.spec.ts
@@ -186,6 +186,10 @@ const ast = parse(/* GraphQL */ `
     @join__unionMember(graph: B, member: "Panda") =
       Movie
     | Book
+
+  input UserInput @join__type(graph: PRODUCTS) @join__type(graph: PANDAS) {
+    name: String!
+  }
 `);
 
 describe('extractSuperGraphInformation', () => {
@@ -393,6 +397,14 @@ describe('extractSuperGraphInformation', () => {
             users,
           ],
           PandaOrUser => [
+            products,
+            pandas,
+          ],
+          UserInput => [
+            products,
+            pandas,
+          ],
+          UserInput.name => [
             products,
             pandas,
           ],

--- a/packages/services/api/src/modules/schema/lib/__tests__/federation-super-graph.spec.ts
+++ b/packages/services/api/src/modules/schema/lib/__tests__/federation-super-graph.spec.ts
@@ -1,0 +1,391 @@
+import { parse } from 'graphql';
+import { extractSuperGraphInformation } from '../federation-super-graph.js';
+
+const ast = parse(/* GraphQL */ `
+  schema
+    @link(url: "https://specs.apollo.dev/link/v1.0")
+    @link(url: "https://specs.apollo.dev/join/v0.3", for: EXECUTION)
+    @link(url: "https://specs.apollo.dev/tag/v0.3")
+    @link(url: "https://specs.apollo.dev/inaccessible/v0.2", for: SECURITY)
+    @link(
+      url: "https://myspecs.dev/myDirective/v1.0"
+      import: ["@myDirective", { name: "@anotherDirective", as: "@hello" }]
+    ) {
+    query: Query
+  }
+
+  directive @hello on FIELD_DEFINITION
+
+  directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+
+  directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
+
+  directive @join__field(
+    graph: join__Graph
+    requires: join__FieldSet
+    provides: join__FieldSet
+    type: String
+    external: Boolean
+    override: String
+    usedOverridden: Boolean
+  ) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
+
+  directive @join__graph(name: String!, url: String!) on ENUM_VALUE
+
+  directive @join__implements(
+    graph: join__Graph!
+    interface: String!
+  ) repeatable on OBJECT | INTERFACE
+
+  directive @join__type(
+    graph: join__Graph!
+    key: join__FieldSet
+    extension: Boolean! = false
+    resolvable: Boolean! = true
+    isInterfaceObject: Boolean! = false
+  ) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
+
+  directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
+
+  directive @link(
+    url: String
+    as: String
+    for: link__Purpose
+    import: [link__Import]
+  ) repeatable on SCHEMA
+
+  directive @myDirective(a: String!) on FIELD_DEFINITION
+
+  directive @tag(
+    name: String!
+  ) repeatable on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION | SCHEMA
+
+  type DeliveryEstimates @join__type(graph: INVENTORY) {
+    estimatedDelivery: String
+    fastestDelivery: String
+  }
+
+  scalar join__FieldSet
+
+  enum join__Graph {
+    INVENTORY @join__graph(name: "inventory", url: "")
+    PANDAS @join__graph(name: "pandas", url: "")
+    PRODUCTS @join__graph(name: "products", url: "")
+    REVIEWS @join__graph(name: "reviews", url: "")
+    USERS @join__graph(name: "users", url: "")
+  }
+
+  scalar link__Import
+
+  enum link__Purpose {
+    SECURITY
+    EXECUTION
+  }
+
+  type Panda @join__type(graph: PANDAS) {
+    name: ID!
+    favoriteFood: String @tag(name: "nom-nom-nom")
+  }
+
+  type Product implements ProductItf & SkuItf
+    @join__implements(graph: INVENTORY, interface: "ProductItf")
+    @join__implements(graph: PRODUCTS, interface: "ProductItf")
+    @join__implements(graph: PRODUCTS, interface: "SkuItf")
+    @join__implements(graph: REVIEWS, interface: "ProductItf")
+    @join__type(graph: INVENTORY, key: "id")
+    @join__type(graph: PRODUCTS, key: "id")
+    @join__type(graph: PRODUCTS, key: "sku package")
+    @join__type(graph: PRODUCTS, key: "sku variation { id }")
+    @join__type(graph: REVIEWS, key: "id") {
+    id: ID! @tag(name: "hi-from-products")
+    dimensions: ProductDimension
+      @join__field(graph: INVENTORY, external: true)
+      @join__field(graph: PRODUCTS)
+    delivery(zip: String): DeliveryEstimates
+      @join__field(graph: INVENTORY, requires: "dimensions { size weight }")
+    sku: String @join__field(graph: PRODUCTS)
+    name: String @join__field(graph: PRODUCTS) @hello
+    package: String @join__field(graph: PRODUCTS)
+    variation: ProductVariation @join__field(graph: PRODUCTS)
+    createdBy: User @join__field(graph: PRODUCTS)
+    hidden: String @join__field(graph: PRODUCTS)
+    reviewsScore: Float! @join__field(graph: REVIEWS, override: "products")
+    oldField: String @join__field(graph: PRODUCTS)
+    reviewsCount: Int! @join__field(graph: REVIEWS)
+    reviews: [Review!]! @join__field(graph: REVIEWS)
+  }
+
+  type ProductDimension @join__type(graph: INVENTORY) @join__type(graph: PRODUCTS) {
+    size: String
+    weight: Float
+  }
+
+  interface ProductItf implements SkuItf
+    @join__implements(graph: PRODUCTS, interface: "SkuItf")
+    @join__type(graph: INVENTORY)
+    @join__type(graph: PRODUCTS)
+    @join__type(graph: REVIEWS) {
+    id: ID!
+    dimensions: ProductDimension @join__field(graph: INVENTORY) @join__field(graph: PRODUCTS)
+    delivery(zip: String): DeliveryEstimates @join__field(graph: INVENTORY)
+    sku: String @join__field(graph: PRODUCTS)
+    name: String @join__field(graph: PRODUCTS)
+    package: String @join__field(graph: PRODUCTS)
+    variation: ProductVariation @join__field(graph: PRODUCTS)
+    createdBy: User @join__field(graph: PRODUCTS)
+    hidden: String @inaccessible @join__field(graph: PRODUCTS)
+    oldField: String @join__field(graph: PRODUCTS) @deprecated(reason: "refactored out")
+    reviewsCount: Int! @join__field(graph: REVIEWS)
+    reviewsScore: Float! @join__field(graph: REVIEWS)
+    reviews: [Review!]! @join__field(graph: REVIEWS)
+  }
+
+  type ProductVariation @join__type(graph: PRODUCTS) {
+    id: ID!
+    name: String
+  }
+
+  type Query
+    @join__type(graph: INVENTORY)
+    @join__type(graph: PANDAS)
+    @join__type(graph: PRODUCTS)
+    @join__type(graph: REVIEWS)
+    @join__type(graph: USERS) {
+    allPandas: [Panda] @join__field(graph: PANDAS)
+    panda(name: ID!): Panda @join__field(graph: PANDAS)
+    allProducts: [ProductItf] @join__field(graph: PRODUCTS)
+    product(id: ID!): ProductItf @join__field(graph: PRODUCTS)
+    review(id: Int!): Review @join__field(graph: REVIEWS)
+  }
+
+  type Review @join__type(graph: REVIEWS) {
+    id: Int!
+    body: String!
+  }
+
+  enum ShippingClass @join__type(graph: INVENTORY) @join__type(graph: PRODUCTS) {
+    STANDARD @join__enumValue(graph: INVENTORY) @join__enumValue(graph: PRODUCTS)
+    EXPRESS @join__enumValue(graph: INVENTORY) @join__enumValue(graph: PRODUCTS)
+    OVERNIGHT @join__enumValue(graph: INVENTORY)
+  }
+
+  interface SkuItf @join__type(graph: PRODUCTS) {
+    sku: String
+  }
+
+  type User @join__type(graph: PRODUCTS, key: "email") @join__type(graph: USERS, key: "email") {
+    email: ID! @tag(name: "test-from-users")
+    totalProductsCreated: Int
+    name: String @join__field(graph: USERS)
+  }
+`);
+
+describe('extractSuperGraphInformation', () => {
+  test('extracts definitions', () => {
+    const result = extractSuperGraphInformation(ast);
+    expect(result).toMatchInlineSnapshot(`
+      {
+        schemaCoordinateOwner: Map {
+          DeliveryEstimates => Set {
+            inventory,
+          },
+          DeliveryEstimates.estimatedDelivery => Set {
+            inventory,
+          },
+          DeliveryEstimates.fastestDelivery => Set {
+            inventory,
+          },
+          Panda => Set {
+            pandas,
+          },
+          Panda.name => Set {
+            pandas,
+          },
+          Panda.favoriteFood => Set {
+            pandas,
+          },
+          Product => Set {
+            inventory,
+            products,
+            reviews,
+          },
+          Product.id => Set {
+            inventory,
+            products,
+            reviews,
+          },
+          Product.dimensions => Set {
+            inventory,
+          },
+          Product.delivery => Set {
+            inventory,
+          },
+          Product.sku => Set {
+            products,
+          },
+          Product.name => Set {
+            products,
+          },
+          Product.package => Set {
+            products,
+          },
+          Product.variation => Set {
+            products,
+          },
+          Product.createdBy => Set {
+            products,
+          },
+          Product.hidden => Set {
+            products,
+          },
+          Product.reviewsScore => Set {
+            reviews,
+          },
+          Product.oldField => Set {
+            products,
+          },
+          Product.reviewsCount => Set {
+            reviews,
+          },
+          Product.reviews => Set {
+            reviews,
+          },
+          ProductDimension => Set {
+            inventory,
+            products,
+          },
+          ProductDimension.size => Set {
+            inventory,
+            products,
+          },
+          ProductDimension.weight => Set {
+            inventory,
+            products,
+          },
+          ProductItf => Set {
+            inventory,
+            products,
+            reviews,
+          },
+          ProductItf.id => Set {
+            inventory,
+            products,
+            reviews,
+          },
+          ProductItf.dimensions => Set {
+            inventory,
+          },
+          ProductItf.delivery => Set {
+            inventory,
+          },
+          ProductItf.sku => Set {
+            products,
+          },
+          ProductItf.name => Set {
+            products,
+          },
+          ProductItf.package => Set {
+            products,
+          },
+          ProductItf.variation => Set {
+            products,
+          },
+          ProductItf.createdBy => Set {
+            products,
+          },
+          ProductItf.hidden => Set {
+            products,
+          },
+          ProductItf.oldField => Set {
+            products,
+          },
+          ProductItf.reviewsCount => Set {
+            reviews,
+          },
+          ProductItf.reviewsScore => Set {
+            reviews,
+          },
+          ProductItf.reviews => Set {
+            reviews,
+          },
+          ProductVariation => Set {
+            products,
+          },
+          ProductVariation.id => Set {
+            products,
+          },
+          ProductVariation.name => Set {
+            products,
+          },
+          Query => Set {
+            inventory,
+            pandas,
+            products,
+            reviews,
+            users,
+          },
+          Query.allPandas => Set {
+            pandas,
+          },
+          Query.panda => Set {
+            pandas,
+          },
+          Query.allProducts => Set {
+            products,
+          },
+          Query.product => Set {
+            products,
+          },
+          Query.review => Set {
+            reviews,
+          },
+          Review => Set {
+            reviews,
+          },
+          Review.id => Set {
+            reviews,
+          },
+          Review.body => Set {
+            reviews,
+          },
+          ShippingClass => Set {
+            inventory,
+            products,
+          },
+          ShippingClass.STANDARD => Set {
+            inventory,
+            products,
+          },
+          ShippingClass.EXPRESS => Set {
+            inventory,
+            products,
+          },
+          ShippingClass.OVERNIGHT => Set {
+            inventory,
+          },
+          SkuItf => Set {
+            products,
+          },
+          SkuItf.sku => Set {
+            products,
+          },
+          User => Set {
+            products,
+            users,
+          },
+          User.email => Set {
+            products,
+            users,
+          },
+          User.totalProductsCreated => Set {
+            products,
+            users,
+          },
+          User.name => Set {
+            users,
+          },
+        },
+      }
+    `);
+  });
+});

--- a/packages/services/api/src/modules/schema/lib/__tests__/federation-super-graph.spec.ts
+++ b/packages/services/api/src/modules/schema/lib/__tests__/federation-super-graph.spec.ts
@@ -178,6 +178,14 @@ const ast = parse(/* GraphQL */ `
     totalProductsCreated: Int
     name: String @join__field(graph: USERS)
   }
+
+  union PandaOrUser
+    @join__type(graph: PRODUCTS)
+    @join__type(graph: PANDAS)
+    @join__unionMember(graph: PRODUCTS, member: "User")
+    @join__unionMember(graph: B, member: "Panda") =
+      Movie
+    | Book
 `);
 
 describe('extractSuperGraphInformation', () => {
@@ -383,6 +391,10 @@ describe('extractSuperGraphInformation', () => {
           ],
           User.name => [
             users,
+          ],
+          PandaOrUser => [
+            products,
+            pandas,
           ],
         },
       }

--- a/packages/services/api/src/modules/schema/lib/federation-super-graph.ts
+++ b/packages/services/api/src/modules/schema/lib/federation-super-graph.ts
@@ -192,6 +192,21 @@ export function extractSuperGraphInformation(documentAst: DocumentNode): SuperGr
 
       return false;
     },
+    ScalarTypeDefinition(node) {
+      const objectTypeServiceReferences = new Set(
+        getJoinTypeEnumServiceName({
+          directives: node.directives ?? [],
+          valueName: 'type',
+        }),
+      );
+
+      if (objectTypeServiceReferences.size) {
+        schemaCoordinateToServiceEnumValueMappings.set(
+          node.name.value,
+          objectTypeServiceReferences,
+        );
+      }
+    },
   });
 
   for (const [schemaCoordinate, serviceEnumValues] of schemaCoordinateToServiceEnumValueMappings) {

--- a/packages/services/api/src/modules/schema/lib/federation-super-graph.ts
+++ b/packages/services/api/src/modules/schema/lib/federation-super-graph.ts
@@ -9,16 +9,16 @@ import {
   visit,
 } from 'graphql';
 
-type SuperGraphInformation = {
+export type SuperGraphInformation = {
   /** Mapping of schema coordinate to the services that own it. */
-  schemaCoordinateServicesMappings: Map<string, Set<string>>;
+  schemaCoordinateServicesMappings: Map<string, Array<string>>;
 };
 
 /**
  * Extracts the super graph information from the GraphQL schema AST.
  */
 export function extractSuperGraphInformation(documentAst: DocumentNode): SuperGraphInformation {
-  const schemaCoordinateServiceMappings = new Map<string, Set<string>>();
+  const schemaCoordinateServicesMappings = new Map<string, Array<string>>();
 
   const serviceEnumValueToServiceNameMappings = new Map<string, string>();
   const schemaCoordinateToServiceEnumValueMappings = new Map<string, Set<string>>();
@@ -128,10 +128,10 @@ export function extractSuperGraphInformation(documentAst: DocumentNode): SuperGr
       continue;
     }
 
-    schemaCoordinateServiceMappings.set(schemaCoordinate, new Set(serviceNames));
+    schemaCoordinateServicesMappings.set(schemaCoordinate, Array.from(serviceNames));
   }
 
-  return { schemaCoordinateServicesMappings: schemaCoordinateServiceMappings };
+  return { schemaCoordinateServicesMappings };
 }
 
 function getJoinGraphEnumServiceName(enumValueDefinitionNode: EnumValueDefinitionNode) {

--- a/packages/services/api/src/modules/schema/lib/federation-super-graph.ts
+++ b/packages/services/api/src/modules/schema/lib/federation-super-graph.ts
@@ -1,0 +1,192 @@
+import {
+  type ConstArgumentNode,
+  type ConstDirectiveNode,
+  type DocumentNode,
+  type EnumValueDefinitionNode,
+  type FieldDefinitionNode,
+  Kind,
+  type NameNode,
+  visit,
+} from 'graphql';
+
+type SuperGraphInformation = {
+  /** Mapping of schema coordinate to the services that own it. */
+  schemaCoordinateServicesMappings: Map<string, Set<string>>;
+};
+
+/**
+ * Extracts the super graph information from the GraphQL schema AST.
+ */
+export function extractSuperGraphInformation(documentAst: DocumentNode): SuperGraphInformation {
+  const schemaCoordinateServiceMappings = new Map<string, Set<string>>();
+
+  const serviceEnumValueToServiceNameMappings = new Map<string, string>();
+  const schemaCoordinateToServiceEnumValueMappings = new Map<string, Set<string>>();
+
+  function interfaceAndObjectHandler(node: {
+    readonly fields?: ReadonlyArray<FieldDefinitionNode> | undefined;
+    readonly directives?: ReadonlyArray<ConstDirectiveNode> | undefined;
+    readonly name: NameNode;
+  }) {
+    const objectTypeServiceReferences = new Set(
+      getJoinTypeEnumServiceName({
+        directives: node.directives ?? [],
+        valueName: 'type',
+      }),
+    );
+
+    schemaCoordinateToServiceEnumValueMappings.set(node.name.value, objectTypeServiceReferences);
+
+    if (node.fields === undefined) {
+      return;
+    }
+
+    for (const fieldNode of node.fields) {
+      const schemaCoordinate = `${node.name.value}.${fieldNode.name.value}`;
+
+      const graphArg = fieldNode.directives
+        ?.find(directive => directive.name.value === 'join__field')
+        ?.arguments?.find(arg => arg.name.value === 'graph');
+
+      if (graphArg === undefined) {
+        schemaCoordinateToServiceEnumValueMappings.set(
+          schemaCoordinate,
+          objectTypeServiceReferences,
+        );
+        continue;
+      }
+
+      const serviceEnumValue = getEnumValueArgumentValue(graphArg);
+
+      if (!serviceEnumValue) {
+        continue;
+      }
+
+      schemaCoordinateToServiceEnumValueMappings.set(schemaCoordinate, new Set([serviceEnumValue]));
+    }
+
+    return false;
+  }
+
+  visit(documentAst, {
+    /** Collect the service enum to service name mappings. */
+    EnumTypeDefinition(node) {
+      if (node.name.value === 'join__Graph' && node.values?.length) {
+        for (const enumValueNode of node.values) {
+          const serviceName = getJoinGraphEnumServiceName(enumValueNode);
+          if (serviceName === null) {
+            continue;
+          }
+
+          serviceEnumValueToServiceNameMappings.set(enumValueNode.name.value, serviceName);
+        }
+      }
+
+      const enumServiceNames = getJoinTypeEnumServiceName({
+        directives: node.directives ?? [],
+        valueName: 'type',
+      });
+
+      if (enumServiceNames.size) {
+        schemaCoordinateToServiceEnumValueMappings.set(node.name.value, enumServiceNames);
+      }
+
+      if (node.values?.length) {
+        for (const enumValueNode of node.values) {
+          const enumValueServiceNames = getJoinTypeEnumServiceName({
+            directives: enumValueNode.directives ?? [],
+            valueName: 'enumValue',
+          });
+
+          if (enumValueServiceNames.size) {
+            const schemaCoordinate = `${node.name.value}.${enumValueNode.name.value}`;
+            schemaCoordinateToServiceEnumValueMappings.set(schemaCoordinate, enumValueServiceNames);
+          }
+        }
+      }
+
+      return false;
+    },
+    ObjectTypeDefinition(node) {
+      return interfaceAndObjectHandler(node);
+    },
+    InterfaceTypeDefinition(node) {
+      return interfaceAndObjectHandler(node);
+    },
+  });
+
+  for (const [schemaCoordinate, serviceEnumValues] of schemaCoordinateToServiceEnumValueMappings) {
+    const serviceNames = new Set<string>();
+    for (const serviceEnumValue of serviceEnumValues) {
+      const serviceName = serviceEnumValueToServiceNameMappings.get(serviceEnumValue);
+      if (serviceName) {
+        serviceNames.add(serviceName);
+      }
+    }
+
+    if (!serviceNames.size) {
+      continue;
+    }
+
+    schemaCoordinateServiceMappings.set(schemaCoordinate, new Set(serviceNames));
+  }
+
+  return { schemaCoordinateServicesMappings: schemaCoordinateServiceMappings };
+}
+
+function getJoinGraphEnumServiceName(enumValueDefinitionNode: EnumValueDefinitionNode) {
+  const arg = enumValueDefinitionNode.directives
+    ?.find(directive => directive.name.value === 'join__graph')
+    ?.arguments?.find(argument => argument.name.value === 'name');
+  if (arg === undefined) {
+    return null;
+  }
+  return getStringValueArgumentValue(arg);
+}
+
+function getJoinTypeEnumServiceName(args: {
+  directives: ReadonlyArray<ConstDirectiveNode>;
+  valueName: 'enumValue' | 'type';
+}) {
+  if (!args.directives?.length) {
+    return new Set<string>();
+  }
+  const enumServiceValues = new Set<string>();
+  for (const directiveNode of args.directives) {
+    if (directiveNode.name.value !== `join__${args.valueName}`) {
+      continue;
+    }
+
+    const nameArgNode = directiveNode.arguments?.find(argument => argument.name.value === 'graph');
+
+    if (nameArgNode === undefined) {
+      continue;
+    }
+
+    const enumServiceValue = getEnumValueArgumentValue(nameArgNode);
+
+    if (enumServiceValue === null) {
+      continue;
+    }
+
+    enumServiceValues.add(enumServiceValue);
+  }
+
+  return enumServiceValues;
+}
+
+function getEnumValueArgumentValue(arg: ConstArgumentNode): string | null {
+  if (arg.value.kind !== Kind.ENUM) {
+    return null;
+  }
+
+  return arg.value.value;
+}
+
+function getStringValueArgumentValue(arg: ConstArgumentNode): string | null {
+  if (arg.value.kind !== Kind.STRING) {
+    return null;
+  }
+
+  return arg.value.value;
+}

--- a/packages/services/api/src/modules/schema/lib/federation-super-graph.ts
+++ b/packages/services/api/src/modules/schema/lib/federation-super-graph.ts
@@ -113,6 +113,16 @@ export function extractSuperGraphInformation(documentAst: DocumentNode): SuperGr
     InterfaceTypeDefinition(node) {
       return interfaceAndObjectHandler(node);
     },
+    UnionTypeDefinition(node) {
+      const objectTypeServiceReferences = new Set(
+        getJoinTypeEnumServiceName({
+          directives: node.directives ?? [],
+          valueName: 'type',
+        }),
+      );
+
+      schemaCoordinateToServiceEnumValueMappings.set(node.name.value, objectTypeServiceReferences);
+    },
   });
 
   for (const [schemaCoordinate, serviceEnumValues] of schemaCoordinateToServiceEnumValueMappings) {

--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -517,11 +517,21 @@ export default gql`
     description: String
     members: [GraphQLUnionTypeMember!]!
     usage: SchemaCoordinateUsage!
+    """
+    Metadata specific to Apollo Federation Projects.
+    Is null if no meta information is available (e.g. this is not an apollo federation project).
+    """
+    supergraphMetadata: SupergraphMetadata
   }
 
   type GraphQLUnionTypeMember {
     name: String!
     usage: SchemaCoordinateUsage!
+    """
+    Metadata specific to Apollo Federation Projects.
+    Is null if no meta information is available (e.g. this is not an apollo federation project).
+    """
+    supergraphMetadata: SupergraphMetadata
   }
 
   type GraphQLEnumType {

--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -562,6 +562,11 @@ export default gql`
     name: String!
     description: String
     usage: SchemaCoordinateUsage!
+    """
+    Metadata specific to Apollo Federation Projects.
+    Is null if no meta information is available (e.g. this is not an apollo federation project).
+    """
+    supergraphMetadata: SupergraphMetadata
   }
 
   type GraphQLField {

--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -551,6 +551,11 @@ export default gql`
     description: String
     fields: [GraphQLInputField!]!
     usage: SchemaCoordinateUsage!
+    """
+    Metadata specific to Apollo Federation Projects.
+    Is null if no meta information is available (e.g. this is not an apollo federation project).
+    """
+    supergraphMetadata: SupergraphMetadata
   }
 
   type GraphQLScalarType {
@@ -582,6 +587,11 @@ export default gql`
     isDeprecated: Boolean!
     deprecationReason: String
     usage: SchemaCoordinateUsage!
+    """
+    Metadata specific to Apollo Federation Projects.
+    Is null if no meta information is available (e.g. this is not an apollo federation project).
+    """
+    supergraphMetadata: SupergraphMetadata
   }
 
   type GraphQLArgument {

--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -470,6 +470,14 @@ export default gql`
     isUsed: Boolean!
   }
 
+  type SupergraphMetadata {
+    """
+    List of service names that own the field/type.
+    Resolves to null if the entity (field, type, scalar) does not belong to any service.
+    """
+    ownedByServiceNames: [String!]
+  }
+
   union GraphQLNamedType =
       GraphQLObjectType
     | GraphQLInterfaceType
@@ -484,6 +492,11 @@ export default gql`
     fields: [GraphQLField!]!
     interfaces: [String!]!
     usage: SchemaCoordinateUsage!
+    """
+    Metadata specific to Apollo Federation Projects.
+    Is null if no meta information is available (e.g. this is not an apollo federation project).
+    """
+    supergraphMetadata: SupergraphMetadata
   }
 
   type GraphQLInterfaceType {
@@ -492,6 +505,11 @@ export default gql`
     fields: [GraphQLField!]!
     interfaces: [String!]!
     usage: SchemaCoordinateUsage!
+    """
+    Metadata specific to Apollo Federation Projects.
+    Is null if no meta information is available.
+    """
+    supergraphMetadata: SupergraphMetadata
   }
 
   type GraphQLUnionType {
@@ -511,6 +529,11 @@ export default gql`
     description: String
     values: [GraphQLEnumValue!]!
     usage: SchemaCoordinateUsage!
+    """
+    Metadata specific to Apollo Federation Projects.
+    Is null if no meta information is available.
+    """
+    supergraphMetadata: SupergraphMetadata
   }
 
   type GraphQLInputObjectType {
@@ -534,6 +557,11 @@ export default gql`
     isDeprecated: Boolean!
     deprecationReason: String
     usage: SchemaCoordinateUsage!
+    """
+    Metadata specific to Apollo Federation Projects.
+    Is null if no meta information is available.
+    """
+    supergraphMetadata: SupergraphMetadata
   }
 
   type GraphQLInputField {
@@ -562,5 +590,10 @@ export default gql`
     isDeprecated: Boolean!
     deprecationReason: String
     usage: SchemaCoordinateUsage!
+    """
+    Metadata specific to Apollo Federation Projects.
+    Is null if no meta information is available.
+    """
+    supergraphMetadata: SupergraphMetadata
   }
 `;

--- a/packages/services/api/src/modules/schema/providers/schema-manager.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-manager.ts
@@ -318,10 +318,12 @@ export class SchemaManager {
       (
         | {
             compositeSchemaSDL: null;
+            supergraphSDL: null;
             schemaCompositionErrors: Array<SchemaCompositionError>;
           }
         | {
             compositeSchemaSDL: string;
+            supergraphSDL: string | null;
             schemaCompositionErrors: null;
           }
       ),

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -563,10 +563,12 @@ export class SchemaPublisher {
               ...(deleteResult.state.fullSchemaSdl
                 ? {
                     compositeSchemaSDL: deleteResult.state.fullSchemaSdl,
+                    supergraphSDL: deleteResult.state.supergraph,
                     schemaCompositionErrors: null,
                   }
                 : {
                     compositeSchemaSDL: null,
+                    supergraphSDL: null,
                     schemaCompositionErrors: deleteResult.state.compositionErrors ?? [],
                   }),
               actionFn: async () => {
@@ -904,10 +906,12 @@ export class SchemaPublisher {
       ...(fullSchemaSdl
         ? {
             compositeSchemaSDL: fullSchemaSdl,
+            supergraphSDL: supergraph,
             schemaCompositionErrors: null,
           }
         : {
             compositeSchemaSDL: null,
+            supergraphSDL: null,
             schemaCompositionErrors: assertNonNull(
               publishResult.state.compositionErrors,
               "Can't be null",

--- a/packages/services/api/src/modules/schema/resolvers.ts
+++ b/packages/services/api/src/modules/schema/resolvers.ts
@@ -933,23 +933,99 @@ export const resolvers: SchemaModule.Resolvers = {
   },
   SchemaExplorer: {
     async type(source, { name }, { injector }) {
-      const namedType = source.schema.getType(name);
+      const entity = source.schema.getType(name);
 
-      if (!namedType) {
+      if (!entity) {
         return null;
       }
 
+      const { supergraph } = source;
+      const usage = injector.get(OperationsManager).countCoordinatesOfType({
+        typename: entity.name,
+        organization: source.usage.organization,
+        project: source.usage.project,
+        target: source.usage.target,
+        period: source.usage.period,
+      });
+
+      if (isObjectType(entity)) {
+        return {
+          entity,
+          usage,
+          supergraph: supergraph
+            ? {
+                ownedByServiceNames:
+                  supergraph.schemaCoordinateServicesMappings.get(entity.name) ?? null,
+                getFieldOwnedByServices: (fieldName: string) =>
+                  supergraph.schemaCoordinateServicesMappings.get(`${entity.name}.${fieldName}`) ??
+                  null,
+              }
+            : null,
+        };
+      }
+      if (isInterfaceType(entity)) {
+        return {
+          entity,
+          usage,
+          supergraph: supergraph
+            ? {
+                ownedByServiceNames:
+                  supergraph.schemaCoordinateServicesMappings.get(entity.name) ?? null,
+                getFieldOwnedByServices: (fieldName: string) =>
+                  supergraph.schemaCoordinateServicesMappings.get(`${entity.name}.${fieldName}`) ??
+                  null,
+              }
+            : null,
+        };
+      }
+      if (isEnumType(entity)) {
+        return {
+          entity,
+          usage,
+          supergraph: supergraph
+            ? {
+                ownedByServiceNames:
+                  supergraph.schemaCoordinateServicesMappings.get(entity.name) ?? null,
+                getEnumValueOwnedByServices: (fieldName: string) =>
+                  supergraph.schemaCoordinateServicesMappings.get(`${entity.name}.${fieldName}`) ??
+                  null,
+              }
+            : null,
+        };
+      }
+      if (isUnionType(entity)) {
+        return {
+          entity,
+          usage,
+          supergraph: supergraph
+            ? {
+                ownedByServiceNames:
+                  supergraph.schemaCoordinateServicesMappings.get(entity.name) ?? null,
+                getUnionMemberOwnedByServices: (memberName: string) =>
+                  supergraph.schemaCoordinateServicesMappings.get(memberName) ?? null,
+              }
+            : null,
+        };
+      }
+      if (isInputObjectType(entity)) {
+        return {
+          entity,
+          usage,
+          supergraph: supergraph
+            ? {
+                ownedByServiceNames:
+                  supergraph.schemaCoordinateServicesMappings.get(entity.name) ?? null,
+                getInputFieldOwnedByServices: (inputFieldName: string) =>
+                  supergraph.schemaCoordinateServicesMappings.get(
+                    `${entity.name}.${inputFieldName}`,
+                  ) ?? null,
+              }
+            : null,
+        };
+      }
       return {
-        // TODO: fix any
-        entity: namedType as any,
-        usage: injector.get(OperationsManager).countCoordinatesOfType({
-          typename: namedType.name,
-          organization: source.usage.organization,
-          project: source.usage.project,
-          target: source.usage.target,
-          period: source.usage.period,
-        }),
-        supergraph: source.supergraph,
+        entity,
+        usage,
       };
     },
     async types({ schema, usage, supergraph }, _, { injector }) {
@@ -990,7 +1066,7 @@ export const resolvers: SchemaModule.Resolvers = {
               ? {
                   ownedByServiceNames:
                     supergraph.schemaCoordinateServicesMappings.get(typename) ?? null,
-                  getFieldUsedByServices: (fieldName: string) =>
+                  getFieldOwnedByServices: (fieldName: string) =>
                     supergraph.schemaCoordinateServicesMappings.get(`${typename}.${fieldName}`) ??
                     null,
                 }
@@ -1006,7 +1082,7 @@ export const resolvers: SchemaModule.Resolvers = {
               ? {
                   ownedByServiceNames:
                     supergraph.schemaCoordinateServicesMappings.get(typename) ?? null,
-                  getFieldUsedByServices: (fieldName: string) =>
+                  getFieldOwnedByServices: (fieldName: string) =>
                     supergraph.schemaCoordinateServicesMappings.get(`${typename}.${fieldName}`) ??
                     null,
                 }
@@ -1022,7 +1098,7 @@ export const resolvers: SchemaModule.Resolvers = {
               ? {
                   ownedByServiceNames:
                     supergraph.schemaCoordinateServicesMappings.get(typename) ?? null,
-                  getEnumValueUsedByServices: (fieldName: string) =>
+                  getEnumValueOwnedByServices: (fieldName: string) =>
                     supergraph.schemaCoordinateServicesMappings.get(`${typename}.${fieldName}`) ??
                     null,
                 }
@@ -1038,7 +1114,7 @@ export const resolvers: SchemaModule.Resolvers = {
               ? {
                   ownedByServiceNames:
                     supergraph.schemaCoordinateServicesMappings.get(typename) ?? null,
-                  getUnionMemberUserByServices: (memberName: string) =>
+                  getUnionMemberOwnedByServices: (memberName: string) =>
                     supergraph.schemaCoordinateServicesMappings.get(memberName) ?? null,
                 }
               : null,
@@ -1053,7 +1129,7 @@ export const resolvers: SchemaModule.Resolvers = {
               ? {
                   ownedByServiceNames:
                     supergraph.schemaCoordinateServicesMappings.get(typename) ?? null,
-                  getInputFieldUsedByServices: (inputFieldName: string) =>
+                  getInputFieldOwnedByServices: (inputFieldName: string) =>
                     supergraph.schemaCoordinateServicesMappings.get(
                       `${typename}.${inputFieldName}`,
                     ) ?? null,
@@ -1096,7 +1172,7 @@ export const resolvers: SchemaModule.Resolvers = {
           ? {
               ownedByServiceNames:
                 supergraph.schemaCoordinateServicesMappings.get(entity.name) ?? null,
-              getFieldUsedByServices: (fieldName: string) =>
+              getFieldOwnedByServices: (fieldName: string) =>
                 supergraph.schemaCoordinateServicesMappings.get(`${entity.name}.${fieldName}`) ??
                 null,
             }
@@ -1125,7 +1201,7 @@ export const resolvers: SchemaModule.Resolvers = {
           ? {
               ownedByServiceNames:
                 supergraph.schemaCoordinateServicesMappings.get(entity.name) ?? null,
-              getFieldUsedByServices: (fieldName: string) =>
+              getFieldOwnedByServices: (fieldName: string) =>
                 supergraph.schemaCoordinateServicesMappings.get(`${entity.name}.${fieldName}`) ??
                 null,
             }
@@ -1154,7 +1230,7 @@ export const resolvers: SchemaModule.Resolvers = {
           ? {
               ownedByServiceNames:
                 supergraph.schemaCoordinateServicesMappings.get(entity.name) ?? null,
-              getFieldUsedByServices: (fieldName: string) =>
+              getFieldOwnedByServices: (fieldName: string) =>
                 supergraph.schemaCoordinateServicesMappings.get(`${entity.name}.${fieldName}`) ??
                 null,
             }
@@ -1174,7 +1250,7 @@ export const resolvers: SchemaModule.Resolvers = {
         },
         usage: t.usage,
         supergraph: t.supergraph
-          ? { ownedByServiceNames: t.supergraph.getFieldUsedByServices(f.name) }
+          ? { ownedByServiceNames: t.supergraph.getFieldOwnedByServices(f.name) }
           : null,
       })),
     interfaces: t => t.entity.getInterfaces().map(i => i.name),
@@ -1198,7 +1274,7 @@ export const resolvers: SchemaModule.Resolvers = {
         },
         usage: t.usage,
         supergraph: t.supergraph
-          ? { ownedByServiceNames: t.supergraph.getFieldUsedByServices(f.name) }
+          ? { ownedByServiceNames: t.supergraph.getFieldOwnedByServices(f.name) }
           : null,
       })),
     interfaces: t => t.entity.getInterfaces().map(i => i.name),
@@ -1224,7 +1300,7 @@ export const resolvers: SchemaModule.Resolvers = {
           },
           supergraph: t.supergraph
             ? {
-                ownedByServiceNames: t.supergraph.getUnionMemberUserByServices(i.name),
+                ownedByServiceNames: t.supergraph.getUnionMemberOwnedByServices(i.name),
               }
             : null,
         };
@@ -1249,7 +1325,7 @@ export const resolvers: SchemaModule.Resolvers = {
         },
         usage: t.usage,
         supergraph: t.supergraph
-          ? { ownedByServiceNames: t.supergraph.getEnumValueUsedByServices(v.name) }
+          ? { ownedByServiceNames: t.supergraph.getEnumValueOwnedByServices(v.name) }
           : null,
       })),
     usage,
@@ -1273,7 +1349,7 @@ export const resolvers: SchemaModule.Resolvers = {
         usage: t.usage,
         supergraph: t.supergraph
           ? {
-              ownedByServiceNames: t.supergraph.getInputFieldUsedByServices(f.name),
+              ownedByServiceNames: t.supergraph.getInputFieldOwnedByServices(f.name),
             }
           : null,
       })),

--- a/packages/services/api/src/modules/schema/resolvers.ts
+++ b/packages/services/api/src/modules/schema/resolvers.ts
@@ -815,6 +815,7 @@ export const resolvers: SchemaModule.Resolvers = {
         supergraph,
       };
     },
+    date: version => version.createdAt,
   },
   SchemaCompareError: {
     __isTypeOf(source: unknown) {

--- a/packages/services/api/src/modules/schema/resolvers.ts
+++ b/packages/services/api/src/modules/schema/resolvers.ts
@@ -10,6 +10,7 @@ import {
   isObjectType,
   isScalarType,
   isUnionType,
+  parse,
 } from 'graphql';
 import { parseResolveInfo } from 'graphql-parse-resolve-info';
 import { z } from 'zod';
@@ -791,6 +792,10 @@ export const resolvers: SchemaModule.Resolvers = {
         ),
       );
 
+      const supergraph = version.supergraphSDL
+        ? buildASTSchema(parse(version.supergraphSDL))
+        : null;
+
       return {
         schema: buildASTSchema(schema.document, {
           assumeValidSDL: true,
@@ -802,6 +807,7 @@ export const resolvers: SchemaModule.Resolvers = {
           project: version.project,
           target: version.target,
         },
+        supergraph: null,
       };
     },
   },

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -292,10 +292,12 @@ export interface Storage {
       (
         | {
             compositeSchemaSDL: null;
+            supergraphSDL: null;
             schemaCompositionErrors: Array<SchemaCompositionError>;
           }
         | {
             compositeSchemaSDL: string;
+            supergraphSDL: string | null;
             schemaCompositionErrors: null;
           }
       ),
@@ -319,10 +321,12 @@ export interface Storage {
       (
         | {
             compositeSchemaSDL: null;
+            supergraphSDL: null;
             schemaCompositionErrors: Array<SchemaCompositionError>;
           }
         | {
             compositeSchemaSDL: string;
+            supergraphSDL: string | null;
             schemaCompositionErrors: null;
           }
       ),

--- a/packages/services/api/src/shared/entities.ts
+++ b/packages/services/api/src/shared/entities.ts
@@ -69,12 +69,13 @@ export interface DateRange {
 export interface SchemaVersion {
   id: string;
   valid: boolean;
-  date: string;
+  createdAt: string;
   commit: string;
   baseSchema: string | null;
   hasPersistedSchemaChanges: boolean;
   previousSchemaVersionId: null | string;
   compositeSchemaSDL: null | string;
+  supergraphSDL: null | string;
   schemaCompositionErrors: Array<SchemaCompositionError> | null;
 }
 

--- a/packages/services/api/src/shared/mappers.ts
+++ b/packages/services/api/src/shared/mappers.ts
@@ -139,7 +139,12 @@ export type GraphQLInputObjectTypeMapper = WithSchemaCoordinatesUsage<{
     getInputFieldOwnedByServices: (inputFieldName: string) => Array<string> | null;
   };
 }>;
-export type GraphQLScalarTypeMapper = WithSchemaCoordinatesUsage<{ entity: GraphQLScalarType }>;
+export type GraphQLScalarTypeMapper = WithSchemaCoordinatesUsage<{
+  entity: GraphQLScalarType;
+  supergraph: null | {
+    ownedByServiceNames: Array<string> | null;
+  };
+}>;
 
 export type SchemaChangeConnection = ReadonlyArray<SchemaChange>;
 export type SchemaErrorConnection = readonly SchemaError[];

--- a/packages/services/api/src/shared/mappers.ts
+++ b/packages/services/api/src/shared/mappers.ts
@@ -108,35 +108,35 @@ export type GraphQLObjectTypeMapper = WithSchemaCoordinatesUsage<{
   entity: GraphQLObjectType;
   supergraph: null | {
     ownedByServiceNames: Array<string> | null;
-    getFieldUsedByServices: (fieldName: string) => Array<string> | null;
+    getFieldOwnedByServices: (fieldName: string) => Array<string> | null;
   };
 }>;
 export type GraphQLInterfaceTypeMapper = WithSchemaCoordinatesUsage<{
   entity: GraphQLInterfaceType;
   supergraph: null | {
     ownedByServiceNames: Array<string> | null;
-    getFieldUsedByServices: (fieldName: string) => Array<string> | null;
+    getFieldOwnedByServices: (fieldName: string) => Array<string> | null;
   };
 }>;
 export type GraphQLUnionTypeMapper = WithSchemaCoordinatesUsage<{
   entity: GraphQLUnionType;
   supergraph: null | {
     ownedByServiceNames: Array<string> | null;
-    getUnionMemberUserByServices: (unionMemberName: string) => Array<string> | null;
+    getUnionMemberOwnedByServices: (unionMemberName: string) => Array<string> | null;
   };
 }>;
 export type GraphQLEnumTypeMapper = WithSchemaCoordinatesUsage<{
   entity: GraphQLEnumType;
   supergraph: null | {
     ownedByServiceNames: Array<string> | null;
-    getEnumValueUsedByServices: (fieldName: string) => Array<string> | null;
+    getEnumValueOwnedByServices: (fieldName: string) => Array<string> | null;
   };
 }>;
 export type GraphQLInputObjectTypeMapper = WithSchemaCoordinatesUsage<{
   entity: GraphQLInputObjectType;
   supergraph: null | {
     ownedByServiceNames: Array<string> | null;
-    getInputFieldUsedByServices: (inputFieldName: string) => Array<string> | null;
+    getInputFieldOwnedByServices: (inputFieldName: string) => Array<string> | null;
   };
 }>;
 export type GraphQLScalarTypeMapper = WithSchemaCoordinatesUsage<{ entity: GraphQLScalarType }>;

--- a/packages/services/api/src/shared/mappers.ts
+++ b/packages/services/api/src/shared/mappers.ts
@@ -64,6 +64,7 @@ export type SchemaExplorerMapper = {
     project: string;
     target: string;
   };
+  supergraph: null | GraphQLSchema;
 };
 
 export type GraphQLFieldMapper = WithSchemaCoordinatesUsage<

--- a/packages/services/api/src/shared/mappers.ts
+++ b/packages/services/api/src/shared/mappers.ts
@@ -79,6 +79,9 @@ export type GraphQLFieldMapper = WithSchemaCoordinatesUsage<
 export type GraphQLInputFieldMapper = WithSchemaCoordinatesUsage<
   WithGraphQLParentInfo<{
     entity: GraphQLInputField;
+    supergraph: null | {
+      ownedByServiceNames: Array<string> | null;
+    };
   }>
 >;
 export type GraphQLEnumValueMapper = WithSchemaCoordinatesUsage<
@@ -131,6 +134,10 @@ export type GraphQLEnumTypeMapper = WithSchemaCoordinatesUsage<{
 }>;
 export type GraphQLInputObjectTypeMapper = WithSchemaCoordinatesUsage<{
   entity: GraphQLInputObjectType;
+  supergraph: null | {
+    ownedByServiceNames: Array<string> | null;
+    getInputFieldUsedByServices: (inputFieldName: string) => Array<string> | null;
+  };
 }>;
 export type GraphQLScalarTypeMapper = WithSchemaCoordinatesUsage<{ entity: GraphQLScalarType }>;
 

--- a/packages/services/api/src/shared/mappers.ts
+++ b/packages/services/api/src/shared/mappers.ts
@@ -17,6 +17,7 @@ import type {
   SchemaChange,
   SchemaError,
 } from '../__generated__/types';
+import { type SuperGraphInformation } from '../modules/schema/lib/federation-super-graph';
 import { SchemaCheckWarning } from '../modules/schema/providers/models/shared';
 import { SchemaBuildError } from '../modules/schema/providers/orchestrators/errors';
 import { SerializableChange } from '../modules/schema/schema-change-from-meta';
@@ -64,12 +65,15 @@ export type SchemaExplorerMapper = {
     project: string;
     target: string;
   };
-  supergraph: null | GraphQLSchema;
+  supergraph: null | SuperGraphInformation;
 };
 
 export type GraphQLFieldMapper = WithSchemaCoordinatesUsage<
   WithGraphQLParentInfo<{
     entity: GraphQLField<any, any, any>;
+    supergraph: null | {
+      ownedByServiceNames: Array<string> | null;
+    };
   }>
 >;
 export type GraphQLInputFieldMapper = WithSchemaCoordinatesUsage<
@@ -78,7 +82,12 @@ export type GraphQLInputFieldMapper = WithSchemaCoordinatesUsage<
   }>
 >;
 export type GraphQLEnumValueMapper = WithSchemaCoordinatesUsage<
-  WithGraphQLParentInfo<{ entity: GraphQLEnumValue }>
+  WithGraphQLParentInfo<{
+    entity: GraphQLEnumValue;
+    supergraph: null | {
+      ownedByServiceNames: Array<string> | null;
+    };
+  }>
 >;
 export type GraphQLArgumentMapper = WithSchemaCoordinatesUsage<
   WithGraphQLParentInfo<{ entity: GraphQLArgument }>
@@ -89,12 +98,28 @@ export type GraphQLUnionTypeMemberMapper = WithSchemaCoordinatesUsage<
   }>
 >;
 
-export type GraphQLObjectTypeMapper = WithSchemaCoordinatesUsage<{ entity: GraphQLObjectType }>;
+export type GraphQLObjectTypeMapper = WithSchemaCoordinatesUsage<{
+  entity: GraphQLObjectType;
+  supergraph: null | {
+    ownedByServiceNames: Array<string> | null;
+    getFieldUsedByServices: (fieldName: string) => Array<string> | null;
+  };
+}>;
 export type GraphQLInterfaceTypeMapper = WithSchemaCoordinatesUsage<{
   entity: GraphQLInterfaceType;
+  supergraph: null | {
+    ownedByServiceNames: Array<string> | null;
+    getFieldUsedByServices: (fieldName: string) => Array<string> | null;
+  };
 }>;
 export type GraphQLUnionTypeMapper = WithSchemaCoordinatesUsage<{ entity: GraphQLUnionType }>;
-export type GraphQLEnumTypeMapper = WithSchemaCoordinatesUsage<{ entity: GraphQLEnumType }>;
+export type GraphQLEnumTypeMapper = WithSchemaCoordinatesUsage<{
+  entity: GraphQLEnumType;
+  supergraph: null | {
+    ownedByServiceNames: Array<string> | null;
+    getEnumValueUsedByServices: (fieldName: string) => Array<string> | null;
+  };
+}>;
 export type GraphQLInputObjectTypeMapper = WithSchemaCoordinatesUsage<{
   entity: GraphQLInputObjectType;
 }>;

--- a/packages/services/api/src/shared/mappers.ts
+++ b/packages/services/api/src/shared/mappers.ts
@@ -95,6 +95,9 @@ export type GraphQLArgumentMapper = WithSchemaCoordinatesUsage<
 export type GraphQLUnionTypeMemberMapper = WithSchemaCoordinatesUsage<
   WithGraphQLParentInfo<{
     entity: GraphQLObjectType;
+    supergraph: null | {
+      ownedByServiceNames: Array<string> | null;
+    };
   }>
 >;
 
@@ -112,7 +115,13 @@ export type GraphQLInterfaceTypeMapper = WithSchemaCoordinatesUsage<{
     getFieldUsedByServices: (fieldName: string) => Array<string> | null;
   };
 }>;
-export type GraphQLUnionTypeMapper = WithSchemaCoordinatesUsage<{ entity: GraphQLUnionType }>;
+export type GraphQLUnionTypeMapper = WithSchemaCoordinatesUsage<{
+  entity: GraphQLUnionType;
+  supergraph: null | {
+    ownedByServiceNames: Array<string> | null;
+    getUnionMemberUserByServices: (unionMemberName: string) => Array<string> | null;
+  };
+}>;
 export type GraphQLEnumTypeMapper = WithSchemaCoordinatesUsage<{
   entity: GraphQLEnumType;
   supergraph: null | {

--- a/packages/services/external-composition/federation-2/package.json
+++ b/packages/services/external-composition/federation-2/package.json
@@ -8,7 +8,7 @@
     "dev": "tsup-node --config ../../../configs/tsup/dev.config.node.ts src/index.ts"
   },
   "dependencies": {
-    "@apollo/composition": "^2.2.2",
+    "@apollo/composition": "^2.4.5",
     "@whatwg-node/fetch": "^0.9.0",
     "@whatwg-node/server": "^0.7.0",
     "graphql": "^16.6.0",

--- a/packages/services/storage/src/db/types.ts
+++ b/packages/services/storage/src/db/types.ts
@@ -189,6 +189,7 @@ export interface schema_versions {
   is_composable: boolean;
   previous_schema_version_id: string | null;
   schema_composition_errors: any | null;
+  supergraph_sdl: string | null;
   target_id: string;
 }
 

--- a/packages/web/app/pages/[orgId]/[projectId]/[targetId]/index.tsx
+++ b/packages/web/app/pages/[orgId]/[projectId]/[targetId]/index.tsx
@@ -24,7 +24,9 @@ function SchemaBlock({ schema }: { schema: CompositeSchemaFieldsFragment }) {
     <Accordion.Item value={schema.id} key={schema.id} className="border-2 border-gray-900/50">
       <Accordion.Header>
         <div>
-          <div className="text-base">{schema.service ?? 'SDL'}</div>
+          <div className="text-base" id={schema.service ?? undefined}>
+            {schema.service ?? 'SDL'}
+          </div>
           {schema.url ? <div className="text-xs text-gray-500">{schema.url}</div> : null}
         </div>
       </Accordion.Header>

--- a/packages/web/app/src/components/target/explorer/enum-type.tsx
+++ b/packages/web/app/src/components/target/explorer/enum-type.tsx
@@ -1,10 +1,6 @@
 import { FragmentType, graphql, useFragment } from '@/gql';
-import {
-  GraphQLTypeCard,
-  GraphQLTypeCardListItem,
-  SchemaExplorerUsageStats,
-  SupergraphMetadataTooltip,
-} from './common';
+import { GraphQLTypeCard, GraphQLTypeCardListItem, SchemaExplorerUsageStats } from './common';
+import { SupergraphMetadataList } from './super-graph-metadata';
 
 export const GraphQLEnumTypeComponent_TypeFragment = graphql(`
   fragment GraphQLEnumTypeComponent_TypeFragment on GraphQLEnumType {
@@ -22,7 +18,7 @@ export const GraphQLEnumTypeComponent_TypeFragment = graphql(`
         ...SchemaExplorerUsageStats_UsageFragment
       }
       supergraphMetadata {
-        ...GraphQLTypeCard_SupergraphMetadataFragment
+        ...SupergraphMetadataList_SupergraphMetadataFragment
       }
     }
     supergraphMetadata {
@@ -47,10 +43,10 @@ export function GraphQLEnumTypeComponent(props: {
         {ttype.values.map((value, i) => (
           <GraphQLTypeCardListItem index={i}>
             <div>{value.name}</div>
-            <SchemaExplorerUsageStats totalRequests={props.totalRequests} usage={value.usage} />
             {value.supergraphMetadata ? (
-              <SupergraphMetadataTooltip supergraphMetadata={value.supergraphMetadata} />
+              <SupergraphMetadataList supergraphMetadata={value.supergraphMetadata} />
             ) : null}
+            <SchemaExplorerUsageStats totalRequests={props.totalRequests} usage={value.usage} />
           </GraphQLTypeCardListItem>
         ))}
       </div>

--- a/packages/web/app/src/components/target/explorer/enum-type.tsx
+++ b/packages/web/app/src/components/target/explorer/enum-type.tsx
@@ -1,5 +1,10 @@
 import { FragmentType, graphql, useFragment } from '@/gql';
-import { GraphQLTypeCard, GraphQLTypeCardListItem, SchemaExplorerUsageStats } from './common';
+import {
+  GraphQLTypeCard,
+  GraphQLTypeCardListItem,
+  SchemaExplorerUsageStats,
+  SupergraphMetadataTooltip,
+} from './common';
 
 export const GraphQLEnumTypeComponent_TypeFragment = graphql(`
   fragment GraphQLEnumTypeComponent_TypeFragment on GraphQLEnumType {
@@ -16,6 +21,12 @@ export const GraphQLEnumTypeComponent_TypeFragment = graphql(`
       usage {
         ...SchemaExplorerUsageStats_UsageFragment
       }
+      supergraphMetadata {
+        ...GraphQLTypeCard_SupergraphMetadataFragment
+      }
+    }
+    supergraphMetadata {
+      ...GraphQLTypeCard_SupergraphMetadataFragment
     }
   }
 `);
@@ -26,12 +37,20 @@ export function GraphQLEnumTypeComponent(props: {
 }) {
   const ttype = useFragment(GraphQLEnumTypeComponent_TypeFragment, props.type);
   return (
-    <GraphQLTypeCard name={ttype.name} kind="enum" description={ttype.description}>
+    <GraphQLTypeCard
+      name={ttype.name}
+      kind="enum"
+      description={ttype.description}
+      supergraphMetadata={ttype.supergraphMetadata}
+    >
       <div className="flex flex-col">
         {ttype.values.map((value, i) => (
           <GraphQLTypeCardListItem index={i}>
             <div>{value.name}</div>
             <SchemaExplorerUsageStats totalRequests={props.totalRequests} usage={value.usage} />
+            {value.supergraphMetadata ? (
+              <SupergraphMetadataTooltip supergraphMetadata={value.supergraphMetadata} />
+            ) : null}
           </GraphQLTypeCardListItem>
         ))}
       </div>

--- a/packages/web/app/src/components/target/explorer/input-object-type.tsx
+++ b/packages/web/app/src/components/target/explorer/input-object-type.tsx
@@ -11,6 +11,9 @@ export const GraphQLInputObjectTypeComponent_TypeFragment = graphql(`
     fields {
       ...GraphQLInputFields_InputFieldFragment
     }
+    supergraphMetadata {
+      ...GraphQLTypeCard_SupergraphMetadataFragment
+    }
   }
 `);
 
@@ -26,6 +29,7 @@ export function GraphQLInputObjectTypeComponent(props: {
       description={ttype.description}
       totalRequests={props.totalRequests}
       usage={ttype.usage}
+      supergraphMetadata={ttype.supergraphMetadata}
     >
       <GraphQLInputFields fields={ttype.fields} totalRequests={props.totalRequests} />
     </GraphQLTypeCard>

--- a/packages/web/app/src/components/target/explorer/interface-type.tsx
+++ b/packages/web/app/src/components/target/explorer/interface-type.tsx
@@ -12,6 +12,9 @@ export const GraphQLInterfaceTypeComponent_TypeFragment = graphql(`
     fields {
       ...GraphQLFields_FieldFragment
     }
+    supergraphMetadata {
+      ...GraphQLTypeCard_SupergraphMetadataFragment
+    }
   }
 `);
 
@@ -26,6 +29,7 @@ export function GraphQLInterfaceTypeComponent(props: {
       name={ttype.name}
       description={ttype.description}
       implements={ttype.interfaces}
+      supergraphMetadata={ttype.supergraphMetadata}
     >
       <GraphQLFields fields={ttype.fields} totalRequests={props.totalRequests} />
     </GraphQLTypeCard>

--- a/packages/web/app/src/components/target/explorer/object-type.tsx
+++ b/packages/web/app/src/components/target/explorer/object-type.tsx
@@ -12,6 +12,9 @@ export const GraphQLObjectTypeComponent_TypeFragment = graphql(`
     fields {
       ...GraphQLFields_FieldFragment
     }
+    supergraphMetadata {
+      ...GraphQLTypeCard_SupergraphMetadataFragment
+    }
   }
 `);
 
@@ -27,6 +30,7 @@ export function GraphQLObjectTypeComponent(props: {
       name={ttype.name}
       description={ttype.description}
       implements={ttype.interfaces}
+      supergraphMetadata={ttype.supergraphMetadata}
     >
       <GraphQLFields
         fields={ttype.fields}

--- a/packages/web/app/src/components/target/explorer/scalar-type.tsx
+++ b/packages/web/app/src/components/target/explorer/scalar-type.tsx
@@ -9,6 +9,9 @@ export const GraphQLScalarTypeComponent_TypeFragment = graphql(`
     usage {
       ...SchemaExplorerUsageStats_UsageFragment
     }
+    supergraphMetadata {
+      ...GraphQLTypeCard_SupergraphMetadataFragment
+    }
   }
 `);
 
@@ -18,7 +21,7 @@ export function GraphQLScalarTypeComponent(props: {
 }) {
   const ttype = useFragment(GraphQLScalarTypeComponent_TypeFragment, props.type);
   return (
-    <GraphQLTypeCard name={ttype.name} kind="scalar">
+    <GraphQLTypeCard name={ttype.name} kind="scalar" supergraphMetadata={ttype.supergraphMetadata}>
       <div className="flex flex-row gap-4 p-4">
         <div className="grow text-sm">
           {typeof ttype.description === 'string' ? <Markdown content={ttype.description} /> : null}

--- a/packages/web/app/src/components/target/explorer/super-graph-metadata.tsx
+++ b/packages/web/app/src/components/target/explorer/super-graph-metadata.tsx
@@ -1,0 +1,60 @@
+import Link from 'next/link';
+import { Tooltip } from '@/components/v2';
+import { PackageIcon } from '@/components/v2/icon';
+import { FragmentType, graphql, useFragment } from '@/gql';
+import { useRouteSelector } from '@/lib/hooks';
+
+function stringToHslColor(str: string, s = 30, l = 80) {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash);
+  }
+
+  const h = hash % 360;
+  return 'hsl(' + h + ', ' + s + '%, ' + l + '%)';
+}
+
+function SubgraphChip(props: { text: string }): React.ReactElement {
+  const router = useRouteSelector();
+
+  return (
+    <Tooltip
+      content={
+        <>
+          <span className="font-bold">{props.text}</span> subgraph
+        </>
+      }
+    >
+      <Link
+        href={`/${router.organizationId}/${router.projectId}/${router.targetId}#${props.text}`}
+        style={{ backgroundColor: stringToHslColor(props.text) }}
+        className="my-[2px] ml-[6px] h-[24px] cursor-pointer items-center justify-between rounded-[16px] pl-[6px] pr-[8px] py-0 text-[12px] font-normal normal-case leading-loose text-[#4f4f4f] inline-block"
+      >
+        <PackageIcon size={12} className="inline-block mr-1" />
+        {props.text}
+      </Link>
+    </Tooltip>
+  );
+}
+
+const SupergraphMetadataList_SupergraphMetadataFragment = graphql(`
+  fragment SupergraphMetadataList_SupergraphMetadataFragment on SupergraphMetadata {
+    ownedByServiceNames
+  }
+`);
+
+export function SupergraphMetadataList(props: {
+  supergraphMetadata: FragmentType<typeof SupergraphMetadataList_SupergraphMetadataFragment>;
+}) {
+  const supergraphMetadata = useFragment(
+    SupergraphMetadataList_SupergraphMetadataFragment,
+    props.supergraphMetadata,
+  );
+  return supergraphMetadata.ownedByServiceNames ? (
+    <div className="w-full flex justify-end">
+      {supergraphMetadata.ownedByServiceNames.map(serviceName => (
+        <SubgraphChip key={serviceName} text={serviceName} />
+      ))}
+    </div>
+  ) : null;
+}

--- a/packages/web/app/src/components/target/explorer/union-type.tsx
+++ b/packages/web/app/src/components/target/explorer/union-type.tsx
@@ -1,5 +1,10 @@
 import { FragmentType, graphql, useFragment } from '@/gql';
-import { GraphQLTypeCard, GraphQLTypeCardListItem, SchemaExplorerUsageStats } from './common';
+import {
+  GraphQLTypeCard,
+  GraphQLTypeCardListItem,
+  SchemaExplorerUsageStats,
+  SupergraphMetadataTooltip,
+} from './common';
 
 export const GraphQLUnionTypeComponent_TypeFragment = graphql(`
   fragment GraphQLUnionTypeComponent_TypeFragment on GraphQLUnionType {
@@ -13,6 +18,12 @@ export const GraphQLUnionTypeComponent_TypeFragment = graphql(`
       usage {
         ...SchemaExplorerUsageStats_UsageFragment
       }
+      supergraphMetadata {
+        ...GraphQLTypeCard_SupergraphMetadataFragment
+      }
+    }
+    supergraphMetadata {
+      ...GraphQLTypeCard_SupergraphMetadataFragment
     }
   }
 `);
@@ -23,12 +34,20 @@ export function GraphQLUnionTypeComponent(props: {
 }) {
   const ttype = useFragment(GraphQLUnionTypeComponent_TypeFragment, props.type);
   return (
-    <GraphQLTypeCard name={ttype.name} kind="union" description={ttype.description}>
+    <GraphQLTypeCard
+      name={ttype.name}
+      kind="union"
+      description={ttype.description}
+      supergraphMetadata={ttype.supergraphMetadata}
+    >
       <div className="flex flex-col">
         {ttype.members.map((member, i) => (
           <GraphQLTypeCardListItem index={i}>
             <div>{member.name}</div>
             <SchemaExplorerUsageStats totalRequests={props.totalRequests} usage={member.usage} />
+            {member.supergraphMetadata ? (
+              <SupergraphMetadataTooltip supergraphMetadata={member.supergraphMetadata} />
+            ) : null}
           </GraphQLTypeCardListItem>
         ))}
       </div>

--- a/packages/web/app/src/components/target/explorer/union-type.tsx
+++ b/packages/web/app/src/components/target/explorer/union-type.tsx
@@ -1,10 +1,6 @@
 import { FragmentType, graphql, useFragment } from '@/gql';
-import {
-  GraphQLTypeCard,
-  GraphQLTypeCardListItem,
-  SchemaExplorerUsageStats,
-  SupergraphMetadataTooltip,
-} from './common';
+import { GraphQLTypeCard, GraphQLTypeCardListItem, SchemaExplorerUsageStats } from './common';
+import { SupergraphMetadataList } from './super-graph-metadata';
 
 export const GraphQLUnionTypeComponent_TypeFragment = graphql(`
   fragment GraphQLUnionTypeComponent_TypeFragment on GraphQLUnionType {
@@ -19,11 +15,12 @@ export const GraphQLUnionTypeComponent_TypeFragment = graphql(`
         ...SchemaExplorerUsageStats_UsageFragment
       }
       supergraphMetadata {
-        ...GraphQLTypeCard_SupergraphMetadataFragment
+        ...SupergraphMetadataList_SupergraphMetadataFragment
       }
     }
     supergraphMetadata {
       ...GraphQLTypeCard_SupergraphMetadataFragment
+      ...SupergraphMetadataList_SupergraphMetadataFragment
     }
   }
 `);
@@ -46,7 +43,7 @@ export function GraphQLUnionTypeComponent(props: {
             <div>{member.name}</div>
             <SchemaExplorerUsageStats totalRequests={props.totalRequests} usage={member.usage} />
             {member.supergraphMetadata ? (
-              <SupergraphMetadataTooltip supergraphMetadata={member.supergraphMetadata} />
+              <SupergraphMetadataList supergraphMetadata={member.supergraphMetadata} />
             ) : null}
           </GraphQLTypeCardListItem>
         ))}

--- a/packages/web/app/src/components/v2/icon.tsx
+++ b/packages/web/app/src/components/v2/icon.tsx
@@ -529,3 +529,25 @@ export const DiffIcon = ({ className }: IconProps): ReactElement => (
     />
   </svg>
 );
+
+export const ServerIcon = (
+  props: IconProps & {
+    size?: number;
+  },
+): ReactElement => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={props.size ?? 16}
+    height={props.size ?? 16}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    strokeWidth={2}
+  >
+    <rect width={20} height={8} x={2} y={2} rx={2} ry={2} />
+    <rect width={20} height={8} x={2} y={14} rx={2} ry={2} />
+    <path d="M6 6h.01M6 18h.01" />
+  </svg>
+);

--- a/packages/web/app/src/components/v2/icon.tsx
+++ b/packages/web/app/src/components/v2/icon.tsx
@@ -43,14 +43,14 @@ export const TrendingUpIcon = ({ className }: IconProps): ReactElement => (
   </svg>
 );
 
-export const PlusIcon = ({ className }: IconProps): ReactElement => (
+export const PlusIcon = (props: IconProps & { size: number }): ReactElement => (
   <svg
     viewBox="0 0 24 24"
-    width="24"
-    height="24"
+    width={props.size ?? 24}
+    height={props.size ?? 24}
     stroke="currentColor"
     xmlns="http://www.w3.org/2000/svg"
-    className={className}
+    className={props.className}
   >
     <path d="M12 5V19" {...DEFAULT_PATH_PROPS} />
     <path d="M5 12H19" {...DEFAULT_PATH_PROPS} />

--- a/packages/web/app/src/components/v2/icon.tsx
+++ b/packages/web/app/src/components/v2/icon.tsx
@@ -530,7 +530,7 @@ export const DiffIcon = ({ className }: IconProps): ReactElement => (
   </svg>
 );
 
-export const ServerIcon = (
+export const PackageIcon = (
   props: IconProps & {
     size?: number;
   },
@@ -545,9 +545,9 @@ export const ServerIcon = (
     strokeLinecap="round"
     strokeLinejoin="round"
     strokeWidth={2}
+    className={props.className}
   >
-    <rect width={20} height={8} x={2} y={2} rx={2} ry={2} />
-    <rect width={20} height={8} x={2} y={14} rx={2} ry={2} />
-    <path d="M6 6h.01M6 18h.01" />
+    <path d="m16.5 9.4-9-5.19M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" />
+    <path d="M3.27 6.96 12 12.01l8.73-5.05M12 22.08V12" />
   </svg>
 );

--- a/packages/web/app/src/components/v2/icon.tsx
+++ b/packages/web/app/src/components/v2/icon.tsx
@@ -43,7 +43,7 @@ export const TrendingUpIcon = ({ className }: IconProps): ReactElement => (
   </svg>
 );
 
-export const PlusIcon = (props: IconProps & { size: number }): ReactElement => (
+export const PlusIcon = (props: IconProps & { size?: number }): ReactElement => (
   <svg
     viewBox="0 0 24 24"
     width={props.size ?? 24}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -786,8 +786,8 @@ importers:
   packages/services/external-composition/federation-2:
     dependencies:
       '@apollo/composition':
-        specifier: ^2.2.2
-        version: 2.2.2(graphql@16.6.0)
+        specifier: ^2.4.5
+        version: 2.4.5(graphql@16.6.0)
       '@whatwg-node/fetch':
         specifier: ^0.9.0
         version: 0.9.0
@@ -1779,6 +1779,12 @@ importers:
         specifier: 3.3.2
         version: 3.3.2
 
+  scripts:
+    devDependencies:
+      '@graphql-hive/client':
+        specifier: '*'
+        version: link:../packages/libraries/client
+
 packages:
 
   /@algolia/autocomplete-core@1.9.2(algoliasearch@4.17.0)(search-insights@2.6.0):
@@ -1977,17 +1983,6 @@ packages:
     dependencies:
       graphql: 16.6.0
 
-  /@apollo/composition@2.2.2(graphql@16.6.0):
-    resolution: {integrity: sha512-5wj9FqDu4E4xfOOLz4SKib8eJQgamHCgOdxwmrGj9N3B8o6P2A+zMfKEVHvEnSpRMKRm9HVcdSGdYV6QcjDIdQ==}
-    engines: {node: '>=14.15.0'}
-    peerDependencies:
-      graphql: ^16.5.0
-    dependencies:
-      '@apollo/federation-internals': 2.2.2(graphql@16.6.0)
-      '@apollo/query-graphs': 2.2.2(graphql@16.6.0)
-      graphql: 16.6.0
-    dev: false
-
   /@apollo/composition@2.4.3(graphql@16.6.0):
     resolution: {integrity: sha512-C0829vugQ+jB+xg1ttrq0fpuHyL78Ap5USiV66k8XjqB0/NxNJiBHARiLGyHa+/Mgl1mFs5hZpIwva4sUuSGpQ==}
     engines: {node: '>=14.15.0'}
@@ -1999,15 +1994,15 @@ packages:
       graphql: 16.6.0
     dev: false
 
-  /@apollo/federation-internals@2.2.2(graphql@16.6.0):
-    resolution: {integrity: sha512-Q16I75qZ6jA8lCoZedM5938oZONrJyL7Pk6TOqw44fndea0As0pb2Ug8dV3pAWq4HhJ+/vBu2WoP14CFcxA9Yw==}
+  /@apollo/composition@2.4.5(graphql@16.6.0):
+    resolution: {integrity: sha512-n7w8gk678CEXjMVa/tXUuuD25Nt+v19AHQ1BCUqVBeaLfH3PzTQPNkRBjXpiX0IZJA7zttwyWw8JeYak11giIQ==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
       graphql: ^16.5.0
     dependencies:
-      chalk: 4.1.2
+      '@apollo/federation-internals': 2.4.5(graphql@16.6.0)
+      '@apollo/query-graphs': 2.4.5(graphql@16.6.0)
       graphql: 16.6.0
-      js-levenshtein: 1.1.6
     dev: false
 
   /@apollo/federation-internals@2.4.3:
@@ -2024,6 +2019,19 @@ packages:
 
   /@apollo/federation-internals@2.4.3(graphql@16.6.0):
     resolution: {integrity: sha512-GPkYC4PRcJNkxGr6cuj4k27l/Tzb7TYJVTfrtMKZ+emiXH9/YY1ph10H7fwqzQTuimri9fRGAEU5XX0IPk99QA==}
+    engines: {node: '>=14.15.0'}
+    peerDependencies:
+      graphql: ^16.5.0
+    dependencies:
+      '@types/uuid': 9.0.1
+      chalk: 4.1.2
+      graphql: 16.6.0
+      js-levenshtein: 1.1.6
+      uuid: 9.0.0
+    dev: false
+
+  /@apollo/federation-internals@2.4.5(graphql@16.6.0):
+    resolution: {integrity: sha512-yXZJ5gOArKFQ6Eyon5o8sbxw+sM/Wznl5ECptf/gkCKS51+AhrVjJu41frWhcKdoeufy835v5XVjeXRx9WO6Ug==}
     engines: {node: '>=14.15.0'}
     peerDependencies:
       graphql: ^16.5.0
@@ -2132,20 +2140,6 @@ packages:
       long: 4.0.0
     dev: false
 
-  /@apollo/query-graphs@2.2.2(graphql@16.6.0):
-    resolution: {integrity: sha512-NHxqfDEsMNFqwxSQ8lqj9APP0jGQAvxt0LOEb4WZgVdw303g1qxu2BapUS4YjxKVRqHDap/EAzBHgwg4J2zfjA==}
-    engines: {node: '>=14.15.0'}
-    peerDependencies:
-      graphql: ^16.5.0
-    dependencies:
-      '@apollo/federation-internals': 2.2.2(graphql@16.6.0)
-      '@types/uuid': 8.3.4
-      deep-equal: 2.1.0
-      graphql: 16.6.0
-      ts-graphviz: 0.16.0
-      uuid: 9.0.0
-    dev: false
-
   /@apollo/query-graphs@2.4.3(graphql@16.6.0):
     resolution: {integrity: sha512-rewBB3KSiZRGK92M21nbpxBFq2Ty+t6KqH9CFrWstpocNAw4P2SMqs9rA3mEQhLYrEyIaWTMwD199/vi/M7QMw==}
     engines: {node: '>=14.15.0'}
@@ -2153,6 +2147,19 @@ packages:
       graphql: ^16.5.0
     dependencies:
       '@apollo/federation-internals': 2.4.3(graphql@16.6.0)
+      deep-equal: 2.1.0
+      graphql: 16.6.0
+      ts-graphviz: 1.5.5
+      uuid: 9.0.0
+    dev: false
+
+  /@apollo/query-graphs@2.4.5(graphql@16.6.0):
+    resolution: {integrity: sha512-6u8MwTSoANsKfw+Fut0P2u9Ngkaw4HQirfiHAuE0cQEUU38ibetWXFUkQ2SEpCfcf5bw71/Mx7g0TDV8figEgQ==}
+    engines: {node: '>=14.15.0'}
+    peerDependencies:
+      graphql: ^16.5.0
+    dependencies:
+      '@apollo/federation-internals': 2.4.5(graphql@16.6.0)
       deep-equal: 2.1.0
       graphql: 16.6.0
       ts-graphviz: 1.5.5
@@ -2479,13 +2486,13 @@ packages:
     peerDependencies:
       graphql: '*'
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.5
       '@babel/generator': 7.21.5
       '@babel/parser': 7.21.8
       '@babel/runtime': 7.21.0
       '@babel/traverse': 7.21.5
       '@babel/types': 7.21.5
-      babel-preset-fbjs: 3.4.0(@babel/core@7.21.4)
+      babel-preset-fbjs: 3.4.0(@babel/core@7.21.5)
       chalk: 4.1.2
       fb-watchman: 2.0.2
       fbjs: 3.0.4
@@ -3505,29 +3512,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dev: true
 
-  /@babel/core@7.21.4:
-    resolution: {integrity: sha512-qt/YV149Jman/6AfmlxJ04LMIu8bMoyl3RB91yTFrxQmgbrSvQMy7cI8Q62FHx1t8wJ8B5fu0UDoLwHAhUo1QA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@ampproject/remapping': 2.2.0
-      '@babel/code-frame': 7.21.4
-      '@babel/generator': 7.21.5
-      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.4)
-      '@babel/helper-module-transforms': 7.21.5
-      '@babel/helpers': 7.21.5
-      '@babel/parser': 7.21.8
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.21.5
-      '@babel/types': 7.21.5
-      convert-source-map: 1.9.0
-      debug: 4.3.4
-      gensync: 1.0.0-beta.2
-      json5: 2.2.3
-      semver: 6.3.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/core@7.21.5:
     resolution: {integrity: sha512-9M398B/QH5DlfCOTKDZT1ozXr0x8uBEeFd+dJraGUZGiaNpGCDVGCc14hZexsMblw3XxltJ+6kSvogp9J+5a9g==}
     engines: {node: '>=6.9.0'}
@@ -3607,20 +3591,6 @@ packages:
       semver: 6.3.0
     dev: true
 
-  /@babel/helper-compilation-targets@7.21.5(@babel/core@7.21.4):
-    resolution: {integrity: sha512-1RkbFGUKex4lvsB9yhIfWltJM5cZKUftB2eNajaDv3dCMEp49iBG0K14uH8NnX9IPux2+mK7JGEOB0jn48/J6w==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/compat-data': 7.21.7
-      '@babel/core': 7.21.4
-      '@babel/helper-validator-option': 7.21.0
-      browserslist: 4.21.5
-      lru-cache: 5.1.1
-      semver: 6.3.0
-    dev: true
-
   /@babel/helper-compilation-targets@7.21.5(@babel/core@7.21.5):
     resolution: {integrity: sha512-1RkbFGUKex4lvsB9yhIfWltJM5cZKUftB2eNajaDv3dCMEp49iBG0K14uH8NnX9IPux2+mK7JGEOB0jn48/J6w==}
     engines: {node: '>=6.9.0'}
@@ -3641,25 +3611,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.21.5
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-member-expression-to-functions': 7.21.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/helper-split-export-declaration': 7.18.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/helper-create-class-features-plugin@7.21.0(@babel/core@7.21.4):
-    resolution: {integrity: sha512-Q8wNiMIdwsv5la5SPxNYzzkPnjgC0Sy0i7jLkVOCdllu/xcVNkr3TeZzbHBJrj+XXRqzX5uCyCoV9eu6xUG7KQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.21.4
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.21.5
       '@babel/helper-function-name': 7.21.0
@@ -3914,13 +3865,6 @@ packages:
       chalk: 2.4.2
       js-tokens: 4.0.0
 
-  /@babel/parser@7.21.4:
-    resolution: {integrity: sha512-alVJj7k7zIxqBZ7BTRhz0IqJFxW1VJbm6N8JbcYhQ186df9ZBPbZBmWSqAMXwHGsCJdYks7z/voa3ibiS5bCIw==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.21.5
-
   /@babel/parser@7.21.8:
     resolution: {integrity: sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==}
     engines: {node: '>=6.0.0'}
@@ -4006,19 +3950,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/helper-create-class-features-plugin': 7.21.0
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.21.4):
-    resolution: {integrity: sha512-cumfXOF0+nzZrrN8Rf0t7M+tF6sZc7vhQwYQck9q1/5w2OExlD+b4v4RpMJFaV1Z7WcDRgO6FqvxqxGlwo+RHQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-create-class-features-plugin': 7.21.0(@babel/core@7.21.4)
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
@@ -4203,20 +4134,6 @@ packages:
       '@babel/plugin-transform-parameters': 7.21.3
     dev: true
 
-  /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.21.4):
-    resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/compat-data': 7.21.7
-      '@babel/core': 7.21.4
-      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.4)
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.21.4)
-      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.21.4)
-    dev: true
-
   /@babel/plugin-proposal-object-rest-spread@7.20.7(@babel/core@7.21.5):
     resolution: {integrity: sha512-d2S98yCiLxDVmBmE8UjGcfPvNEUbA1U5q5WxaWFUGRzJSVAZqm5W6MbPct0jxnegUZ0niLeNX+IOzEs7wYg9Dg==}
     engines: {node: '>=6.9.0'}
@@ -4383,15 +4300,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.21.4):
-    resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
   /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.21.5):
     resolution: {integrity: sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==}
     peerDependencies:
@@ -4463,16 +4371,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-syntax-flow@7.18.6(@babel/core@7.21.4):
-    resolution: {integrity: sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
   /@babel/plugin-syntax-flow@7.18.6(@babel/core@7.21.5):
     resolution: {integrity: sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==}
     engines: {node: '>=6.9.0'}
@@ -4525,16 +4423,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/helper-plugin-utils': 7.20.2
-
-  /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.21.4):
-    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
 
   /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.21.5):
     resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
@@ -4602,15 +4490,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.21.4):
-    resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -4723,16 +4602,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-arrow-functions@7.20.7(@babel/core@7.21.4):
-    resolution: {integrity: sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
   /@babel/plugin-transform-arrow-functions@7.20.7(@babel/core@7.21.5):
     resolution: {integrity: sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==}
     engines: {node: '>=6.9.0'}
@@ -4779,16 +4648,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.21.4):
-    resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
   /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.21.5):
     resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
     engines: {node: '>=6.9.0'}
@@ -4805,16 +4664,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-block-scoping@7.21.0(@babel/core@7.21.4):
-    resolution: {integrity: sha512-Mdrbunoh9SxwFZapeHVrwFmri16+oYotcZysSzhNIVDwIAb1UV+kvnxULSYq9J3/q5MDG+4X6w8QVgD1zhBXNQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -4836,26 +4685,6 @@ packages:
     dependencies:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-compilation-targets': 7.21.5
-      '@babel/helper-environment-visitor': 7.21.5
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-split-export-declaration': 7.18.6
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-classes@7.21.0(@babel/core@7.21.4):
-    resolution: {integrity: sha512-RZhbYTCEUAe6ntPehC4hlslPWosNHDox+vAs4On/mCLRLfoDVHf6hVEd7kuxr1RnHwJmxFfUM3cZiZRmPxJPXQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.4)
       '@babel/helper-environment-visitor': 7.21.5
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-optimise-call-expression': 7.18.6
@@ -4897,17 +4726,6 @@ packages:
       '@babel/template': 7.20.7
     dev: true
 
-  /@babel/plugin-transform-computed-properties@7.20.7(@babel/core@7.21.4):
-    resolution: {integrity: sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/template': 7.20.7
-    dev: true
-
   /@babel/plugin-transform-computed-properties@7.20.7(@babel/core@7.21.5):
     resolution: {integrity: sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==}
     engines: {node: '>=6.9.0'}
@@ -4925,16 +4743,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-destructuring@7.21.3(@babel/core@7.21.4):
-    resolution: {integrity: sha512-bp6hwMFzuiE4HqYEyoGJ/V2LeIWn+hLVKc4pnj++E5XQptwhtcGmSayM029d/j2X1bPKGTlsyPwAubuU22KhMA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -5019,17 +4827,6 @@ packages:
       '@babel/plugin-syntax-flow': 7.18.6
     dev: true
 
-  /@babel/plugin-transform-flow-strip-types@7.19.0(@babel/core@7.21.4):
-    resolution: {integrity: sha512-sgeMlNaQVbCSpgLSKP4ZZKfsJVnFnNQlUSk6gPYzR/q7tzCgQF2t8RBKAP6cKJeZdveei7Q7Jm527xepI8lNLg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.21.4)
-    dev: true
-
   /@babel/plugin-transform-flow-strip-types@7.19.0(@babel/core@7.21.5):
     resolution: {integrity: sha512-sgeMlNaQVbCSpgLSKP4ZZKfsJVnFnNQlUSk6gPYzR/q7tzCgQF2t8RBKAP6cKJeZdveei7Q7Jm527xepI8lNLg==}
     engines: {node: '>=6.9.0'}
@@ -5050,16 +4847,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-for-of@7.21.0(@babel/core@7.21.4):
-    resolution: {integrity: sha512-LlUYlydgDkKpIY7mcBWvyPPmMcOphEyYA27Ef4xpbh1IiDNLr0kZsos2nf92vz3IccvJI25QUwp86Eo5s6HmBQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
   /@babel/plugin-transform-for-of@7.21.0(@babel/core@7.21.5):
     resolution: {integrity: sha512-LlUYlydgDkKpIY7mcBWvyPPmMcOphEyYA27Ef4xpbh1IiDNLr0kZsos2nf92vz3IccvJI25QUwp86Eo5s6HmBQ==}
     engines: {node: '>=6.9.0'}
@@ -5077,18 +4864,6 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/helper-compilation-targets': 7.21.5
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.21.4):
-    resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-compilation-targets': 7.21.5(@babel/core@7.21.4)
       '@babel/helper-function-name': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
@@ -5114,16 +4889,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-literals@7.18.9(@babel/core@7.21.4):
-    resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
   /@babel/plugin-transform-literals@7.18.9(@babel/core@7.21.5):
     resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
     engines: {node: '>=6.9.0'}
@@ -5140,16 +4905,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.21.4):
-    resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -5194,20 +4949,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/helper-module-transforms': 7.21.5
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-simple-access': 7.21.5
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
-  /@babel/plugin-transform-modules-commonjs@7.21.2(@babel/core@7.21.4):
-    resolution: {integrity: sha512-Cln+Yy04Gxua7iPdj6nOV96smLGjpElir5YwzF0LBPKoPlLDNJePNlrGGaybAJkd0zKRnOVXOgizSqPYMNYkzA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
       '@babel/helper-module-transforms': 7.21.5
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-simple-access': 7.21.5
@@ -5335,19 +5076,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.21.4):
-    resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-replace-supers': 7.20.7
-    transitivePeerDependencies:
-      - supports-color
-    dev: true
-
   /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.21.5):
     resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
     engines: {node: '>=6.9.0'}
@@ -5370,16 +5098,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-parameters@7.21.3(@babel/core@7.21.4):
-    resolution: {integrity: sha512-Wxc+TvppQG9xWFYatvCGPvZ6+SIUxQ2ZdiBP+PHYMIjnPXD+uThCshaz4NZOnODAtBjjcVQQ/3OKs9LW28purQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
   /@babel/plugin-transform-parameters@7.21.3(@babel/core@7.21.5):
     resolution: {integrity: sha512-Wxc+TvppQG9xWFYatvCGPvZ6+SIUxQ2ZdiBP+PHYMIjnPXD+uThCshaz4NZOnODAtBjjcVQQ/3OKs9LW28purQ==}
     engines: {node: '>=6.9.0'}
@@ -5396,16 +5114,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.21.4):
-    resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -5428,13 +5136,13 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-react-display-name@7.18.6(@babel/core@7.21.4):
+  /@babel/plugin-transform-react-display-name@7.18.6(@babel/core@7.21.5):
     resolution: {integrity: sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/core': 7.21.4
+      '@babel/core': 7.21.5
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -5457,20 +5165,6 @@ packages:
       '@babel/helper-module-imports': 7.21.4
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-jsx': 7.18.6
-      '@babel/types': 7.21.5
-    dev: true
-
-  /@babel/plugin-transform-react-jsx@7.19.0(@babel/core@7.21.4):
-    resolution: {integrity: sha512-UVEvX3tXie3Szm3emi1+G63jyw1w5IcMY0FSKM+CRnKRI5Mr1YbCNgsSTwoTwKphQEG9P+QqmuRFneJPZuHNhg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-module-imports': 7.21.4
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.21.4)
       '@babel/types': 7.21.5
     dev: true
 
@@ -5563,16 +5257,6 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
-  /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.21.4):
-    resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
   /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.21.5):
     resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
     engines: {node: '>=6.9.0'}
@@ -5589,17 +5273,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-    dev: true
-
-  /@babel/plugin-transform-spread@7.20.7(@babel/core@7.21.4):
-    resolution: {integrity: sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
     dev: true
@@ -5640,16 +5313,6 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/helper-plugin-utils': 7.20.2
-    dev: true
-
-  /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.21.4):
-    resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.21.4
       '@babel/helper-plugin-utils': 7.20.2
     dev: true
 
@@ -6065,24 +5728,6 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/traverse@7.21.4:
-    resolution: {integrity: sha512-eyKrRHKdyZxqDm+fV1iqL9UAHMoIg0nDaGqfIOd8rKH17m5snv7Gn4qgjBoFfLz9APvjFU/ICT00NVCv1Epp8Q==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.21.4
-      '@babel/generator': 7.21.5
-      '@babel/helper-environment-visitor': 7.21.5
-      '@babel/helper-function-name': 7.21.0
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.21.8
-      '@babel/types': 7.21.5
-      debug: 4.3.4
-      globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@babel/traverse@7.21.5:
     resolution: {integrity: sha512-AhQoI3YjWi6u/y/ntv7k48mcrCXmus0t79J9qPNlk/lAsFlCiJ047RmbfMOawySTHtywXhbXgpx/8nXMYd+oFw==}
     engines: {node: '>=6.9.0'}
@@ -6115,6 +5760,7 @@ packages:
       '@babel/helper-string-parser': 7.21.5
       '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
+    dev: true
 
   /@babel/types@7.21.5:
     resolution: {integrity: sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==}
@@ -7961,8 +7607,8 @@ packages:
       value-or-promise: 1.0.11
     dev: true
 
-  /@graphql-tools/batch-execute@8.5.18:
-    resolution: {integrity: sha512-mNv5bpZMLLwhkmPA6+RP81A6u3KF4CSKLf3VX9hbomOkQR4db8pNs8BOvpZU54wKsUzMzdlws/2g/Dabyb2Vsg==}
+  /@graphql-tools/batch-execute@8.5.22:
+    resolution: {integrity: sha512-hcV1JaY6NJQFQEwCKrYhpfLK8frSXDbtNMoTur98u10Cmecy1zrqNKSqhEyGetpgHxaJRqszGzKeI3RuroDN6A==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
@@ -8080,7 +7726,7 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/batch-execute': 8.5.18
+      '@graphql-tools/batch-execute': 8.5.22
       '@graphql-tools/executor': 0.0.15
       '@graphql-tools/schema': 9.0.19
       '@graphql-tools/utils': 9.2.1
@@ -8482,10 +8128,10 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@babel/parser': 7.21.4
+      '@babel/parser': 7.21.8
       '@babel/plugin-syntax-import-assertions': 7.20.0
-      '@babel/traverse': 7.21.4
-      '@babel/types': 7.21.4
+      '@babel/traverse': 7.21.5
+      '@babel/types': 7.21.5
       '@graphql-tools/utils': 9.2.1(graphql@16.6.0)
       graphql: 16.6.0
       tslib: 2.5.2
@@ -13584,7 +13230,7 @@ packages:
         optional: true
     dependencies:
       '@babel/generator': 7.17.7
-      '@babel/parser': 7.21.4
+      '@babel/parser': 7.21.8
       '@babel/traverse': 7.17.3
       '@babel/types': 7.17.0
       javascript-natural-sort: 0.7.1
@@ -14179,10 +13825,6 @@ packages:
 
   /@types/unist@2.0.6:
     resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
-
-  /@types/uuid@8.3.4:
-    resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==}
-    dev: false
 
   /@types/uuid@9.0.1:
     resolution: {integrity: sha512-rFT3ak0/2trgvp4yYZo5iKFEPsET7vKydKF+VRCxlQ9bpheehyAJH89dAkaLEq/j/RZXJIqcgsmPJKUP1Z28HA==}
@@ -15462,38 +15104,38 @@ packages:
     resolution: {integrity: sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==}
     dev: true
 
-  /babel-preset-fbjs@3.4.0(@babel/core@7.21.4):
+  /babel-preset-fbjs@3.4.0(@babel/core@7.21.5):
     resolution: {integrity: sha512-9ywCsCvo1ojrw0b+XYk7aFvTH6D9064t0RIL1rtMf3nsa02Xw41MS7sZw216Im35xj/UY0PDBQsa1brUDDF1Ow==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.21.4
-      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.21.4)
-      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.21.4)
-      '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.21.4)
-      '@babel/plugin-transform-arrow-functions': 7.20.7(@babel/core@7.21.4)
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.21.4)
-      '@babel/plugin-transform-classes': 7.21.0(@babel/core@7.21.4)
-      '@babel/plugin-transform-computed-properties': 7.20.7(@babel/core@7.21.4)
-      '@babel/plugin-transform-destructuring': 7.21.3(@babel/core@7.21.4)
-      '@babel/plugin-transform-flow-strip-types': 7.19.0(@babel/core@7.21.4)
-      '@babel/plugin-transform-for-of': 7.21.0(@babel/core@7.21.4)
-      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.21.4)
-      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.21.4)
-      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-transform-modules-commonjs': 7.21.2(@babel/core@7.21.4)
-      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.21.4)
-      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-transform-react-display-name': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-transform-react-jsx': 7.19.0(@babel/core@7.21.4)
-      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.21.4)
-      '@babel/plugin-transform-spread': 7.20.7(@babel/core@7.21.4)
-      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.21.4)
+      '@babel/core': 7.21.5
+      '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.21.5)
+      '@babel/plugin-proposal-object-rest-spread': 7.20.7(@babel/core@7.21.5)
+      '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.21.5)
+      '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.21.5)
+      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.21.5)
+      '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.21.5)
+      '@babel/plugin-transform-arrow-functions': 7.20.7(@babel/core@7.21.5)
+      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.21.5)
+      '@babel/plugin-transform-block-scoping': 7.21.0(@babel/core@7.21.5)
+      '@babel/plugin-transform-classes': 7.21.0(@babel/core@7.21.5)
+      '@babel/plugin-transform-computed-properties': 7.20.7(@babel/core@7.21.5)
+      '@babel/plugin-transform-destructuring': 7.21.3(@babel/core@7.21.5)
+      '@babel/plugin-transform-flow-strip-types': 7.19.0(@babel/core@7.21.5)
+      '@babel/plugin-transform-for-of': 7.21.0(@babel/core@7.21.5)
+      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.21.5)
+      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.21.5)
+      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.21.5)
+      '@babel/plugin-transform-modules-commonjs': 7.21.2(@babel/core@7.21.5)
+      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.21.5)
+      '@babel/plugin-transform-parameters': 7.21.3(@babel/core@7.21.5)
+      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.21.5)
+      '@babel/plugin-transform-react-display-name': 7.18.6(@babel/core@7.21.5)
+      '@babel/plugin-transform-react-jsx': 7.19.0(@babel/core@7.21.5)
+      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.21.5)
+      '@babel/plugin-transform-spread': 7.20.7(@babel/core@7.21.5)
+      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.21.5)
       babel-plugin-syntax-trailing-function-commas: 7.0.0-beta.0
     transitivePeerDependencies:
       - supports-color
@@ -28855,10 +28497,6 @@ packages:
   /ts-dedent@2.2.0:
     resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
     engines: {node: '>=6.10'}
-
-  /ts-graphviz@0.16.0:
-    resolution: {integrity: sha512-3fTPO+G6bSQNvMh/XQQzyiahVLMMj9kqYO99ivUraNJ3Wp05HZOOVtRhi6w9hq7+laP1MKHjLBtGWqTeb1fcpg==}
-    dev: false
 
   /ts-graphviz@1.5.5:
     resolution: {integrity: sha512-abon0Tlcgvxcqr8x+p8QH1fTbR2R4cEXKGZfT4OJONZWah2YfqkmERb6hrr82omAc1IHwk5PlF8g4BS/ECYvwQ==}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ packages:
   - packages/libraries/*
   - integration-tests
   - deployment
+  - scripts

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@hive/scripts",
+  "type": "module",
+  "devDependencies": {
+    "@graphql-hive/client": "*"
+  }
+}

--- a/scripts/seed-local-env.ts
+++ b/scripts/seed-local-env.ts
@@ -311,7 +311,10 @@ async function federation() {
       email: ID! @tag(name: "test-from-users")
       name: String
       totalProductsCreated: Int
+      createdAt: DateTime
     }
+
+    scalar DateTime
   `;
 
   let res = await fetch(reportingEndpoint, {


### PR DESCRIPTION
### Background

On the Explorer page, we want to show users from which subgraph a specific schema coordinate (field/type/etc.) originates.
We can extract this data from the annotated supergraph SDL.

https://www.notion.so/theguildoss/Display-the-subgraph-from-which-the-type-is-originated-0734755cb4cf4a7fb298f923da6140ea?pvs=4

### Description

- Refactors the insert/decoding logic for schema versions
- Store supergraph SDL in the schema_versions database table
- Attempt to construct meta information based on the supergraph SDL and expose it via the GraphQL API if available
![image](https://github.com/kamilkisiela/graphql-hive/assets/14338007/ffafb3ad-c351-44fb-8601-308c245e8183)


### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
