### PR TITLE
Add ca certificates to base docker images

### DIFF
--- a/docker/app.dockerfile
+++ b/docker/app.dockerfile
@@ -1,5 +1,7 @@
 FROM node:18.16.1-slim
 
+RUN apt-get update && apt-get install -y ca-certificates
+
 ENV NODE_ENV production
 
 WORKDIR /usr/src/app

--- a/docker/cli.dockerfile
+++ b/docker/cli.dockerfile
@@ -1,5 +1,7 @@
 FROM node:18.16.0-slim
 
+RUN apt-get update && apt-get install -y ca-certificates
+
 WORKDIR /usr/src/app
 COPY . /usr/src/app/
 

--- a/docker/migrations.dockerfile
+++ b/docker/migrations.dockerfile
@@ -1,5 +1,7 @@
 FROM node:18.16.1-slim
 
+RUN apt-get update && apt-get install -y ca-certificates
+
 WORKDIR /usr/src/app
 COPY . /usr/src/app/
 


### PR DESCRIPTION
### Background

When deploying hive with using Hashicorp Vault init container, the container fails with error

```
time="2022-10-19T17:58:45Z" level=error msg="failed to request new Vault token" app=vault-env err="Put \"********/login\": x509: certificate signed by unknown authority"
```

### Description

Add CA-certificates to base images
