### PR TITLE
feat: useYogaHive

### DIFF
--- a/.changeset/fifty-lions-cheat.md
+++ b/.changeset/fifty-lions-cheat.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/client': minor
+---
+
+Add `useYogaHive` plugin for better integration with GraphQL Yoga.

--- a/packages/libraries/client/package.json
+++ b/packages/libraries/client/package.json
@@ -60,7 +60,8 @@
     "@envelop/types": "4.0.0",
     "@types/async-retry": "1.4.5",
     "graphql-yoga": "4.0.1",
-    "nock": "13.3.1"
+    "nock": "13.3.1",
+    "vitest": "0.31.1"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",

--- a/packages/libraries/client/src/client.ts
+++ b/packages/libraries/client/src/client.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { ExecutionArgs, ExecutionResult, GraphQLSchema } from 'graphql';
+import { ExecutionResult, GraphQLSchema } from 'graphql';
 import { createOperationsStore } from './internal/operations-store.js';
 import { createReporting } from './internal/reporting.js';
 import type { HiveClient, HivePluginOptions } from './internal/types.js';
@@ -30,8 +30,8 @@ export function createHive(options: HivePluginOptions): HiveClient {
     schemaReporter.report({ schema });
   }
 
-  function collectUsage(args: ExecutionArgs) {
-    return usage.collect(args);
+  function collectUsage() {
+    return usage.collect();
   }
 
   async function dispose() {

--- a/packages/libraries/client/src/envelop.ts
+++ b/packages/libraries/client/src/envelop.ts
@@ -23,11 +23,11 @@ export function useHive(clientOrOptions: HiveClient | HivePluginOptions): Plugin
       hive.reportSchema({ schema });
     },
     onExecute({ args }) {
-      const complete = hive.collectUsage(args);
+      const complete = hive.collectUsage();
 
       return {
         onExecuteDone({ result }) {
-          complete(result);
+          complete(args, result);
         },
       };
     },

--- a/packages/libraries/client/src/index.ts
+++ b/packages/libraries/client/src/index.ts
@@ -1,5 +1,6 @@
 export type { HivePluginOptions, HiveClient } from './internal/types.js';
 export { useHive } from './envelop.js';
+export { useHive as useYogaHive } from './yoga.js';
 export { hiveApollo, createSupergraphSDLFetcher, createSupergraphManager } from './apollo.js';
 export { createSchemaFetcher, createServicesFetcher } from './gateways.js';
 export { createHive } from './client.js';

--- a/packages/libraries/client/src/internal/types.ts
+++ b/packages/libraries/client/src/internal/types.ts
@@ -6,7 +6,7 @@ import type { SchemaReporter } from './reporting.js';
 export interface HiveClient {
   info(): Promise<void>;
   reportSchema: SchemaReporter['report'];
-  collectUsage(args: ExecutionArgs): CollectUsageCallback;
+  collectUsage(): CollectUsageCallback;
   /**
    * @deprecated https://github.com/kamilkisiela/graphql-hive/issues/659
    */
@@ -22,6 +22,7 @@ export type AbortAction = {
 };
 
 export type CollectUsageCallback = (
+  args: ExecutionArgs,
   result:
     | AsyncIterableIteratorOrValue<GraphQLErrorsResult>
     | AsyncIterableOrValue<GraphQLErrorsResult>

--- a/packages/libraries/client/src/internal/usage.ts
+++ b/packages/libraries/client/src/internal/usage.ts
@@ -1,7 +1,6 @@
 import {
   ArgumentNode,
   DocumentNode,
-  ExecutionArgs,
   GraphQLInputObjectType,
   GraphQLInputType,
   GraphQLInterfaceType,
@@ -46,11 +45,11 @@ import {
 } from './utils.js';
 
 interface UsageCollector {
-  collect(args: ExecutionArgs): CollectUsageCallback;
+  collect(): CollectUsageCallback;
   dispose(): Promise<void>;
 }
 
-function isAbortAction(result: Parameters<CollectUsageCallback>[0]): result is AbortAction {
+function isAbortAction(result: Parameters<CollectUsageCallback>[1]): result is AbortAction {
   return 'action' in result && result.action === 'abort';
 }
 
@@ -151,10 +150,10 @@ export function createUsage(pluginOptions: HivePluginOptions): UsageCollector {
 
   return {
     dispose: agent.dispose,
-    collect(args) {
+    collect() {
       const finish = measureDuration();
 
-      return function complete(result) {
+      return function complete(args, result) {
         try {
           if (isAbortAction(result)) {
             logger.info(result.reason);

--- a/packages/libraries/client/src/yoga.ts
+++ b/packages/libraries/client/src/yoga.ts
@@ -1,0 +1,61 @@
+import { DocumentNode, GraphQLSchema, parse } from 'graphql';
+import type { Plugin } from 'graphql-yoga';
+import LRU from 'tiny-lru';
+import { createHive } from './client.js';
+import type { CollectUsageCallback, HiveClient, HivePluginOptions } from './internal/types.js';
+import { isHiveClient } from './internal/utils.js';
+
+export function useHive(clientOrOptions: HiveClient): Plugin;
+export function useHive(clientOrOptions: HivePluginOptions): Plugin;
+export function useHive(clientOrOptions: HiveClient | HivePluginOptions): Plugin {
+  const hive = isHiveClient(clientOrOptions)
+    ? clientOrOptions
+    : createHive({
+        ...clientOrOptions,
+        agent: {
+          name: 'hive-client-yoga',
+          ...clientOrOptions.agent,
+        },
+      });
+
+  void hive.info();
+
+  const lru = LRU<DocumentNode>(10_000);
+  let latestSchema: GraphQLSchema | null = null;
+  const cache = new WeakMap<Request, CollectUsageCallback>();
+
+  return {
+    onSchemaChange({ schema }) {
+      hive.reportSchema({ schema });
+      latestSchema = schema;
+    },
+    onParams(context) {
+      if (context.params.query && latestSchema) {
+        try {
+          let document = lru.get(context.params.query);
+          if (document === undefined) {
+            document = parse(context.params.query);
+            lru.set(context.params.query, document);
+          }
+          const callback = hive.collectUsage({
+            document,
+            operationName: context.params.operationName,
+            schema: latestSchema,
+          });
+          cache.set(context.request, callback);
+        } catch {
+          // ignore
+        }
+      }
+    },
+    onResultProcess(context) {
+      const callback = cache.get(context.request);
+      if (callback) {
+        // we don't support batching :)
+        if (Array.isArray(context.result) === false) {
+          callback(context.result as any);
+        }
+      }
+    },
+  };
+}

--- a/packages/libraries/client/tests/tsconfig.json
+++ b/packages/libraries/client/tests/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.json",
+  "include": ["."],
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": ".",
+    "target": "es2017",
+    "module": "esnext",
+    "skipLibCheck": true,
+    "types": ["vitest/globals"],
+    "noEmit": true
+  }
+}

--- a/packages/libraries/client/tests/usage.spec.ts
+++ b/packages/libraries/client/tests/usage.spec.ts
@@ -136,14 +136,17 @@ test('should send data to Hive', async () => {
     usage: true,
   });
 
-  const collect = hive.collectUsage({
-    schema,
-    document: op,
-    operationName: 'deleteProject',
-  });
+  const collect = hive.collectUsage();
 
   await waitFor(2000);
-  collect({});
+  collect(
+    {
+      schema,
+      document: op,
+      operationName: 'deleteProject',
+    },
+    {},
+  );
   await hive.dispose();
   await waitFor(1000);
   http.done();
@@ -232,14 +235,17 @@ test('should send data to Hive (deprecated endpoint)', async () => {
     },
   });
 
-  const collect = hive.collectUsage({
-    schema,
-    document: op,
-    operationName: 'deleteProject',
-  });
+  const collect = hive.collectUsage();
 
   await waitFor(2000);
-  collect({});
+  collect(
+    {
+      schema,
+      document: op,
+      operationName: 'deleteProject',
+    },
+    {},
+  );
   await hive.dispose();
   await waitFor(1000);
   http.done();
@@ -309,11 +315,14 @@ test('should not leak the exception', async () => {
     },
   });
 
-  hive.collectUsage({
-    schema,
-    document: op,
-    operationName: 'deleteProject',
-  })({});
+  hive.collectUsage()(
+    {
+      schema,
+      document: op,
+      operationName: 'deleteProject',
+    },
+    {},
+  );
 
   await waitFor(1000);
   await hive.dispose();
@@ -364,15 +373,24 @@ test('sendImmediately should not stop the schedule', async () => {
     },
   });
 
-  const collect = hive.collectUsage({
+  const args = {
     schema,
     document: op,
     operationName: 'deleteProject',
-  });
+  };
+
+  const collect = hive.collectUsage();
 
   expect(logger.info).toHaveBeenCalledTimes(0);
 
-  collect({});
+  collect(
+    {
+      schema,
+      document: op,
+      operationName: 'deleteProject',
+    },
+    {},
+  );
   await waitFor(200);
   // Because maxSize is 2 and sendInterval is 100ms
   // the scheduled send task should be done by now
@@ -384,8 +402,8 @@ test('sendImmediately should not stop the schedule', async () => {
 
   // Now we will check the maxSize
   // We run collect three times
-  collect({});
-  collect({});
+  collect(args, {});
+  collect(args, {});
   expect(logger.error).not.toHaveBeenCalled();
   expect(logger.info).toHaveBeenCalledWith(`[hive][usage] Sending (queue 1) (attempt 1)`);
   expect(logger.info).toHaveBeenCalledWith(`[hive][usage] Sending immediately`);
@@ -398,7 +416,7 @@ test('sendImmediately should not stop the schedule', async () => {
   expect(logger.info).toHaveBeenCalledTimes(5);
 
   // Let's check if the scheduled send task is still running
-  collect({});
+  collect(args, {});
   await waitFor(200);
   expect(logger.error).not.toHaveBeenCalled();
   expect(logger.info).toHaveBeenCalledWith(`[hive][usage] Sending (queue 1) (attempt 1)`);

--- a/packages/libraries/client/tests/yoga.spec.ts
+++ b/packages/libraries/client/tests/yoga.spec.ts
@@ -1,6 +1,9 @@
 import axios from 'axios';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { createSchema, createYoga } from 'graphql-yoga';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import nock from 'nock';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { useResponseCache } from '@graphql-yoga/plugin-response-cache';
 import { useHive } from '../src/yoga.js';
 
@@ -92,7 +95,8 @@ it('reports usage', async () => {
     ],
   });
 
-  await new Promise(async resolve => {
+  // eslint-disable-next-line no-async-promise-executor
+  await new Promise<void>(async resolve => {
     const res = await yoga.fetch('http://localhost/graphql', {
       method: 'POST',
       headers: {
@@ -202,8 +206,8 @@ it('reports usage with response cache', async () => {
       }),
     ],
   });
-
-  await new Promise(async resolve => {
+  // eslint-disable-next-line no-async-promise-executor
+  await new Promise<void>(async resolve => {
     for (const _ of [1, 2, 3]) {
       const res = await yoga.fetch('http://localhost/graphql', {
         method: 'POST',

--- a/packages/libraries/client/tests/yoga.spec.ts
+++ b/packages/libraries/client/tests/yoga.spec.ts
@@ -12,10 +12,6 @@ beforeAll(() => {
 });
 
 it('reports usage', async () => {
-  axios.interceptors.request.use(config => {
-    console.log(config.url);
-    return config;
-  });
   const graphqlScope = nock('http://localhost')
     .post('/graphql')
     .reply(200, {

--- a/packages/libraries/client/tests/yoga.spec.ts
+++ b/packages/libraries/client/tests/yoga.spec.ts
@@ -1,0 +1,227 @@
+import axios from 'axios';
+import { createSchema, createYoga } from 'graphql-yoga';
+import nock from 'nock';
+import { useResponseCache } from '@graphql-yoga/plugin-response-cache';
+import { useHive } from '../src/yoga.js';
+
+beforeAll(() => {
+  nock.cleanAll();
+});
+
+it('reports usage', async () => {
+  axios.interceptors.request.use(config => {
+    console.log(config.url);
+    return config;
+  });
+  const graphqlScope = nock('http://localhost')
+    .post('/graphql')
+    .reply(200, {
+      data: {
+        __typename: 'Query',
+        tokenInfo: {
+          __typename: 'TokenInfo',
+          token: {
+            name: 'brrrt',
+          },
+          organization: {
+            name: 'mom',
+            cleanId: 'ur-mom',
+          },
+          project: {
+            name: 'projecto',
+            type: 'FEDERATION',
+            cleanId: 'projecto',
+          },
+          target: {
+            name: 'projecto',
+            cleanId: 'projecto',
+          },
+          canReportSchema: true,
+          canCollectUsage: true,
+          canReadOperations: true,
+        },
+      },
+    })
+    .post('/usage', body => {
+      expect(body.map).toMatchInlineSnapshot(`
+        {
+          0063ba7bf2695b896c464057aef29cdc: {
+            fields: [
+              Query.hi,
+            ],
+            operation: {hi},
+            operationName: anonymous,
+          },
+        }
+      `);
+
+      return true;
+    })
+    .reply(200);
+  const yoga = createYoga({
+    schema: createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          hi: String
+        }
+      `,
+    }),
+    plugins: [
+      useHive({
+        enabled: true,
+        debug: true,
+        token: 'brrrt',
+        selfHosting: {
+          applicationUrl: 'http://localhost/foo',
+          graphqlEndpoint: 'http://localhost/graphql',
+          usageEndpoint: 'http://localhost/usage',
+        },
+        usage: {
+          endpoint: 'http://localhost/usage',
+          clientInfo() {
+            return {
+              name: 'brrr',
+              version: '1',
+            };
+          },
+        },
+        agent: {
+          maxSize: 1,
+        },
+      }),
+    ],
+  });
+
+  await new Promise(async resolve => {
+    const res = await yoga.fetch('http://localhost/graphql', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: `{ hi }`,
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toMatchInlineSnapshot('{"data":{"hi":null}}');
+
+    setTimeout(() => {
+      graphqlScope.done();
+      resolve();
+    }, 1000);
+  });
+});
+
+it('reports usage with response cache', async () => {
+  axios.interceptors.request.use(config => {
+    console.log(config.url);
+    return config;
+  });
+  let usageCount = 0;
+  const graphqlScope = nock('http://localhost')
+    .post('/graphql')
+    .reply(200, {
+      data: {
+        __typename: 'Query',
+        tokenInfo: {
+          __typename: 'TokenInfo',
+          token: {
+            name: 'brrrt',
+          },
+          organization: {
+            name: 'mom',
+            cleanId: 'ur-mom',
+          },
+          project: {
+            name: 'projecto',
+            type: 'FEDERATION',
+            cleanId: 'projecto',
+          },
+          target: {
+            name: 'projecto',
+            cleanId: 'projecto',
+          },
+          canReportSchema: true,
+          canCollectUsage: true,
+          canReadOperations: true,
+        },
+      },
+    })
+    .post('/usage', body => {
+      usageCount++;
+      expect(body.map).toMatchInlineSnapshot(`
+        {
+          0063ba7bf2695b896c464057aef29cdc: {
+            fields: [
+              Query.hi,
+            ],
+            operation: {hi},
+            operationName: anonymous,
+          },
+        }
+      `);
+
+      return true;
+    })
+    .thrice()
+    .reply(200);
+  const yoga = createYoga({
+    schema: createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          hi: String
+        }
+      `,
+    }),
+    plugins: [
+      useResponseCache({
+        session: () => null,
+        ttl: Infinity,
+      }),
+      useHive({
+        enabled: true,
+        debug: true,
+        token: 'brrrt',
+        selfHosting: {
+          applicationUrl: 'http://localhost/foo',
+          graphqlEndpoint: 'http://localhost/graphql',
+          usageEndpoint: 'http://localhost/usage',
+        },
+        usage: {
+          endpoint: 'http://localhost/usage',
+          clientInfo() {
+            return {
+              name: 'brrr',
+              version: '1',
+            };
+          },
+        },
+        agent: {
+          maxSize: 1,
+        },
+      }),
+    ],
+  });
+
+  await new Promise(async resolve => {
+    for (const _ of [1, 2, 3]) {
+      const res = await yoga.fetch('http://localhost/graphql', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: `{ hi }`,
+        }),
+      });
+      expect(res.status).toBe(200);
+      expect(await res.text()).toEqual('{"data":{"hi":null}}');
+    }
+
+    setTimeout(() => {
+      graphqlScope.done();
+      expect(usageCount).toEqual(3);
+      resolve();
+    }, 1000);
+  });
+});

--- a/packages/services/server/src/graphql-handler.ts
+++ b/packages/services/server/src/graphql-handler.ts
@@ -13,7 +13,7 @@ import { isGraphQLError } from '@envelop/core';
 import { useGenericAuth } from '@envelop/generic-auth';
 import { useGraphQLModules } from '@envelop/graphql-modules';
 import { useSentry } from '@envelop/sentry';
-import { useHive } from '@graphql-hive/client';
+import { useYogaHive } from '@graphql-hive/client';
 import { useResponseCache } from '@graphql-yoga/plugin-response-cache';
 import { HiveError, Registry, RegistryContext } from '@hive/api';
 import { cleanRequestId } from '@hive/service-common';
@@ -191,7 +191,7 @@ export const graphqlHandler = (options: GraphQLHandlerOptions): RouteHandlerMeth
           return null;
         },
       }),
-      useHive({
+      useYogaHive({
         debug: true,
         enabled: !!options.hiveConfig,
         token: options.hiveConfig?.token ?? '',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,6 +429,9 @@ importers:
       nock:
         specifier: 13.3.1
         version: 13.3.1
+      vitest:
+        specifier: 0.31.1
+        version: 0.31.1
     publishDirectory: dist
 
   packages/libraries/core:


### PR DESCRIPTION
### Background

When using the yoga response cache plugin, hive metrics wont be reported with the `useHive` envelop plugin, as the execution phase is skipped.

### Description

This Yoga plugin that acts in the `onParams`  and `onResultProcess` hooks, which are always invoked. This leads to the usage data being always reported.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
