### PR TITLE
fix: avoid leaking internal (unexpected) errors to the outside world

### DIFF
--- a/integration-tests/tests/api/policy/policy-check.spec.ts
+++ b/integration-tests/tests/api/policy/policy-check.spec.ts
@@ -221,9 +221,11 @@ describe('Schema policy checks', () => {
       expect(message).toContain(`Detected 2 errors`);
       expect(message.split('\n').slice(1).join('\n')).toMatchInlineSnapshot(`
         ✖ Detected 2 errors
-
-           - Description is required for type Query (source: policy-require-description)
-           - Description is required for type User (source: policy-require-description)
+        - Description is required for type Query (source: policy-require-description)
+        - Description is required for type User (source: policy-require-description)
+        i Detected 2 changes
+        - Type User was added
+        - Field user was added to object type Query
       `);
     });
 
@@ -277,13 +279,14 @@ describe('Schema policy checks', () => {
       expect(message).toContain(`Detected 1 warning`);
       expect(message.split('\n').slice(1).join('\n')).toMatchInlineSnapshot(`
         ✖ Detected 2 errors
-
-           - Description is required for type Query (source: policy-require-description)
-           - Description is required for type User (source: policy-require-description)
-
+        - Description is required for type Query (source: policy-require-description)
+        - Description is required for type User (source: policy-require-description)
         ⚠ Detected 1 warning
-
-           - Deprecation reason is required for field foo in type Query. (source: policy-require-deprecation-reason)
+        - Deprecation reason is required for field foo in type Query. (source: policy-require-deprecation-reason)
+        i Detected 3 changes
+        - Type User was added
+        - Field user was added to object type Query
+        - Field Query.foo is deprecated
       `);
     });
   });

--- a/packages/services/api/src/modules/schema/providers/models/composite.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite.ts
@@ -446,8 +446,8 @@ export class CompositeModel {
     const { changes, breakingChanges } =
       diffCheck.status === 'failed'
         ? {
-            changes: diffCheck.reason?.changes ?? [],
-            breakingChanges: diffCheck.reason?.breakingChanges ?? [],
+            changes: diffCheck.reason.changes ?? [],
+            breakingChanges: diffCheck.reason.breakingChanges ?? [],
           }
         : {
             changes: diffCheck.result?.changes ?? [],

--- a/packages/services/api/src/modules/schema/providers/models/composite.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite.ts
@@ -136,6 +136,7 @@ export class CompositeModel {
         selector,
         schemas,
         modifiedSdl: incoming.sdl,
+        baseSchema,
       }),
     ]);
 
