### PR TITLE
Cache Query.tokenInfo for 5s

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,7 +107,8 @@
   },
   "pnpm": {
     "overrides": {
-      "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.cd77847.0"
+      "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.cd77847.0",
+      "@envelop/response-cache": "5.0.1-alpha-20230614122817-14924772"
     },
     "patchedDependencies": {
       "@theguild/buddy@0.1.0": "patches/@theguild__buddy@0.1.0.patch",

--- a/package.json
+++ b/package.json
@@ -107,8 +107,7 @@
   },
   "pnpm": {
     "overrides": {
-      "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.cd77847.0",
-      "@envelop/response-cache": "5.0.1-alpha-20230614122817-14924772"
+      "@storybook/react-docgen-typescript-plugin": "1.0.6--canary.9.cd77847.0"
     },
     "patchedDependencies": {
       "@theguild/buddy@0.1.0": "patches/@theguild__buddy@0.1.0.patch",

--- a/packages/services/server/package.json
+++ b/packages/services/server/package.json
@@ -19,6 +19,7 @@
     "@escape.tech/graphql-armor-max-depth": "2.0.0",
     "@escape.tech/graphql-armor-max-directives": "2.0.0",
     "@escape.tech/graphql-armor-max-tokens": "2.0.0",
+    "@graphql-yoga/plugin-response-cache": "2.0.0",
     "@sentry/integrations": "7.54.0",
     "@sentry/node": "7.54.0",
     "@trpc/server": "10.29.1",

--- a/packages/services/server/src/graphql-handler.ts
+++ b/packages/services/server/src/graphql-handler.ts
@@ -12,6 +12,7 @@ import { useGenericAuth } from '@envelop/generic-auth';
 import { useGraphQLModules } from '@envelop/graphql-modules';
 import { useSentry } from '@envelop/sentry';
 import { useHive } from '@graphql-hive/client';
+import { useResponseCache } from '@graphql-yoga/plugin-response-cache';
 import { Registry, RegistryContext } from '@hive/api';
 import { HiveError } from '@hive/api';
 import { cleanRequestId } from '@hive/service-common';
@@ -207,6 +208,15 @@ export const graphqlHandler = (options: GraphQLHandlerOptions): RouteHandlerMeth
           author: 'Hive API',
           commit: options.release,
         },
+      }),
+      useResponseCache({
+        session: request =>
+          request.headers.get('authentication') ?? request.headers.get('x-api-token'),
+        ttl: 0,
+        ttlPerSchemaCoordinate: {
+          'Query.tokenInfo': 5000 /* 5 seconds */,
+        },
+        invalidateViaMutation: false,
       }),
       useGraphQLModules(options.registry),
       useNoIntrospection({

--- a/packages/services/server/src/graphql-handler.ts
+++ b/packages/services/server/src/graphql-handler.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import type {
   FastifyLoggerInstance,
   FastifyReply,
@@ -24,6 +25,10 @@ import { useArmor } from './use-armor';
 import { extractUserId, useSentryUser } from './use-sentry-user';
 
 const reqIdGenerate = hyperid({ fixedLength: true });
+
+function hashSessionId(sessionId: string): string {
+  return createHash('sha256').update(sessionId).digest('hex');
+}
 
 const SuperTokenAccessTokenModel = zod.object({
   version: zod.literal('1'),
@@ -210,11 +215,19 @@ export const graphqlHandler = (options: GraphQLHandlerOptions): RouteHandlerMeth
         },
       }),
       useResponseCache({
-        session: request =>
-          request.headers.get('authentication') ?? request.headers.get('x-api-token'),
+        session: request => {
+          const sessionValue =
+            request.headers.get('authorization') ?? request.headers.get('x-api-token');
+
+          if (sessionValue != null) {
+            return hashSessionId(sessionValue);
+          }
+
+          return null;
+        },
         ttl: 0,
         ttlPerSchemaCoordinate: {
-          'Query.tokenInfo': 5000 /* 5 seconds */,
+          'Query.tokenInfo': 5_000 /* 5 seconds */,
         },
         invalidateViaMutation: false,
       }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,6 @@ settings:
 
 overrides:
   '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.cd77847.0
-  '@envelop/response-cache': 5.0.1-alpha-20230614122817-14924772
 
 patchedDependencies:
   '@apollo/federation@0.38.1':
@@ -5240,8 +5239,8 @@ packages:
       tslib: 2.5.3
     dev: false
 
-  /@envelop/response-cache@5.0.1-alpha-20230614122817-14924772(@envelop/core@4.0.0)(graphql@16.6.0):
-    resolution: {integrity: sha512-8HJIScHZ3b8gWod8d8ZB+AdiJLs5hWiaFw8DB+P/WDu/27dRcOncokHUSksM0sEk33sqaUEebpokS/V5uUC6UQ==}
+  /@envelop/response-cache@5.0.1(@envelop/core@4.0.0)(graphql@16.6.0):
+    resolution: {integrity: sha512-mObEI0PZsMHZ6dTzGpuQOJ+QhSrTIH4y9tChv1DeM0eKakRutY9l96EZ6mQGSfVcrJklkOOvCyUZdBs1qQrOmw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@envelop/core': ^4.0.0
@@ -7644,7 +7643,7 @@ packages:
       graphql: ^15.2.0 || ^16.0.0
       graphql-yoga: ^4.0.0
     dependencies:
-      '@envelop/response-cache': 5.0.1-alpha-20230614122817-14924772(@envelop/core@4.0.0)(graphql@16.6.0)
+      '@envelop/response-cache': 5.0.1(@envelop/core@4.0.0)(graphql@16.6.0)
       graphql: 16.6.0
       graphql-yoga: 4.0.0(graphql@16.6.0)
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1024,6 +1024,9 @@ importers:
       '@escape.tech/graphql-armor-max-tokens':
         specifier: 2.0.0
         version: 2.0.0
+      '@graphql-yoga/plugin-response-cache':
+        specifier: 2.0.0
+        version: 2.0.0(@envelop/core@4.0.0)(graphql-yoga@4.0.0)(graphql@16.6.0)
       '@sentry/integrations':
         specifier: 7.54.0
         version: 7.54.0
@@ -5236,6 +5239,22 @@ packages:
       tslib: 2.5.3
     dev: false
 
+  /@envelop/response-cache@5.0.0(@envelop/core@4.0.0)(graphql@16.6.0):
+    resolution: {integrity: sha512-CVcH0D2Ht0Rr1UJhOPPN5LUK18/UaoBi1PtNlqusY2yI5yHbzztqVsg9mxQv6jHuIHE6FWAYzZJN38viPGyYuA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      '@envelop/core': ^4.0.0
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      '@envelop/core': 4.0.0
+      '@graphql-tools/utils': 10.0.1(graphql@16.6.0)
+      '@whatwg-node/fetch': 0.9.4
+      fast-json-stable-stringify: 2.1.0
+      graphql: 16.6.0
+      lru-cache: 9.1.1
+      tslib: 2.5.3
+    dev: false
+
   /@envelop/sentry@6.0.0(@envelop/core@4.0.0)(@sentry/node@7.54.0)(graphql@16.6.0):
     resolution: {integrity: sha512-qvGzmHXTvVIptyk55ROTWLZZl/S0FRv/grUNfXKWRDBPnOTgGFlXTm8dFklRIJC5s+ws9cMDlLjkXep/M2JBVg==}
     engines: {node: '>=16.0.0'}
@@ -7616,6 +7635,20 @@ packages:
     engines: {node: '>=16.0.0'}
     dependencies:
       tslib: 2.5.3
+
+  /@graphql-yoga/plugin-response-cache@2.0.0(@envelop/core@4.0.0)(graphql-yoga@4.0.0)(graphql@16.6.0):
+    resolution: {integrity: sha512-lwAw8MTejnuZLxs69kde4GAGzfiK6yxDvzqzxjH6JA8BgCNNLPH9AkodVbV6AzVC5/M1D7S2VnL1RfWUAj2UqQ==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^15.2.0 || ^16.0.0
+      graphql-yoga: ^4.0.0
+    dependencies:
+      '@envelop/response-cache': 5.0.0(@envelop/core@4.0.0)(graphql@16.6.0)
+      graphql: 16.6.0
+      graphql-yoga: 4.0.0(graphql@16.6.0)
+    transitivePeerDependencies:
+      - '@envelop/core'
+    dev: false
 
   /@graphql-yoga/subscription@3.1.0:
     resolution: {integrity: sha512-Vc9lh8KzIHyS3n4jBlCbz7zCjcbtQnOBpsymcRvHhFr2cuH+knmRn0EmzimMQ58jQ8kxoRXXC3KJS3RIxSdPIg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.cd77847.0
+  '@envelop/response-cache': 5.0.1-alpha-20230614122817-14924772
 
 patchedDependencies:
   '@apollo/federation@0.38.1':
@@ -5239,8 +5240,8 @@ packages:
       tslib: 2.5.3
     dev: false
 
-  /@envelop/response-cache@5.0.0(@envelop/core@4.0.0)(graphql@16.6.0):
-    resolution: {integrity: sha512-CVcH0D2Ht0Rr1UJhOPPN5LUK18/UaoBi1PtNlqusY2yI5yHbzztqVsg9mxQv6jHuIHE6FWAYzZJN38viPGyYuA==}
+  /@envelop/response-cache@5.0.1-alpha-20230614122817-14924772(@envelop/core@4.0.0)(graphql@16.6.0):
+    resolution: {integrity: sha512-8HJIScHZ3b8gWod8d8ZB+AdiJLs5hWiaFw8DB+P/WDu/27dRcOncokHUSksM0sEk33sqaUEebpokS/V5uUC6UQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       '@envelop/core': ^4.0.0
@@ -7643,7 +7644,7 @@ packages:
       graphql: ^15.2.0 || ^16.0.0
       graphql-yoga: ^4.0.0
     dependencies:
-      '@envelop/response-cache': 5.0.0(@envelop/core@4.0.0)(graphql@16.6.0)
+      '@envelop/response-cache': 5.0.1-alpha-20230614122817-14924772(@envelop/core@4.0.0)(graphql@16.6.0)
       graphql: 16.6.0
       graphql-yoga: 4.0.0(graphql@16.6.0)
     transitivePeerDependencies:


### PR DESCRIPTION
This should take some pressure off from `Query.tokenInfo`