### PR TITLE
fix typecheck issues after refactor

### DIFF
--- a/packages/services/api/src/modules/schema/providers/registry-checks.ts
+++ b/packages/services/api/src/modules/schema/providers/registry-checks.ts
@@ -335,6 +335,7 @@ export class RegistryChecks {
         reason: {
           compareFailure: {
             message: `Failed to compare schemas: ${(error as Error).message}`,
+            source: 'composition' as const,
           },
         },
       } satisfies CheckResult;


### PR DESCRIPTION
Seems like some changes in https://github.com/kamilkisiela/graphql-hive/commit/71b22e34364418dbfc5375a51c8b597186a45eeb cause build/typecheck issues. We missed it because of some turbo caching issues (i guess).
Running with `--force` seems to bring this error. Also it happens in other PRs. 