### PR TITLE
feat: insert null instead of empty array

### DIFF
--- a/packages/services/api/src/modules/schema/providers/models/shared.ts
+++ b/packages/services/api/src/modules/schema/providers/models/shared.ts
@@ -109,7 +109,7 @@ export type SchemaCheckFailure = {
     /** Absence means schema changes were skipped. */
     schemaChanges: null | {
       breaking: Array<Change> | null;
-      safe: Array<Change>;
+      safe: Array<Change> | null;
     };
     /** Absence means the schema policy is disabled or wasn't done because composition failed. */
     schemaPolicy: null | {
@@ -264,7 +264,7 @@ export function buildSchemaCheckFailureState(args: {
   const compositionErrors: Array<CompositionFailureError> = [];
   let schemaChanges: null | {
     breaking: Array<Change> | null;
-    safe: Array<Change>;
+    safe: Array<Change> | null;
   } = null;
   let schemaPolicy: null | {
     errors: SchemaCheckWarning[] | null;

--- a/packages/services/api/src/modules/schema/providers/models/single.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single.ts
@@ -127,7 +127,7 @@ export class SingleModel {
       conclusion: SchemaCheckConclusion.Success,
       state: {
         schemaChanges: diffCheck.result?.changes ?? null,
-        schemaPolicyWarnings: policyCheck.result?.warnings ?? [],
+        schemaPolicyWarnings: policyCheck.result?.warnings ?? null,
         composition: {
           compositeSchemaSDL: compositionCheck.result.fullSchemaSdl,
           supergraphSDL: compositionCheck.result.supergraph,

--- a/packages/services/api/src/modules/schema/providers/registry-checks.ts
+++ b/packages/services/api/src/modules/schema/providers/registry-checks.ts
@@ -2,7 +2,7 @@ import { URL } from 'node:url';
 import type { GraphQLSchema } from 'graphql';
 import { Injectable, Scope } from 'graphql-modules';
 import hashObject from 'object-hash';
-import { type Change, CriticalityLevel } from '@graphql-inspector/core';
+import { CriticalityLevel, type Change } from '@graphql-inspector/core';
 import type { CheckPolicyResponse } from '@hive/policy';
 import type { CompositionFailureError } from '@hive/schema';
 import { Schema } from '../../../shared/entities';

--- a/packages/services/api/src/modules/schema/providers/registry-checks.ts
+++ b/packages/services/api/src/modules/schema/providers/registry-checks.ts
@@ -2,7 +2,7 @@ import { URL } from 'node:url';
 import type { GraphQLSchema } from 'graphql';
 import { Injectable, Scope } from 'graphql-modules';
 import hashObject from 'object-hash';
-import { CriticalityLevel, type Change } from '@graphql-inspector/core';
+import { type Change, CriticalityLevel } from '@graphql-inspector/core';
 import type { CheckPolicyResponse } from '@hive/policy';
 import type { CompositionFailureError } from '@hive/schema';
 import { Schema } from '../../../shared/entities';
@@ -301,15 +301,13 @@ export class RegistryChecks {
       safeChanges.push(change);
     }
 
-    const hasBreakingChanges = breakingChanges.length > 0;
-
-    if (hasBreakingChanges) {
+    if (breakingChanges.length > 0) {
       this.logger.debug('Detected breaking changes');
       return {
         status: 'failed',
         reason: {
           breakingChanges,
-          safeChanges,
+          safeChanges: safeChanges.length ? safeChanges : null,
           changes,
         },
       } satisfies CheckResult;
@@ -322,7 +320,7 @@ export class RegistryChecks {
     return {
       status: 'completed',
       result: {
-        changes,
+        changes: changes.length ? changes : null,
       },
     } satisfies CheckResult;
   }


### PR DESCRIPTION
### Background

Nothing major, but after this got deployed we should run these SQL statements.

```sql
UPDATE schema_checks set schema_policy_warnings = NULL where schema_policy_warnings = '[]'::jsonb;
UPDATE schema_checks set safe_schema_changes = NULL where safe_schema_changes = '[]'::jsonb;
```

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
