### PR TITLE
Update apollo-router automatically

### DIFF
--- a/.github/workflows/apollo-router-updater.yaml
+++ b/.github/workflows/apollo-router-updater.yaml
@@ -1,0 +1,51 @@
+name: Apollo Router Updater
+on:
+  schedule:
+    # Every 2 hours
+    - cron: '0 */2 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch: {}
+
+jobs:
+  deployment:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+
+      - name: setup environment
+        uses: ./.github/actions/setup
+        with:
+          codegen: false
+          actor: apollo-router-updater
+          cacheNext: false
+          cacheTurbo: false
+
+      - name: Check for updates
+        id: check
+        run: |
+          pnpm tsx ./scripts/apollo-router-action.ts
+
+      - name: Run updates
+        if: steps.check.outputs.update == 'true'
+        run: cargo update -p apollo-router --precise ${{ steps.check.outputs.version }}
+
+      - name: Create Pull Request
+        if: steps.check.outputs.update == 'true'
+        uses: peter-evans/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update apollo-router to version ${{ steps.check.outputs.version }}
+          committer: GitHub <noreply@github.com>
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
+          signoff: false
+          branch: apollo-router-update-${{ steps.check.outputs.version }}
+          delete-branch: true
+          title: ${{ steps.check.outputs.title }}
+          body: |
+            Automatic update of apollo-router to version ${{ steps.check.outputs.version }}.
+          assignees: kamilkisiela
+          reviewers: kamilkisiela
+          draft: false

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "workspace": "pnpm run --filter $1 $2"
   },
   "devDependencies": {
+    "@actions/core": "1.10.0",
     "@changesets/changelog-github": "0.4.8",
     "@changesets/cli": "2.26.2",
     "@graphql-codegen/add": "5.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -49,6 +49,9 @@ importers:
 
   .:
     devDependencies:
+      '@actions/core':
+        specifier: 1.10.0
+        version: 1.10.0
       '@changesets/changelog-github':
         specifier: 0.4.8
         version: 0.4.8
@@ -1846,6 +1849,19 @@ packages:
     dependencies:
       graphql: 16.6.0
     dev: false
+
+  /@actions/core@1.10.0:
+    resolution: {integrity: sha512-2aZDDa3zrrZbP5ZYg159sNoLRb61nQ7awl5pSvIq5Qpj81vwDzdMRKzkWJGJuwVvWpvZKx7vspJALyvaaIQyug==}
+    dependencies:
+      '@actions/http-client': 2.1.0
+      uuid: 8.3.2
+    dev: true
+
+  /@actions/http-client@2.1.0:
+    resolution: {integrity: sha512-BonhODnXr3amchh4qkmjPMUO8mFi/zLaaCeCAJZqch8iQqyDnVIkySjB38VHAC8IJ+bnlgfOqlhpyCUZHlQsqw==}
+    dependencies:
+      tunnel: 0.0.6
+    dev: true
 
   /@algolia/autocomplete-core@1.9.2(@algolia/client-search@4.17.1)(algoliasearch@4.17.1)(search-insights@2.6.0):
     resolution: {integrity: sha512-hkG80c9kx9ClVAEcUJbTd2ziVC713x9Bji9Ty4XJfKXlxlsx3iXsoNhAwfeR4ulzIUg7OE5gez0UU1zVDdG7kg==}
@@ -29276,6 +29292,11 @@ packages:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
     dependencies:
       safe-buffer: 5.2.1
+
+  /tunnel@0.0.6:
+    resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
+    engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
+    dev: true
 
   /turbo-darwin-64@1.10.9:
     resolution: {integrity: sha512-Avz3wsYYb8/vjyHPVRFbNbowIiaF33vcBRklIUkPchTLvZekrT5x3ltQBCflyoi2zJV9g08hK4xXTGuCxeVvPA==}

--- a/scripts/apollo-router-action.ts
+++ b/scripts/apollo-router-action.ts
@@ -1,0 +1,110 @@
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { setOutput } from '@actions/core';
+
+const GITHUB_REPOSITORY = ensureEnv('GITHUB_REPOSITORY');
+
+const [localVersion, latestStableVersion] = await Promise.all([
+  fetchLocalVersion(),
+  fetchLatestVersion(),
+]);
+
+console.log(`Latest stable version: ${latestStableVersion}`);
+console.log(`Local version: ${localVersion}`);
+
+if (localVersion === latestStableVersion) {
+  console.log('Local version is up to date');
+  setOutput('update', 'false');
+  process.exit(0);
+}
+
+console.log('Local version is out of date');
+
+if (await isPullRequestOpen(latestStableVersion)) {
+  console.log(`PR already exists`);
+  setOutput('update', 'false');
+} else {
+  console.log('PR does not exist.');
+  console.log(`Run: cargo update -p apollo-router --precise ${latestStableVersion}`);
+  console.log('Then commit and push the changes.');
+  setOutput('update', 'true');
+  setOutput('version', latestStableVersion);
+}
+
+function ensureEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) {
+    throw new Error(`Missing ${name} environment variable`);
+  }
+
+  return value;
+}
+
+async function fetchLatestVersion() {
+  const versionsResponse = await fetch('https://crates.io/api/v1/crates/apollo-router/versions', {
+    method: 'GET',
+  });
+
+  if (!versionsResponse.ok) {
+    throw new Error('Failed to fetch versions');
+  }
+
+  const { versions } = await versionsResponse.json();
+
+  let latestStableVersion: string | undefined;
+  const stableRegex = /^(\d+\.\d+\.\d+)$/;
+
+  for (const version of versions) {
+    if (!stableRegex.test(version.num)) {
+      continue;
+    }
+
+    latestStableVersion = version.num;
+    break;
+  }
+
+  if (!latestStableVersion) {
+    throw new Error('Failed to find latest stable version');
+  }
+
+  return latestStableVersion;
+}
+
+async function fetchLocalVersion() {
+  const lockFile = await readFile(join(process.cwd(), './Cargo.lock'), 'utf-8');
+
+  const apolloRouterPackage = lockFile
+    .split('[[package]]')
+    .find(pkg => pkg.includes('name = "apollo-router"'));
+
+  if (!apolloRouterPackage) {
+    throw new Error('Failed to find apollo-router package in Cargo.lock');
+  }
+
+  const versionMatch = apolloRouterPackage.match(/version = "(.*)"/);
+
+  if (!versionMatch) {
+    throw new Error('Failed to find version of apollo-router package in Cargo.lock');
+  }
+
+  return versionMatch[1];
+}
+
+async function isPullRequestOpen(latestStableVersion: string) {
+  const prTitle = `Update apollo-router to ${latestStableVersion}`;
+
+  setOutput('title', prTitle);
+
+  const prResponse = await fetch(`https://api.github.com/repos/${GITHUB_REPOSITORY}/pulls`);
+
+  if (!prResponse.ok) {
+    throw new Error('Failed to fetch PRs');
+  }
+
+  const prs: Array<{
+    title: string;
+    html_url: string;
+  }> = await prResponse.json();
+
+  return prs.some(pr => pr.title === prTitle);
+}


### PR DESCRIPTION
This PR adds a cron job (runs every 2 hours but can be triggered manually as well) to check the latest version of `apollo-router` and compare it with the local version from `Cargo.lock`.

If the local version is out of date, a `Cargo.lock` file will be updated and a Pull Request opened.

Current solution (renovate) does not work...