### PR TITLE
refactor: remodel schema check failure object

### DIFF
--- a/packages/services/api/src/modules/schema/providers/models/shared.ts
+++ b/packages/services/api/src/modules/schema/providers/models/shared.ts
@@ -260,10 +260,6 @@ export function buildSchemaCheckFailureState(args: {
     compositionErrors.push(...args.compositionCheck.reason.errors);
   }
 
-  if (args.compositionCheck.status === 'failed') {
-    compositionErrors.push(...args.compositionCheck.reason.errors);
-  }
-
   if (args.diffCheck.status === 'failed') {
     if (args.diffCheck.reason.changes) {
       schemaChanges = {

--- a/packages/services/api/src/modules/schema/providers/models/single-legacy.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single-legacy.ts
@@ -5,12 +5,11 @@ import type { PublishInput } from '../schema-publisher';
 import type { Project, SingleSchema, Target } from './../../../../shared/entities';
 import { Logger } from './../../../shared/providers/logger';
 import {
-  CheckFailureReasonCode,
+  buildSchemaCheckFailureState,
   PublishFailureReasonCode,
   PublishIgnoreReasonCode,
   /* Check */
   SchemaCheckConclusion,
-  SchemaCheckFailureReason,
   SchemaCheckResult,
   /* Publish */
   SchemaPublishConclusion,
@@ -76,8 +75,8 @@ export class SingleLegacyModel {
       return {
         conclusion: SchemaCheckConclusion.Success,
         state: {
-          changes: null,
-          warnings: null,
+          schemaChanges: null,
+          schemaPolicyWarnings: null,
         },
       };
     }
@@ -100,46 +99,21 @@ export class SingleLegacyModel {
     ]);
 
     if (compositionCheck.status === 'failed' || diffCheck.status === 'failed') {
-      const reasons: SchemaCheckFailureReason[] = [];
-
-      if (compositionCheck.status === 'failed') {
-        this.logger.debug('Failing schema check due to composition errors');
-        reasons.push({
-          code: CheckFailureReasonCode.CompositionFailure,
-          compositionErrors: compositionCheck.reason.errors,
-        });
-      }
-
-      if (diffCheck.status === 'failed') {
-        this.logger.debug('Failing schema check due to breaking changes');
-        if (diffCheck.reason.changes) {
-          reasons.push({
-            code: CheckFailureReasonCode.BreakingChanges,
-            changes: diffCheck.reason.changes ?? [],
-            breakingChanges: diffCheck.reason.breakingChanges,
-          });
-        }
-
-        if (diffCheck.reason.compareFailure) {
-          reasons.push({
-            code: CheckFailureReasonCode.CompositionFailure,
-            compositionErrors: [diffCheck.reason.compareFailure],
-          });
-        }
-      }
-
       return {
         conclusion: SchemaCheckConclusion.Failure,
-        warnings: [],
-        reasons,
+        state: buildSchemaCheckFailureState({
+          compositionCheck,
+          diffCheck,
+          policyCheck: null,
+        }),
       };
     }
 
     return {
       conclusion: SchemaCheckConclusion.Success,
       state: {
-        changes: diffCheck.result?.changes ?? null,
-        warnings: null,
+        schemaChanges: diffCheck.result?.changes ?? null,
+        schemaPolicyWarnings: null,
       },
     };
   }

--- a/packages/services/api/src/modules/schema/providers/registry-checks.ts
+++ b/packages/services/api/src/modules/schema/providers/registry-checks.ts
@@ -1,7 +1,7 @@
 import { URL } from 'node:url';
 import { Injectable, Scope } from 'graphql-modules';
 import hashObject from 'object-hash';
-import { CriticalityLevel } from '@graphql-inspector/core';
+import { type Change, CriticalityLevel } from '@graphql-inspector/core';
 import type { CompositionFailureError } from '@hive/schema';
 import { Schema } from '../../../shared/entities';
 import { buildSchema } from '../../../shared/schema';
@@ -293,9 +293,15 @@ export class RegistryChecks {
         );
       }
 
-      const breakingChanges = changes.filter(
-        change => change.criticality.level === CriticalityLevel.Breaking,
-      );
+      const safeChanges: Array<Change> = [];
+      const breakingChanges: Array<Change> = [];
+      for (const change of changes) {
+        if (change.criticality.level === CriticalityLevel.Breaking) {
+          breakingChanges.push(change);
+          continue;
+        }
+        safeChanges.push(change);
+      }
 
       const hasBreakingChanges = breakingChanges.length > 0;
 
@@ -305,6 +311,7 @@ export class RegistryChecks {
           status: 'failed',
           reason: {
             breakingChanges,
+            safeChanges,
             changes,
           },
         } satisfies CheckResult;

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -310,7 +310,7 @@ export class SchemaPublisher {
           ...(checkResult.state.schemaChanges?.safe ?? []),
         ],
         breakingChanges: checkResult.state.schemaChanges?.breaking ?? [],
-        compositionErrors: checkResult.state.compositionErrors ?? [],
+        compositionErrors: checkResult.state.composition.errors ?? [],
         warnings: checkResult.state.schemaPolicy?.warnings ?? [],
         errors: checkResult.state.schemaPolicy?.errors?.map(formatPolicyError) ?? [],
       });
@@ -337,7 +337,7 @@ export class SchemaPublisher {
       errors: [
         ...(checkResult.state.schemaChanges?.breaking ?? []),
         ...(checkResult.state.schemaPolicy?.errors?.map(formatPolicyError) ?? []),
-        ...(checkResult.state.compositionErrors ?? []),
+        ...(checkResult.state.composition.errors ?? []),
       ],
     } as const;
   }

--- a/packages/services/api/src/modules/schema/resolvers.ts
+++ b/packages/services/api/src/modules/schema/resolvers.ts
@@ -112,6 +112,11 @@ export const resolvers: SchemaModule.Resolvers = {
         return {
           ...result,
           changes: result.changes.map(toGraphQLSchemaChange),
+          errors:
+            result.errors?.map(error => ({
+              ...error,
+              path: 'path' in error ? error.path?.split('.') : null,
+            })) ?? [],
         };
       }
 


### PR DESCRIPTION
### Background

Part of a series of smaller PRs for cleaning up things before I pull in larger changes for persisting schema checks.

Related https://github.com/kamilkisiela/graphql-hive/issues/333

### Description

This changes the structure of the check failure state so it is later easier to read and write it to the database. Also removes some duplicated code.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
