### PR TITLE
Correcting simple copy typo

### DIFF
--- a/packages/web/docs/src/pages/docs/get-started/single-project.mdx
+++ b/packages/web/docs/src/pages/docs/get-started/single-project.mdx
@@ -294,7 +294,7 @@ Now that you use the basic functionality of Hive as a schema registry, we recomm
 powerful features of Hive:
 
 - [CI/CD Integration](/docs/integrations/ci-cd)
-- [Usage Reporting and Monintoring](/docs/features/usage-reporting)
+- [Usage Reporting and Monitoring](/docs/features/usage-reporting)
 - [Conditional Breaking Changes](/docs/management/targets#conditional-breaking-changes)
 - [Alerts and Notifications](/docs/management/projects#alerts-and-notifications)
 - [Schema Policies](/docs/features/schema-policy)


### PR DESCRIPTION
### Background

The documentation has a simple typo; "Monintoring" is a misspelling of "Monitoring" which this PR corrects

### Description

No major changes, just a simple copy update
