### PR TITLE
Changes in rate-limiter to allow no data-loss for Enterprise users

### DIFF
--- a/packages/services/api/src/modules/rate-limit/providers/rate-limit.provider.ts
+++ b/packages/services/api/src/modules/rate-limit/providers/rate-limit.provider.ts
@@ -2,7 +2,6 @@ import { Inject, Injectable, Scope } from 'graphql-modules';
 import type { RateLimitApi, RateLimitApiInput } from '@hive/rate-limit';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
 import { fetch } from '@whatwg-node/fetch';
-import { HiveError } from '../../../shared/errors';
 import { sentry } from '../../../shared/sentry';
 import { Logger } from '../../shared/providers/logger';
 import type { RateLimitServiceConfig } from './tokens';

--- a/packages/services/api/src/modules/rate-limit/providers/rate-limit.provider.ts
+++ b/packages/services/api/src/modules/rate-limit/providers/rate-limit.provider.ts
@@ -34,16 +34,6 @@ export class RateLimitProvider {
       : null;
   }
 
-  async assertRateLimit(input: RateLimitApiInput['checkRateLimit']) {
-    const limit = await this.checkRateLimit(input);
-
-    if (limit.limited) {
-      throw new HiveError(`Monthly limit for ${input.type} has reached!`);
-    }
-
-    return limit;
-  }
-
   @sentry('RateLimitProvider.checkRateLimit')
   async checkRateLimit(input: RateLimitApiInput['checkRateLimit']) {
     if (this.rateLimit === null) {
@@ -53,6 +43,7 @@ export class RateLimitProvider {
       );
 
       return {
+        usagePercenrage: 0,
         limited: false,
       };
     }

--- a/packages/services/api/src/modules/rate-limit/resolvers.ts
+++ b/packages/services/api/src/modules/rate-limit/resolvers.ts
@@ -17,7 +17,7 @@ export const resolvers: RateLimitModule.Resolvers = {
         });
 
         logger.debug('Fetched rate-limit info:', { orgId: org.id, operationsRateLimit });
-        limitedForOperations = operationsRateLimit.limited;
+        limitedForOperations = operationsRateLimit.usagePercenrage >= 1;
       } catch (e) {
         logger.error('Failed to fetch rate-limit info:', org.id, e);
       }

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -439,6 +439,7 @@ export interface Storage {
       organization: string;
       org_name: string;
       org_clean_id: string;
+      org_plan_name: string;
       owner_email: string;
       target: string;
       limit_operations_monthly: number;

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -2431,6 +2431,7 @@ export async function createStorage(connection: string, maximumPoolSize: number)
           organization: string;
           org_name: string;
           org_clean_id: string;
+          org_plan_name: string;
           owner_email: string;
           target: string;
           limit_operations_monthly: number;
@@ -2444,6 +2445,7 @@ export async function createStorage(connection: string, maximumPoolSize: number)
             o.name as org_name,
             o.limit_operations_monthly,
             o.limit_retention_days,
+            o.plan_name as org_plan_name,
             t.id as target,
             u.email as owner_email
           FROM public.targets AS t

--- a/packages/web/app/pages/[orgId]/index.tsx
+++ b/packages/web/app/pages/[orgId]/index.tsx
@@ -190,7 +190,6 @@ function ProjectsPage(): ReactElement {
                   </div>
                 )}
               </div>
-
               <Activities />
             </>
           )

--- a/packages/web/app/pages/[orgId]/view/subscription/index.tsx
+++ b/packages/web/app/pages/[orgId]/view/subscription/index.tsx
@@ -6,7 +6,6 @@ import { OrganizationLayout } from '@/components/layouts';
 import { BillingView } from '@/components/organization/billing/Billing';
 import { CurrencyFormatter } from '@/components/organization/billing/helpers';
 import { InvoicesList } from '@/components/organization/billing/InvoicesList';
-import { RateLimitWarn } from '@/components/organization/billing/RateLimitWarn';
 import { OrganizationUsageEstimationView } from '@/components/organization/Usage';
 import { Card, Heading, Stat, Tabs, Title } from '@/components/v2';
 import { FragmentType, graphql, useFragment } from '@/gql';
