### PR TITLE
refactor: lift the service name check to the schema publisher

### DIFF
--- a/packages/services/api/src/modules/schema/providers/models/composite-legacy.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite-legacy.ts
@@ -74,7 +74,6 @@ export class CompositeLegacyModel {
     const schemas = latestVersion
       ? swapServices(latestVersion.schemas, incoming).schemas
       : [incoming];
-    const initial = latest === null;
     const orchestrator = project.type === ProjectType.FEDERATION ? this.federation : this.stitching;
 
     const serviceNameCheck = await this.checks.serviceName({
@@ -103,7 +102,7 @@ export class CompositeLegacyModel {
     if (checksumCheck.status === 'completed' && checksumCheck.result === 'unchanged') {
       return {
         conclusion: SchemaCheckConclusion.Success,
-        state: { initial, changes: null, warnings: null },
+        state: { changes: null, warnings: null },
       };
     }
 
@@ -161,7 +160,6 @@ export class CompositeLegacyModel {
     return {
       conclusion: SchemaCheckConclusion.Success,
       state: {
-        initial,
         changes: diffCheck.result?.changes ?? null,
         warnings: null,
       },

--- a/packages/services/api/src/modules/schema/providers/models/composite-legacy.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite-legacy.ts
@@ -42,7 +42,7 @@ export class CompositeLegacyModel {
   }: {
     input: {
       sdl: string;
-      serviceName?: string | null;
+      serviceName: string;
     };
     selector: {
       organization: string;
@@ -64,7 +64,7 @@ export class CompositeLegacyModel {
       target: selector.target,
       date: Date.now() as any,
       sdl: input.sdl,
-      service_name: input.serviceName!,
+      service_name: input.serviceName,
       service_url: temp,
       action: 'PUSH',
       metadata: null,
@@ -75,23 +75,6 @@ export class CompositeLegacyModel {
       ? swapServices(latestVersion.schemas, incoming).schemas
       : [incoming];
     const orchestrator = project.type === ProjectType.FEDERATION ? this.federation : this.stitching;
-
-    const serviceNameCheck = await this.checks.serviceName({
-      name: incoming.service_name,
-    });
-
-    if (serviceNameCheck.status === 'failed') {
-      return {
-        conclusion: SchemaCheckConclusion.Failure,
-        // Do we want to use this new "warning" field to let users know they should upgrade to new model?
-        warnings: [],
-        reasons: [
-          {
-            code: CheckFailureReasonCode.MissingServiceName,
-          },
-        ],
-      };
-    }
 
     const checksumCheck = await this.checks.checksum({
       schemas,

--- a/packages/services/api/src/modules/schema/providers/models/composite.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite.ts
@@ -56,7 +56,7 @@ export class CompositeModel {
   }: {
     input: {
       sdl: string;
-      serviceName?: string | null;
+      serviceName: string;
     };
     selector: {
       organization: string;
@@ -83,7 +83,7 @@ export class CompositeModel {
       target: selector.target,
       date: Date.now() as any,
       sdl: input.sdl,
-      service_name: input.serviceName!,
+      service_name: input.serviceName,
       service_url: temp,
       action: 'PUSH',
       metadata: null,
@@ -94,22 +94,6 @@ export class CompositeModel {
       ? swapServices(latestVersion.schemas, incoming).schemas
       : [incoming];
     const compareToLatest = organization.featureFlags.compareToPreviousComposableVersion === false;
-
-    const serviceNameCheck = await this.checks.serviceName({
-      name: incoming.service_name,
-    });
-
-    if (serviceNameCheck.status === 'failed') {
-      return {
-        conclusion: SchemaCheckConclusion.Failure,
-        warnings: [],
-        reasons: [
-          {
-            code: CheckFailureReasonCode.MissingServiceName,
-          },
-        ],
-      };
-    }
 
     const checksumCheck = await this.checks.checksum({
       schemas,

--- a/packages/services/api/src/modules/schema/providers/models/composite.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite.ts
@@ -93,7 +93,6 @@ export class CompositeModel {
     const schemas = latestVersion
       ? swapServices(latestVersion.schemas, incoming).schemas
       : [incoming];
-    const initial = latest === null;
     const compareToLatest = organization.featureFlags.compareToPreviousComposableVersion === false;
 
     const serviceNameCheck = await this.checks.serviceName({
@@ -122,7 +121,6 @@ export class CompositeModel {
       return {
         conclusion: SchemaCheckConclusion.Success,
         state: {
-          initial,
           warnings: null,
           changes: null,
         },
@@ -206,7 +204,6 @@ export class CompositeModel {
     return {
       conclusion: SchemaCheckConclusion.Success,
       state: {
-        initial,
         warnings: policyCheck.result?.warnings ?? [],
         changes: diffCheck.result?.changes ?? null,
       },

--- a/packages/services/api/src/modules/schema/providers/models/shared.ts
+++ b/packages/services/api/src/modules/schema/providers/models/shared.ts
@@ -105,7 +105,6 @@ export type SchemaCheckSuccess = {
   state: {
     changes: Array<Change> | null;
     warnings: SchemaCheckWarning[] | null;
-    initial: boolean;
   };
 };
 

--- a/packages/services/api/src/modules/schema/providers/models/shared.ts
+++ b/packages/services/api/src/modules/schema/providers/models/shared.ts
@@ -59,8 +59,6 @@ export type SchemaDeleteConclusion =
   (typeof SchemaDeleteConclusion)[keyof typeof SchemaDeleteConclusion];
 
 export const CheckFailureReasonCode = {
-  MissingServiceUrl: 'MISSING_SERVICE_URL',
-  MissingServiceName: 'MISSING_SERVICE_NAME',
   CompositionFailure: 'COMPOSITION_FAILURE',
   BreakingChanges: 'BREAKING_CHANGES',
   PolicyInfringement: 'POLICY_INFRINGEMENT',
@@ -79,9 +77,6 @@ export type SchemaCheckWarning = {
 };
 
 export type SchemaCheckFailureReason =
-  | {
-      code: (typeof CheckFailureReasonCode)['MissingServiceName'];
-    }
   | {
       code: (typeof CheckFailureReasonCode)['CompositionFailure'];
       compositionErrors: Array<{

--- a/packages/services/api/src/modules/schema/providers/models/single-legacy.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single-legacy.ts
@@ -62,7 +62,6 @@ export class SingleLegacyModel {
       metadata: null,
     };
 
-    const initial = latest === null;
     const latestVersion = latest;
     const schemas = [incoming] as [SingleSchema];
 
@@ -79,7 +78,6 @@ export class SingleLegacyModel {
         state: {
           changes: null,
           warnings: null,
-          initial,
         },
       };
     }
@@ -142,7 +140,6 @@ export class SingleLegacyModel {
       state: {
         changes: diffCheck.result?.changes ?? null,
         warnings: null,
-        initial,
       },
     };
   }

--- a/packages/services/api/src/modules/schema/providers/models/single.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single.ts
@@ -68,7 +68,6 @@ export class SingleModel {
       metadata: null,
     };
 
-    const initial = latest === null;
     const latestVersion = latest;
     const schemas = [incoming] as [SingleSchema];
     const compareToLatest = organization.featureFlags.compareToPreviousComposableVersion === false;
@@ -86,7 +85,6 @@ export class SingleModel {
         state: {
           changes: null,
           warnings: [],
-          initial,
         },
       };
     }
@@ -167,7 +165,6 @@ export class SingleModel {
       state: {
         changes: diffCheck.result?.changes ?? null,
         warnings: policyCheck.result?.warnings ?? [],
-        initial,
       },
     };
   }

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -323,7 +323,7 @@ export class SchemaPublisher {
         valid: true,
         changes: checkResult.state.changes ?? [],
         warnings: checkResult.state.warnings ?? [],
-        initial: checkResult.state.initial,
+        initial: latestVersion == null,
       } as const;
     }
 

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -239,7 +239,24 @@ export class SchemaPublisher {
         break;
       case ProjectType.FEDERATION:
       case ProjectType.STITCHING:
+        if (input.service == null) {
+          this.logger.debug('No service name provided (type=%s)', project.type, modelVersion);
+
+          return {
+            __typename: 'SchemaCheckError',
+            valid: false,
+            changes: [],
+            warnings: [],
+            errors: [
+              {
+                message: 'Missing service name',
+              },
+            ],
+          } as const;
+        }
+
         this.logger.debug('Using %s registry model (version=%s)', project.type, modelVersion);
+
         checkResult = await this.models[project.type][modelVersion].check({
           input: {
             sdl: input.sdl,
@@ -303,13 +320,6 @@ export class SchemaPublisher {
             message: string;
           }>
         ).concat(
-          getReasonByCode(checkResult, CheckFailureReasonCode.MissingServiceName)
-            ? [
-                {
-                  message: 'Missing service name',
-                },
-              ]
-            : [],
           getReasonByCode(checkResult, CheckFailureReasonCode.PolicyInfringement)?.errors.map(
             e => ({ message: formatPolicyMessage(e) }),
           ) ?? [],
@@ -337,13 +347,6 @@ export class SchemaPublisher {
           message: string;
         }>
       ).concat(
-        getReasonByCode(checkResult, CheckFailureReasonCode.MissingServiceName)
-          ? [
-              {
-                message: 'Missing service name',
-              },
-            ]
-          : [],
         getReasonByCode(checkResult, CheckFailureReasonCode.BreakingChanges)?.breakingChanges ?? [],
         getReasonByCode(checkResult, CheckFailureReasonCode.PolicyInfringement)?.errors.map(e => ({
           message: formatPolicyMessage(e),


### PR DESCRIPTION
### Background

Part of a series of smaller PRs for cleaning up things before I pull in larger changes for persisting schema checks.

I discussed a bit with @kamilkisiela on whether a check that failed because of a missing service name should be persisted.
We came to the conclusion that having the service name is rather a prerequisite for doing the check. Thus, it makes sense to lift the service name check outside the individual models `check` method to the `SchemaPublisher.check` method, as we also letter on do not want to persist a check with this reason.

Related https://github.com/kamilkisiela/graphql-hive/issues/333

### Description

see background. lift the service name check outside the individual models `check` method to the `SchemaPublisher.check` method. Also remove `!` 👀

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
