### PR TITLE
add optional s3_session_token variable and remove setting region to auto

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -18,7 +18,7 @@ Integration tests are based pre-built Docker images, so you can run it in 2 mode
 
 #### Running from Source Code
 
-**TL;DR**: Use `pnpm integration:prepare` command to setup the complete environment from locally
+**TL;DR**: Use `pnpm integration:prepare` command to set up the complete environment from locally
 running integration tests. You can ignore the rest of the commands in this section, if this script
 worked for you, and just run `pnpm test:integration` to run the actual tests.
 
@@ -27,32 +27,28 @@ image.
 
 To do so, follow these instructions:
 
-2. Install all deps: `pnpm i`
-3. Generate types: `pnpm graphql:generate`
-4. Build source code: `pnpm build`
-5. Set env vars:
-
-```bash
-export COMMIT_SHA="local"
-export RELEASE="local"
-export BRANCH_NAME="local"
-export BUILD_TYPE=""
-export DOCKER_TAG=":local"
-```
-
-6. Compile a local Docker image by running:
+1. Install all deps: `pnpm i`
+2. Generate types: `pnpm graphql:generate`
+3. Build source code: `pnpm build`
+4. Set env vars:
+   ```bash
+   export COMMIT_SHA="local"
+   export RELEASE="local"
+   export BRANCH_NAME="local"
+   export BUILD_TYPE=""
+   export DOCKER_TAG=":local"
+   ```
+5. Compile a local Docker image by running:
    `docker buildx bake -f docker/docker.hcl integration-tests --load`
-7. Use Docker Compose to run the built containers (based on `community` compose file), along with
+6. Use Docker Compose to run the built containers (based on `community` compose file), along with
    the extra containers:
-
-```bash
-export DOCKER_TAG=":local"
-export DOCKER_REGISTRY=""
-
-docker compose -f ./docker/docker-compose.community.yml -f ./integration-tests/docker-compose.integration.yaml --env-file ./integration-tests/.env up -d --wait
-```
-
-8. Run the tests: `pnpm --filter integration-tests test:integration`
+   ```bash
+   export DOCKER_TAG=":local"
+   export DOCKER_REGISTRY=""
+   
+   docker compose -f ./docker/docker-compose.community.yml -f ./integration-tests/docker-compose.integration.yaml --env-file ./integration-tests/.env up -d --wait
+   ```
+7. Run the tests: `pnpm --filter integration-tests test:integration`
 
 #### Running from Pre-Built Docker Image
 
@@ -65,14 +61,12 @@ To run integration tests locally, from the pre-build Docker image, follow:
 4. Decide on the commit ID / Docker image tag you would like to use (make sure `build-and-dockerize`
    is done successfully)
 5. Set the needed env vars, and use Docker Compose to run all local services:
-
-```bash
-export DOCKER_REGISTRY="ghcr.io/kamilkisiela/graphql-hive/"
-export DOCKER_TAG=":IMAGE_TAG_HERE"
-
-docker compose -f ./docker/docker-compose.community.yml -f ./integration-tests/docker-compose.integration.yaml --env-file ./integration-tests/.env up -d --wait
-```
-
+   ```bash
+   export DOCKER_REGISTRY="ghcr.io/kamilkisiela/graphql-hive/"
+   export DOCKER_TAG=":IMAGE_TAG_HERE"
+   
+   docker compose -f ./docker/docker-compose.community.yml -f ./integration-tests/docker-compose.integration.yaml --env-file ./integration-tests/.env up -d --wait
+   ```
 6. Run the tests: `pnpm --filter integration-tests test:integration`
 
 ## E2E Tests
@@ -90,15 +84,13 @@ To run e2e tests locally, from the local source code, follow:
 3. Generate types: `pnpm graphql:generate`
 4. Build source code: `pnpm build`
 5. Set env vars:
