### PR TITLE
Set readiness of usage service based on errors returned by Kafka

### DIFF
--- a/packages/services/service-common/src/graceful-shutdown.ts
+++ b/packages/services/service-common/src/graceful-shutdown.ts
@@ -6,7 +6,7 @@ const signalTraps = ['SIGTERM', 'SIGINT', 'SIGUSR2'];
 export function registerShutdown(config: {
   logger: FastifyLoggerInstance;
   onShutdown(): void | Promise<void>;
-}) {
+}): (reason?: string) => Promise<void> {
   let exited = false;
 
   async function shutdown() {
@@ -48,4 +48,17 @@ export function registerShutdown(config: {
       }
     });
   });
+
+  return async (reason?: string) => {
+    try {
+      config.logger.info(`Manual shutdown ${reason ? `(${reason})` : ''}`);
+      await shutdown();
+      config.logger.info(`shutdown process done, exiting with code 0`);
+      process.exit(0);
+    } catch (e) {
+      config.logger.warn(`shutdown process failed, exiting with code 1`);
+      config.logger.error(e);
+      process.exit(1);
+    }
+  };
 }

--- a/packages/services/usage/src/index.ts
+++ b/packages/services/usage/src/index.ts
@@ -50,9 +50,12 @@ async function main() {
         buffer: env.kafka.buffer,
         connection: env.kafka.connection,
       },
+      onStop(reason) {
+        return shutdown(reason);
+      },
     });
 
-    registerShutdown({
+    const shutdown = registerShutdown({
       logger: server.log,
       async onShutdown() {
         await Promise.all([stop(), server.close()]);


### PR DESCRIPTION
It should mark the pod as not ready when Kafka producer fails to send a message.