### PR TITLE
refactor: lift boolean that is not used locally up

### DIFF
--- a/packages/services/api/src/modules/schema/providers/models/composite-legacy.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite-legacy.ts
@@ -74,7 +74,6 @@ export class CompositeLegacyModel {
     const schemas = latestVersion
       ? swapServices(latestVersion.schemas, incoming).schemas
       : [incoming];
-    const initial = latest === null;
     const orchestrator = project.type === ProjectType.FEDERATION ? this.federation : this.stitching;
 
     const serviceNameCheck = await this.checks.serviceName({
@@ -103,7 +102,7 @@ export class CompositeLegacyModel {
     if (checksumCheck.status === 'completed' && checksumCheck.result === 'unchanged') {
       return {
         conclusion: SchemaCheckConclusion.Success,
-        state: { initial, changes: null, warnings: null },
+        state: { changes: null, warnings: null },
       };
     }
 
@@ -161,7 +160,6 @@ export class CompositeLegacyModel {
     return {
       conclusion: SchemaCheckConclusion.Success,
       state: {
-        initial,
         changes: diffCheck.result?.changes ?? null,
         warnings: null,
       },

--- a/packages/services/api/src/modules/schema/providers/models/composite.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite.ts
@@ -93,7 +93,6 @@ export class CompositeModel {
     const schemas = latestVersion
       ? swapServices(latestVersion.schemas, incoming).schemas
       : [incoming];
-    const initial = latest === null;
     const compareToLatest = organization.featureFlags.compareToPreviousComposableVersion === false;
 
     const serviceNameCheck = await this.checks.serviceName({
@@ -122,7 +121,6 @@ export class CompositeModel {
       return {
         conclusion: SchemaCheckConclusion.Success,
         state: {
-          initial,
           warnings: null,
           changes: null,
         },
@@ -206,7 +204,6 @@ export class CompositeModel {
     return {
       conclusion: SchemaCheckConclusion.Success,
       state: {
-        initial,
         warnings: policyCheck.result?.warnings ?? [],
         changes: diffCheck.result?.changes ?? null,
       },

--- a/packages/services/api/src/modules/schema/providers/models/shared.ts
+++ b/packages/services/api/src/modules/schema/providers/models/shared.ts
@@ -105,7 +105,6 @@ export type SchemaCheckSuccess = {
   state: {
     changes: Array<Change> | null;
     warnings: SchemaCheckWarning[] | null;
-    initial: boolean;
   };
 };
 

--- a/packages/services/api/src/modules/schema/providers/models/single-legacy.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single-legacy.ts
@@ -62,7 +62,6 @@ export class SingleLegacyModel {
       metadata: null,
     };
 
-    const initial = latest === null;
     const latestVersion = latest;
     const schemas = [incoming] as [SingleSchema];
 
@@ -79,7 +78,6 @@ export class SingleLegacyModel {
         state: {
           changes: null,
           warnings: null,
-          initial,
         },
       };
     }
@@ -142,7 +140,6 @@ export class SingleLegacyModel {
       state: {
         changes: diffCheck.result?.changes ?? null,
         warnings: null,
-        initial,
       },
     };
   }

--- a/packages/services/api/src/modules/schema/providers/models/single.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single.ts
@@ -68,7 +68,6 @@ export class SingleModel {
       metadata: null,
     };
 
-    const initial = latest === null;
     const latestVersion = latest;
     const schemas = [incoming] as [SingleSchema];
     const compareToLatest = organization.featureFlags.compareToPreviousComposableVersion === false;
@@ -86,7 +85,6 @@ export class SingleModel {
         state: {
           changes: null,
           warnings: [],
-          initial,
         },
       };
     }
@@ -167,7 +165,6 @@ export class SingleModel {
       state: {
         changes: diffCheck.result?.changes ?? null,
         warnings: policyCheck.result?.warnings ?? [],
-        initial,
       },
     };
   }

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -323,7 +323,7 @@ export class SchemaPublisher {
         valid: true,
         changes: checkResult.state.changes ?? [],
         warnings: checkResult.state.warnings ?? [],
-        initial: checkResult.state.initial,
+        initial: latestVersion == null,
       } as const;
     }
 


### PR DESCRIPTION
### Background

Part of a series of smaller PRs for cleaning up things before I pull in larger changes for persisting schema checks.

Related https://github.com/kamilkisiela/graphql-hive/issues/333

### Description

This removes the unnecessary casting of a boolean from each of the individual models (and returning them; while being unused locally) by instead having the same code once where it is actually needed and can be coomputed in the same way.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