-
-```bash
-export COMMIT_SHA="local"
-export RELEASE="local"
-export BRANCH_NAME="local"
-export BUILD_TYPE=""
-export DOCKER_TAG=":local"
-```
-
+   ```bash
+   export COMMIT_SHA="local"
+   export RELEASE="local"
+   export BRANCH_NAME="local"
+   export BUILD_TYPE=""
+   export DOCKER_TAG=":local"
+   ```
 6. Compile a local Docker image by running: `docker buildx bake -f docker/docker.hcl build --load`
 7. Run the e2e environment, by running:
    `docker compose -f ./docker/docker-compose.community.yml -f ./docker/docker-compose.end2end.yml --env-file ./integration-tests/.env up -d --wait`
@@ -114,12 +106,10 @@ To run integration tests locally, from the pre-build Docker image, follow:
 3. Generate types: `pnpm graphql:generate`
 4. Build source code: `pnpm build`
 5. Decide on the commit ID / Docker image tag you would like to use and set it as env var:
-
-```bash
-export DOCKER_REGISTRY="ghcr.io/kamilkisiela/graphql-hive/"
-export DOCKER_TAG=":IMAGE_TAG_HERE"
-```
-
+   ```bash
+   export DOCKER_REGISTRY="ghcr.io/kamilkisiela/graphql-hive/"
+   export DOCKER_TAG=":IMAGE_TAG_HERE"
+   ```
 6. Run the e2e environment, by running:
    `docker compose -f ./docker/docker-compose.community.yml --env-file ./integration-tests/.env up -d --wait`
 7. Run Cypress: `pnpm test:e2e`
@@ -142,6 +132,6 @@ Keep in mind that integration tests are running a combination of 2 Docker Compos
 If you are having issues with running Docker images, follow these instructions:
 
 1. Make sure you have the latest Docker installed.
-1. Make sure no containers are running (`docker ps` and then `docker stop CONTAINER_ID`).
-1. Delete the local volume used for testing, it's located under `.hive` directory.
-1. Try to run `docker system prune` to clean all the Docker images, containers, networks and caches.
+2. Make sure no containers are running (`docker ps` and then `docker stop CONTAINER_ID`).
+3. Delete the local volume used for testing, it's located under `.hive` directory.
+4. Try to run `docker system prune` to clean all the Docker images, containers, networks and caches.

