### PR TITLE
cli: prevent reading a key of undefined value from config file

### DIFF
--- a/.changeset/dirty-adults-clap.md
+++ b/.changeset/dirty-adults-clap.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': patch
+---
+
+prevent reading a key of undefined value from config file

--- a/packages/libraries/cli/src/helpers/config.ts
+++ b/packages/libraries/cli/src/helpers/config.ts
@@ -108,12 +108,18 @@ export class Config {
     }
   }
 
-  get<TKey extends ValidConfigurationKeys>(key: TKey): GetZodValueType<TKey, typeof ConfigModel> {
+  get<TKey extends ValidConfigurationKeys>(
+    key: TKey,
+  ): GetZodValueType<TKey, typeof ConfigModel> | null {
     const map = this.read();
 
     const parts = key.split('.');
     let current: any = map;
     for (const part of parts) {
+      if (current == null) {
+        return null;
+      }
+
       current = current[part];
     }
 


### PR DESCRIPTION
Reading `registry.endpoint` from the config below, results in `Cannot read properties of undefined (reading 'endpoint')`.

```json
{
  "token": "123456",
  "registry": "it should be an object..."
}
```