@@ -445,8 +446,8 @@ export class CompositeModel {
     const { changes, breakingChanges } =
       diffCheck.status === 'failed'
         ? {
-            changes: diffCheck.reason.changes ?? [],
-            breakingChanges: diffCheck.reason.breakingChanges ?? [],
+            changes: diffCheck.reason?.changes ?? [],
+            breakingChanges: diffCheck.reason?.breakingChanges ?? [],
           }
         : {
             changes: diffCheck.result?.changes ?? [],

--- a/packages/services/api/src/modules/schema/providers/models/shared.ts
+++ b/packages/services/api/src/modules/schema/providers/models/shared.ts
@@ -72,10 +72,11 @@ export type CheckFailureReasonCode =
 export type CheckPolicyResultRecord = CheckPolicyResponse[number] | { message: string };
 export type SchemaCheckWarning = {
   message: string;
-  source?: string | undefined | null;
+  source: string | null;
 
   line?: number;
   column?: number;
+  ruleId: string | null;
 };
 
 export type SchemaCheckSuccess = {

--- a/packages/services/api/src/modules/schema/providers/models/shared.ts
+++ b/packages/services/api/src/modules/schema/providers/models/shared.ts
@@ -105,7 +105,7 @@ export type SchemaCheckFailure = {
         };
     /** Absence means schema changes were skipped. */
     schemaChanges: null | {
-      breaking: Array<Change>;
+      breaking: Array<Change> | null;
       safe: Array<Change>;
     };
     /** Absence means the schema policy is disabled or wasn't done because composition failed. */
@@ -260,7 +260,7 @@ export function buildSchemaCheckFailureState(args: {
 }): SchemaCheckFailure['state'] {
   const compositionErrors: Array<CompositionFailureError> = [];
   let schemaChanges: null | {
-    breaking: Array<Change>;
+    breaking: Array<Change> | null;
     safe: Array<Change>;
   } = null;
   let schemaPolicy: null | {
@@ -272,13 +272,18 @@ export function buildSchemaCheckFailureState(args: {
     compositionErrors.push(...args.compositionCheck.reason.errors);
   }
 
-  if (args.diffCheck.status === 'failed') {
-    if (args.diffCheck.reason.changes) {
-      schemaChanges = {
-        breaking: args.diffCheck.reason.breakingChanges,
-        safe: args.diffCheck.reason.safeChanges,
-      };
-    }
+  if (args.diffCheck.reason) {
+    schemaChanges = {
+      breaking: args.diffCheck.reason.breakingChanges,
+      safe: args.diffCheck.reason.safeChanges,
+    };
+  }
+
+  if (args.diffCheck.result) {
+    schemaChanges = {
+      breaking: null,
+      safe: args.diffCheck.result.changes,
+    };
   }
 
   if (args.policyCheck) {

--- a/packages/services/api/src/modules/schema/providers/models/shared.ts
+++ b/packages/services/api/src/modules/schema/providers/models/shared.ts
@@ -278,10 +278,6 @@ export function buildSchemaCheckFailureState(args: {
         safe: args.diffCheck.reason.safeChanges,
       };
     }
-
-    if (args.diffCheck.reason.compareFailure) {
-      compositionErrors.push(args.diffCheck.reason.compareFailure);
-    }
   }
 
   if (args.policyCheck) {

--- a/packages/services/api/src/modules/schema/providers/models/single.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single.ts
@@ -109,6 +109,7 @@ export class SingleModel {
         selector,
         schemas,
         modifiedSdl: input.sdl,
+        baseSchema,
       }),
     ]);
 

--- a/packages/services/api/src/modules/schema/providers/orchestrators/single.ts
+++ b/packages/services/api/src/modules/schema/providers/orchestrators/single.ts
@@ -3,7 +3,6 @@ import type { SchemaBuilderApi } from '@hive/schema';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
 import { fetch } from '@whatwg-node/fetch';
 import { Orchestrator, ProjectType, SchemaObject } from '../../../../shared/entities';
-import { HiveError } from '../../../../shared/errors';
 import { sentry } from '../../../../shared/sentry';
 import { Logger } from '../../../shared/providers/logger';
 import type { SchemaServiceConfig } from './tokens';
@@ -44,7 +43,7 @@ export class SingleOrchestrator implements Orchestrator {
       this.logger.debug('More than one schema (sources=%o)', {
         sources: schemas.map(s => s.source),
       });
-      throw new HiveError('too many schemas');
+      throw new Error('too many schemas');
     }
 
     const result = await this.schemaService.composeAndValidate.mutate({

--- a/packages/services/api/src/modules/schema/providers/registry-checks.ts
+++ b/packages/services/api/src/modules/schema/providers/registry-checks.ts
@@ -183,12 +183,6 @@ export class RegistryChecks {
         status: 'skipped',
       };
     }
-    if (result.errors.length > 0) {
-      this.logger.debug('Skip policy check due schemas not being valid.');
-      return {
-        status: 'skipped',
-      } satisfies CheckResult;
-    }
 
     const policyResult = await this.policy.checkPolicy(result.sdl, modifiedSdl, selector);
     const warnings = policyResult?.warnings?.map<SchemaCheckWarning>(toSchemaCheckWarning) ?? [];
@@ -257,12 +251,6 @@ export class RegistryChecks {
 
     if (existingSchemaResult.sdl == null || incomingSchemaResult.sdl == null) {
       this.logger.debug('Skip policy check due to no SDL being composed.');
-      return {
-        status: 'skipped',
-      } satisfies CheckResult;
-    }
-    if (existingSchemaResult.errors.length > 0 || incomingSchemaResult.errors.length > 0) {
-      this.logger.debug('Skip policy check due schemas not being valid.');
       return {
         status: 'skipped',
       } satisfies CheckResult;

--- a/packages/services/api/src/modules/schema/providers/registry-checks.ts
+++ b/packages/services/api/src/modules/schema/providers/registry-checks.ts
@@ -503,4 +503,5 @@ const toSchemaCheckWarning = (record: CheckPolicyResponse[number]): SchemaCheckW
   source: record.ruleId ? `policy-${record.ruleId}` : 'policy',
   column: record.column,
   line: record.line,
+  ruleId: record.ruleId ?? null,
 });

--- a/packages/services/api/src/modules/schema/providers/registry-checks.ts
+++ b/packages/services/api/src/modules/schema/providers/registry-checks.ts
@@ -2,6 +2,7 @@ import { URL } from 'node:url';
 import { Injectable, Scope } from 'graphql-modules';
 import hashObject from 'object-hash';
 import { type Change, CriticalityLevel } from '@graphql-inspector/core';
+import type { CheckPolicyResponse } from '@hive/policy';
 import type { CompositionFailureError } from '@hive/schema';
 import { Schema } from '../../../shared/entities';
 import { buildSchema } from '../../../shared/schema';
@@ -48,13 +49,6 @@ function isCompositionValidationError(error: CompositionFailureError): error is 
   source: 'composition';
 } {
   return error.source === 'composition';
-}
-
-function isPolicyValidationError(error: CompositionFailureError): error is {
-  message: string;
-  source: 'policy';
-} {
-  return error.source === 'policy';
 }
 
 function isGraphQLValidationError(error: CompositionFailureError): error is {
@@ -139,7 +133,6 @@ export class RegistryChecks {
           errorsBySource: {
             graphql: validationErrors.filter(isGraphQLValidationError),
             composition: validationErrors.filter(isCompositionValidationError),
-            policy: validationErrors.filter(isPolicyValidationError),
           },
         },
       } satisfies CheckResult;
@@ -184,46 +177,31 @@ export class RegistryChecks {
       ),
     );
 
-    try {
-      const policyResult = await this.policy.checkPolicy(sdl.raw, modifiedSdl, selector);
-      const warnings =
-        policyResult?.warnings?.map<SchemaCheckWarning>(record => ({
-          message: record.message,
-          source: record.ruleId ? `policy-${record.ruleId}` : 'policy',
-          column: record.column,
-          line: record.line,
-        })) ?? [];
+    const policyResult = await this.policy.checkPolicy(sdl.raw, modifiedSdl, selector);
+    const warnings = policyResult?.warnings?.map<SchemaCheckWarning>(toSchemaCheckWarning) ?? [];
 
-      if (policyResult === null) {
-        return {
-          status: 'skipped',
-        } satisfies CheckResult;
-      }
-
-      if (policyResult.success) {
-        return {
-          status: 'completed',
-          result: {
-            warnings,
-          },
-        } satisfies CheckResult;
-      }
-
+    if (policyResult === null) {
       return {
-        status: 'failed',
-        reason: {
-          errors: policyResult.errors,
+        status: 'skipped',
+      } satisfies CheckResult;
+    }
+
+    if (policyResult.success) {
+      return {
+        status: 'completed',
+        result: {
           warnings,
         },
       } satisfies CheckResult;
-    } catch (e) {
-      return {
-        status: 'failed',
-        reason: {
-          errors: [{ message: (e as Error).message }],
-        },
-      } satisfies CheckResult;
     }
+
+    return {
+      status: 'failed',
+      reason: {
+        errors: policyResult.errors.map(toSchemaCheckWarning),
+        warnings,
+      },
+    } satisfies CheckResult;
   }
 
   async diff({
@@ -252,94 +230,80 @@ export class RegistryChecks {
       } satisfies CheckResult;
     }
 
-    try {
-      const [existingSchema, incomingSchema] = await Promise.all([
-        ensureSDL(
-          orchestrator.composeAndValidate(
-            version.schemas.map(s => this.helper.createSchemaObject(s)),
-            project.externalComposition,
-          ),
-        ).then(schema => {
-          return buildSchema(
-            this.helper.createSchemaObject({
-              sdl: schema.raw,
-            }),
-          );
-        }),
-        ensureSDL(
-          orchestrator.composeAndValidate(
-            schemas.map(s => this.helper.createSchemaObject(s)),
-            project.externalComposition,
-          ),
-        ).then(schema => {
-          return buildSchema(
-            this.helper.createSchemaObject({
-              sdl: schema.raw,
-            }),
-          );
-        }),
-      ]);
-
-      const changes = [...(await this.inspector.diff(existingSchema, incomingSchema, selector))];
-
-      if (includeUrlChanges) {
-        changes.push(
-          ...detectUrlChanges(version.schemas, schemas).map(change =>
-            schemaChangeFromMeta({
-              ...change,
-              isSafeBasedOnUsage: false,
-            }),
-          ),
+    const [existingSchema, incomingSchema] = await Promise.all([
+      ensureSDL(
+        orchestrator.composeAndValidate(
+          version.schemas.map(s => this.helper.createSchemaObject(s)),
+          project.externalComposition,
+        ),
+      ).then(schema => {
+        return buildSchema(
+          this.helper.createSchemaObject({
+            sdl: schema.raw,
+          }),
         );
+      }),
+      ensureSDL(
+        orchestrator.composeAndValidate(
+          schemas.map(s => this.helper.createSchemaObject(s)),
+          project.externalComposition,
+        ),
+      ).then(schema => {
+        return buildSchema(
+          this.helper.createSchemaObject({
+            sdl: schema.raw,
+          }),
+        );
+      }),
+    ]);
+
+    const changes = [...(await this.inspector.diff(existingSchema, incomingSchema, selector))];
+
+    if (includeUrlChanges) {
+      changes.push(
+        ...detectUrlChanges(version.schemas, schemas).map(change =>
+          schemaChangeFromMeta({
+            ...change,
+            isSafeBasedOnUsage: false,
+          }),
+        ),
+      );
+    }
+
+    const safeChanges: Array<Change> = [];
+    const breakingChanges: Array<Change> = [];
+    for (const change of changes) {
+      if (change.criticality.level === CriticalityLevel.Breaking) {
+        breakingChanges.push(change);
+        continue;
       }
+      safeChanges.push(change);
+    }
 
-      const safeChanges: Array<Change> = [];
-      const breakingChanges: Array<Change> = [];
-      for (const change of changes) {
-        if (change.criticality.level === CriticalityLevel.Breaking) {
-          breakingChanges.push(change);
-          continue;
-        }
-        safeChanges.push(change);
-      }
+    const hasBreakingChanges = breakingChanges.length > 0;
 
-      const hasBreakingChanges = breakingChanges.length > 0;
-
-      if (hasBreakingChanges) {
-        this.logger.debug('Detected breaking changes');
-        return {
-          status: 'failed',
-          reason: {
-            breakingChanges,
-            safeChanges,
-            changes,
-          },
-        } satisfies CheckResult;
-      }
-
-      if (changes.length) {
-        this.logger.debug('Detected non-breaking changes');
-      }
-
-      return {
-        status: 'completed',
-        result: {
-          changes,
-        },
-      } satisfies CheckResult;
-    } catch (error: unknown) {
-      this.logger.debug('Failed to compare schemas (error=%s)', (error as Error).message);
-
+    if (hasBreakingChanges) {
+      this.logger.debug('Detected breaking changes');
       return {
         status: 'failed',
         reason: {
-          compareFailure: {
-            message: `Failed to compare schemas: ${(error as Error).message}`,
-            source: 'composition' as const,
-          },
+          breakingChanges,
+          safeChanges,
+          changes,
         },
       } satisfies CheckResult;
     }
+
+    if (changes.length) {
+      this.logger.debug('Detected non-breaking changes');
+    }
+
+    return {
+      status: 'completed',
+      result: {
+        changes,
+      },
+    } satisfies CheckResult;
   }
 
   async serviceName(service: { name: string | null }) {
@@ -510,3 +474,10 @@ export function detectUrlChanges(
 
   return changes;
 }
+
+const toSchemaCheckWarning = (record: CheckPolicyResponse[number]): SchemaCheckWarning => ({
+  message: record.message,
+  source: record.ruleId ? `policy-${record.ruleId}` : 'policy',
+  column: record.column,
+  line: record.line,
+});

--- a/packages/services/api/src/modules/schema/providers/schema-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-helper.ts
@@ -96,6 +96,9 @@ export function extendWithBase(
 
 type CreateSchemaObjectInput = Parameters<typeof createSchemaObject>[0];
 
+/**
+ * @deprecated Please don't throw random errors. Handle them gracefully instead. 😇
+ */
 export async function ensureSDL(
   composeAndValidationResultPromise: Promise<ComposeAndValidateResult>,
   strategy: 'reject-on-graphql-errors' | 'ignore-errors' = 'ignore-errors',

--- a/packages/services/schema/src/cache.ts
+++ b/packages/services/schema/src/cache.ts
@@ -98,7 +98,10 @@ export function createCache(options: {
   return {
     timeoutMs,
     isTimeoutError(error: unknown): error is TimeoutError {
-      return error instanceof TimeoutError;
+      return (
+        error instanceof TimeoutError ||
+        ((error as null | { message?: string })?.message?.startsWith('TimeoutError') ?? false)
+      );
     },
     reuse<I, O>(groupKey: string, factory: (input: I) => Promise<O>): (input: I) => Promise<O> {
       return async input => {

--- a/packages/services/schema/src/orchestrators.ts
+++ b/packages/services/schema/src/orchestrators.ts
@@ -307,8 +307,6 @@ async function callExternalService(
       }
     }
 
-    console.log(error);
-
     throw error;
   }
 }

--- a/packages/services/schema/src/orchestrators.ts
+++ b/packages/services/schema/src/orchestrators.ts
@@ -251,6 +251,20 @@ async function callExternalService(
     return JSON.parse(response.body) as unknown;
   } catch (error) {
     if (error instanceof RequestError) {
+      if (!error.response) {
+        logger.info('Network error without response. (%s)', error.message);
+        return {
+          type: 'failure',
+          result: {
+            errors: [
+              {
+                message: `External composition network failure. Is the service reachable?`,
+                source: 'graphql',
+              },
+            ],
+          },
+        } satisfies CompositionFailure;
+      }
       if (error.response) {
         const message = error.response.body ? error.response.body : error.response.statusMessage;
 
@@ -292,6 +306,8 @@ async function callExternalService(
         } satisfies CompositionFailure;
       }
     }
+
+    console.log(error);
 
     throw error;
   }

--- a/packages/services/schema/src/orchestrators.ts
+++ b/packages/services/schema/src/orchestrators.ts
@@ -47,7 +47,7 @@ interface CompositionSuccess {
   };
 }
 
-export type CompositionErrorSource = 'graphql' | 'composition' | 'policy';
+export type CompositionErrorSource = 'graphql' | 'composition';
 
 export interface CompositionFailureError {
   message: string;


### PR DESCRIPTION
### Background

Related https://github.com/kamilkisiela/graphql-hive/issues/333

### Description

After talking with @dotansimha, we came to the conclusion that these checks can potentially expose sensitive messages. It makes more sense to drop the try-catch statement and let those kind of errors escalate.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