--- a/packages/services/api/src/create.ts
+++ b/packages/services/api/src/create.ts
@@ -127,6 +127,7 @@ export function createRegistry({
     endpoint: string;
     accessKeyId: string;
     secretAccessKeyId: string;
+    sessionToken?: string;
   };
   encryptionSecret: string;
   feedback: {
@@ -145,8 +146,8 @@ export function createRegistry({
     client: new AwsClient({
       accessKeyId: s3.accessKeyId,
       secretAccessKey: s3.secretAccessKeyId,
+      sessionToken: s3.sessionToken,
       service: 's3',
-      region: 'auto',
     }),
     bucket: s3.bucketName,
     endpoint: s3.endpoint,

--- a/packages/services/cdn-worker/README.md
+++ b/packages/services/cdn-worker/README.md
@@ -6,7 +6,7 @@ Hive comes with a CDN worker (deployed to CF Workers), along with KV cache to st
 
 To run Hive CDN locally, you can use the following command: `pnpm dev`.
 
-> Note: during dev, KV is mocked using JS `Map`, so it's ephermal and will be deleted with any
+> Note: during dev, KV is mocked using JS `Map`, so it's ephemeral and will be deleted with any
 > change in code.
 
 To publish manually a schema, for target id `1`:

--- a/packages/services/cdn-worker/src/index.ts
+++ b/packages/services/cdn-worker/src/index.ts
@@ -11,12 +11,14 @@ import { createIsKeyValid } from './key-validation';
 declare let S3_ENDPOINT: string;
 declare let S3_ACCESS_KEY_ID: string;
 declare let S3_SECRET_ACCESS_KEY: string;
+declare let S3_SESSION_TOKEN: string;
 declare let S3_BUCKET_NAME: string;
 
 const s3 = {
   client: new AwsClient({
     accessKeyId: S3_ACCESS_KEY_ID,
     secretAccessKey: S3_SECRET_ACCESS_KEY,
+    sessionToken: S3_SESSION_TOKEN,
     service: 's3',
   }),
   bucketName: S3_BUCKET_NAME,

--- a/packages/services/server/README.md
+++ b/packages/services/server/README.md
@@ -5,7 +5,7 @@ The GraphQL API for GraphQL Hive.
 ## Configuration
 
 | Name                                        | Required                                       | Description                                                                                   | Example Value                                        |
-| ------------------------------------------- | ---------------------------------------------- | --------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
+|---------------------------------------------|------------------------------------------------| --------------------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | `PORT`                                      | **Yes**                                        | The port this service is running on.                                                          | `4013`                                               |
 | `ENCRYPTION_SECRET`                         | **Yes**                                        | Secret for encrypting stuff.                                                                  | `8ebe95cg21c1fee355e9fa32c8c33141`                   |
 | `WEB_APP_URL`                               | **Yes**                                        | The url of the web app.                                                                       | `http://127.0.0.1:3000`                              |
@@ -33,6 +33,7 @@ The GraphQL API for GraphQL Hive.
 | `S3_ACCESS_KEY_ID`                          | **Yes**                                        | The S3 access key id.                                                                         | `minioadmin`                                         |
 | `S3_SECRET_ACCESS_KEY`                      | **Yes**                                        | The S3 secret access key.                                                                     | `minioadmin`                                         |
 | `S3_BUCKET_NAME`                            | **Yes**                                        | The S3 bucket name.                                                                           | `artifacts`                                          |
+| `S3_SESSION_TOKEN`                          | No                                             | The S3 session token.                                                                         | `dummytoken`                                         |
 | `S3_PUBLIC_URL`                             | No                                             | The public URL of the S3, in case it differs from the `S#_ENDPOINT`.                          | `http://localhost:8083`                              |
 | `CDN_API`                                   | No                                             | Whether the CDN exposed via API is enabled.                                                   | `1` (enabled) or `0` (disabled)                      |
 | `CDN_API_BASE_URL`                          | No (Yes if `CDN_API` is set to `1`)            | The public base url of the API service.                                                       | `http://localhost:8082`                              |

--- a/packages/services/server/src/environment.ts
+++ b/packages/services/server/src/environment.ts
@@ -139,6 +139,7 @@ const S3Model = zod.object({
   S3_ENDPOINT: zod.string().url(),
   S3_ACCESS_KEY_ID: zod.string(),
   S3_SECRET_ACCESS_KEY: zod.string(),
+  S3_SESSION_TOKEN: emptyString(zod.string().optional()),
   S3_BUCKET_NAME: zod.string(),
   S3_PUBLIC_URL: emptyString(zod.string().url().optional()),
 });
@@ -328,6 +329,7 @@ export const env = {
     credentials: {
       accessKeyId: s3.S3_ACCESS_KEY_ID,
       secretAccessKey: s3.S3_SECRET_ACCESS_KEY,
+      sessionToken: s3.S3_SESSION_TOKEN
     },
   },
   organizationOIDC: base.AUTH_ORGANIZATION_OIDC === '1',

--- a/packages/services/server/src/index.ts
+++ b/packages/services/server/src/index.ts
@@ -214,6 +214,7 @@ export async function main() {
       s3: {
         accessKeyId: env.s3.credentials.accessKeyId,
         secretAccessKeyId: env.s3.credentials.secretAccessKey,
+        sessionToken: env.s3.credentials.sessionToken,
         bucketName: env.s3.bucketName,
         endpoint: env.s3.endpoint,
       },


### PR DESCRIPTION
### Background
This fixes an issue when using graphql-hive with aws s3 as the artifact storage provider.

### Description

Adding a way to pass the optional S3_SESSION_TOKEN variable. This should not change any existing behavior.

Also removing setting the region to 'auto'  while creating the AWS client. The region should be guessed correctly via:
https://github.com/kamilkisiela/graphql-hive/blob/d6c417837d9bcd80412d1b2283244d0dbf9e3649/packages/services/cdn-worker/src/aws.ts#L413

nit: added some indentation fixes to the Testing readme file.


By the way, this is a great project! 
