### PR TITLE
Apollo Router accepts invalid SSL certificates (opt-in)

### DIFF
--- a/packages/libraries/router/src/usage.rs
+++ b/packages/libraries/router/src/usage.rs
@@ -52,6 +52,9 @@ struct Config {
     /// A maximum number of operations to hold in a buffer before sending to GraphQL Hive
     /// Default: 1000
     buffer_size: Option<usize>,
+    /// Accept invalid SSL certificates
+    /// Default: false
+    accept_invalid_certs: Option<bool>,
 }
 
 impl Default for Config {
@@ -61,6 +64,7 @@ impl Default for Config {
             exclude: None,
             client_name_header: None,
             client_version_header: None,
+            accept_invalid_certs: Some(false),
             buffer_size: Some(1000),
         }
     }
@@ -161,6 +165,7 @@ impl Plugin for UsagePlugin {
         };
 
         let buffer_size = init.config.buffer_size.unwrap_or(1000);
+        let accept_invalid_certs = init.config.accept_invalid_certs.unwrap_or(false);
 
         Ok(UsagePlugin {
             config: init.config,
@@ -169,6 +174,7 @@ impl Plugin for UsagePlugin {
                 token,
                 endpoint,
                 buffer_size,
+                accept_invalid_certs,
             ))),
         })
     }

--- a/packages/web/docs/src/pages/docs/integrations/apollo-router.mdx
+++ b/packages/web/docs/src/pages/docs/integrations/apollo-router.mdx
@@ -57,6 +57,7 @@ Once you have all services schemas pushed to Hive, and available in the CDN, you
 - `HIVE_CDN_ENDPOINT` - the endpoint Hive generated for you in the previous step
 - `HIVE_CDN_KEY` - the access key
 - `HIVE_CDN_POLL_INTERVAL` - polling interval (default is 10 seconds)
+- `HIVE_CDN_ACCEPT_INVALID_CERTS` - accepts invalid SSL certificates (default is `false`)
 - `HIVE_REGISTRY_LOG` - defines the log level for the registry (default is `INFO`)
 
 <Callout>
@@ -120,6 +121,10 @@ plugins:
     #  A maximum number of operations to hold in a buffer before sending to GraphQL Hive
     #  Default: 1000
     # buffer_size: 1000
+    #
+    #  Accepts invalid SSL certificates
+    #  Default: false
+    # accept_invalid_certs: true
 ```
 
 ## Additional Resources


### PR DESCRIPTION
Fixes #2340

Ideally we should accept a list of certificates but this PR aims to unblock users quickly.