### PR TITLE
feat: make sure unexpected serialization errors are reported

### DIFF
--- a/packages/services/server/package.json
+++ b/packages/services/server/package.json
@@ -19,6 +19,7 @@
     "@escape.tech/graphql-armor-max-depth": "1.8.4",
     "@escape.tech/graphql-armor-max-directives": "1.6.5",
     "@escape.tech/graphql-armor-max-tokens": "1.3.2",
+    "@graphql-tools/utils": "^10.0.0",
     "@sentry/integrations": "7.52.1",
     "@sentry/node": "7.52.1",
     "@trpc/server": "10.27.1",

--- a/packages/services/server/src/graphql-handler.ts
+++ b/packages/services/server/src/graphql-handler.ts
@@ -21,6 +21,7 @@ import { asyncStorage } from './async-storage';
 import type { HiveConfig } from './environment';
 import { useArmor } from './use-armor';
 import { extractUserId, useSentryUser } from './use-sentry-user';
+import { useUnexpectedSerializationError } from './use-unexpected-serialization-error';
 
 const reqIdGenerate = hyperid({ fixedLength: true });
 
@@ -93,6 +94,7 @@ export const graphqlHandler = (options: GraphQLHandlerOptions): RouteHandlerMeth
   const server = createYoga<Context>({
     logging: options.logger,
     plugins: [
+      useUnexpectedSerializationError(),
       useArmor(),
       useSentry({
         startTransaction: false,

--- a/packages/services/server/src/use-unexpected-serialization-error.ts
+++ b/packages/services/server/src/use-unexpected-serialization-error.ts
@@ -1,6 +1,6 @@
 import { GraphQLScalarType } from 'graphql';
 import { type Plugin } from 'graphql-yoga';
-import { isGraphQLError } from 'graphql-yoga/typings/error';
+import { isGraphQLError } from '@envelop/core';
 import { MapperKind, mapSchema } from '@graphql-tools/utils';
 
 /**

--- a/packages/services/server/src/use-unexpected-serialization-error.ts
+++ b/packages/services/server/src/use-unexpected-serialization-error.ts
@@ -1,0 +1,44 @@
+import { GraphQLScalarType } from 'graphql';
+import { type Plugin } from 'graphql-yoga';
+import { isGraphQLError } from 'graphql-yoga/typings/error';
+import { MapperKind, mapSchema } from '@graphql-tools/utils';
+
+/**
+ * Scalar serialization errors are swallowed by graphql-yoga, because they are GraphQLErrors and not Errors.
+ * We can map them to normal errors in order to report them.
+ *
+ * See https://github.com/n1ru4l/envelop/issues/1808
+ */
+export function useUnexpectedSerializationError(): Plugin<any> {
+  return {
+    onSchemaChange({ schema, replaceSchema }) {
+      if (schema.extensions?.[didApplyTransformSymbol]) {
+        return;
+      }
+
+      const newSchema = mapSchema(schema, {
+        [MapperKind.SCALAR_TYPE](type) {
+          const config = type.toConfig();
+          return new GraphQLScalarType({
+            ...config,
+            serialize(value) {
+              try {
+                return config.serialize(value);
+              } catch (err) {
+                if (isGraphQLError(err)) {
+                  throw new Error(err.message);
+                }
+                throw err;
+              }
+            },
+          });
+        },
+      });
+      // @ts-expect-error GraphQLSchemaExtensions does not yet include symbol in its index signature
+      newSchema.extensions[didApplyTransformSymbol] = true;
+      replaceSchema(schema);
+    },
+  };
+}
+
+const didApplyTransformSymbol = Symbol('didApplyTransform');

--- a/packages/services/server/src/use-unexpected-serialization-error.ts
+++ b/packages/services/server/src/use-unexpected-serialization-error.ts
@@ -36,7 +36,7 @@ export function useUnexpectedSerializationError(): Plugin<any> {
       });
       // @ts-expect-error GraphQLSchemaExtensions does not yet include symbol in its index signature
       newSchema.extensions[didApplyTransformSymbol] = true;
-      replaceSchema(schema);
+      replaceSchema(newSchema);
     },
   };
 }

--- a/packages/services/server/src/use-unexpected-serialization-error.ts
+++ b/packages/services/server/src/use-unexpected-serialization-error.ts
@@ -3,7 +3,7 @@ import { isGraphQLError } from '@envelop/core';
 import { MapperKind, mapSchema } from '@graphql-tools/utils';
 
 /**
- * Scalar serialization errors are swallowed by graphql-yoga, because they are GraphQLErrors and not Errors.
+ * Scalar serialization errors are swallowed by sentry in graphql-yoga, because they are GraphQLErrors and not Errors.
  * We can map them to normal errors in order to report them.
  *
  * See https://github.com/n1ru4l/envelop/issues/1808

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1002,6 +1002,9 @@ importers:
       '@escape.tech/graphql-armor-max-tokens':
         specifier: 1.3.2
         version: 1.3.2
+      '@graphql-tools/utils':
+        specifier: ^10.0.0
+        version: 10.0.0(graphql@16.6.0)
       '@sentry/integrations':
         specifier: 7.52.1
         version: 7.52.1


### PR DESCRIPTION
### Background

See https://github.com/n1ru4l/envelop/issues/1808

### Description

This maps GraphQLErrors raised by scalars `serialize` function/method to normal Errors in order to get them masked and reported via Sentry.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