@@ -80,8 +79,7 @@ function Page(props: {
         </Tabs.Trigger>
       </Tabs.List>
       <Tabs.Content value="overview">
-        <RateLimitWarn organization={organization} />
-        <Card className="mt-8">
+        <Card>
           <Heading className="mb-2">Your current plan</Heading>
           <div>
             <BillingView organization={organization} query={query}>

--- a/packages/web/app/src/components/layouts/organization.tsx
+++ b/packages/web/app/src/components/layouts/organization.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/lib/access/organization';
 import { getIsStripeEnabled } from '@/lib/billing/stripe-public-key';
 import { useRouteSelector, useToggle } from '@/lib/hooks';
+import { RateLimitWarn } from '../organization/billing/RateLimitWarn';
 
 enum TabValue {
   Overview = 'overview',
@@ -31,6 +32,7 @@ const OrganizationLayout_OrganizationFragment = graphql(`
     me {
       ...CanAccessOrganization_MemberFragment
     }
+    ...RateLimitWarn_OrganizationFragment
   }
 `);
 
@@ -137,7 +139,6 @@ export function OrganizationLayout<
           <CreateProjectModal isOpen={isModalOpen} toggleModalOpen={toggleModalOpen} />
         </div>
       </SubHeader>
-
       <Tabs className="container" value={value}>
         <Tabs.List>
           <Tabs.Trigger value={TabValue.Overview} asChild>
@@ -164,10 +165,13 @@ export function OrganizationLayout<
             </Tabs.Trigger>
           )}
         </Tabs.List>
-        <Tabs.Content value={value} className={className}>
-          {children(organizationQuery.data!, {
-            organization: orgId,
-          })}
+        <Tabs.Content value={value}>
+          <RateLimitWarn organization={organization} />
+          <div className={className}>
+            {children(organizationQuery.data!, {
+              organization: orgId,
+            })}
+          </div>
         </Tabs.Content>
       </Tabs>
     </>

--- a/packages/web/app/src/components/organization/billing/RateLimitWarn.tsx
+++ b/packages/web/app/src/components/organization/billing/RateLimitWarn.tsx
@@ -23,11 +23,10 @@ export function RateLimitWarn(props: {
 
   if (organization.plan === BillingPlanType.Enterprise) {
     return (
-      <Callout type="warning" className="w-full">
+      <Callout type="warning" className="w-full mb-2">
         <b>Your organization has reached it's contract limit.</b>
         <br />
-        The data in your organization <b>{organization.name}</b> is still being processed and no
-        data will be lost.
+        The data under your organization is still being processed and no data will be lost.
         <br />
         Please contact our support team to increase your contract limit.
       </Callout>
@@ -35,11 +34,11 @@ export function RateLimitWarn(props: {
   }
 
   return (
-    <Callout type="warning" className="w-full">
+    <Callout type="warning" className="w-full mb-2">
       <b>Your organization is being rate-limited for operations.</b>
       <br />
       Since you have reached your organization rate-limit and data ingestion limitation, your
-      organization <b>{organization.name}</b> is currently unable to ingest data.
+      organization is currently unable to ingest data.
     </Callout>
   );
 }

--- a/packages/web/app/src/components/organization/billing/RateLimitWarn.tsx
+++ b/packages/web/app/src/components/organization/billing/RateLimitWarn.tsx
@@ -1,10 +1,12 @@
 import { ReactElement } from 'react';
 import { Callout } from '@/components/v2';
 import { FragmentType, graphql, useFragment } from '@/gql';
+import { BillingPlanType } from '@/graphql';
 
 const RateLimitWarn_OrganizationFragment = graphql(`
   fragment RateLimitWarn_OrganizationFragment on Organization {
     name
+    plan
     rateLimit {
       limitedForOperations
     }
@@ -19,11 +21,24 @@ export function RateLimitWarn(props: {
     return null;
   }
 
+  if (organization.plan === BillingPlanType.Enterprise) {
+    return (
+      <Callout type="warning" className="w-full">
+        <b>Your organization has reached it's contract limit.</b>
+        <br />
+        The data in your organization <b>{organization.name}</b> is still being processed and no
+        data will be lost.
+        <br />
+        Please contact our support team to increase your contract limit.
+      </Callout>
+    );
+  }
+
   return (
-    <Callout type="warning" className="w-1/2">
+    <Callout type="warning" className="w-full">
       <b>Your organization is being rate-limited for operations.</b>
       <br />
-      Since you reached your organization rate-limit and data ingestion limitation, your
+      Since you have reached your organization rate-limit and data ingestion limitation, your
       organization <b>{organization.name}</b> is currently unable to ingest data.
     </Callout>
   );


### PR DESCRIPTION
Closes https://github.com/the-guild-org/graphql-hive-deployment/issues/1379 

This PR removes the hard rate-limit for Enterprise users. 

This is the new behavior:

### Free/Pro plan
- When the limit is reached, a hard limit is performed and data ingestion stops. 
- Info about the limit is reported to Grafana. 
- Email is sent when 90% and 100% are reached. 
- Users will see the following message on the dashboard:

![image](https://github.com/kamilkisiela/graphql-hive/assets/3680083/8c0fb9ad-373a-401c-abc5-6910969d52a8)

### Enterprise
- When the limit is reached, a soft limit is performed and data is still ingested. 
- Info about the limit is reported to Grafana. 
- Info about the limit is reported to Grafana. 
- Email is sent when 90% and 100% are reached. 
- Users will see the following message on the dashboard:

![image](https://github.com/kamilkisiela/graphql-hive/assets/3680083/ac151625-fbf2-469f-88a8-60f6cec4b021)
