### PR TITLE
Improvements to error handling in Yoga

### DIFF
--- a/packages/services/server/src/graphql-handler.ts
+++ b/packages/services/server/src/graphql-handler.ts
@@ -5,7 +5,16 @@ import type {
   FastifyRequest,
   RouteHandlerMethod,
 } from 'fastify';
-import { DocumentNode, GraphQLError, print, ValidationContext, ValidationRule } from 'graphql';
+import {
+  DocumentNode,
+  GraphQLError,
+  Kind,
+  print,
+  ValidationContext,
+  ValidationRule,
+  type DefinitionNode,
+  type OperationDefinitionNode,
+} from 'graphql';
 import { createYoga, Plugin, useErrorHandler } from 'graphql-yoga';
 import hyperid from 'hyperid';
 import zod from 'zod';
@@ -129,7 +138,11 @@ export const graphqlHandler = (options: GraphQLHandlerOptions): RouteHandlerMeth
         configureScope(args, scope) {
           const transaction = scope.getTransaction();
 
-          // Reduce the number of transactions to avoid overloading Sentry
+          // Get the operation name from the request, or use the operation name from the document.
+          const operationName =
+            args.operationName ??
+            args.document.definitions.find(isOperationDefinitionNode)?.name?.value ??
+            'unknown';
           const ctx = args.contextValue as Context;
           const clientNameHeaderValue = ctx.req.headers['graphql-client-name'];
           const clientName = Array.isArray(clientNameHeaderValue)
@@ -137,14 +150,15 @@ export const graphqlHandler = (options: GraphQLHandlerOptions): RouteHandlerMeth
             : clientNameHeaderValue;
 
           if (transaction) {
-            transaction.setName(`graphql.${args.operationName || 'unknown'}`);
+            transaction.setName(`graphql.${operationName}`);
             transaction.setTag('graphql_client_name', clientName ?? 'unknown');
+            // Reduce the number of transactions to avoid overloading Sentry
             transaction.sampled = !!clientName && clientName !== 'Hive Client';
           }
 
           scope.setContext('Extra Info', {
+            operationName,
             variables: JSON.stringify(args.variableValues),
-            operationName: args.operationName,
             operation: print(args.document),
             userId: extractUserId(args.contextValue as any),
           });
@@ -165,15 +179,21 @@ export const graphqlHandler = (options: GraphQLHandlerOptions): RouteHandlerMeth
       }),
       useSentryUser(),
       useErrorHandler(({ errors, context }): void => {
+        // Not sure what changed, but the `context` is now an object with a contextValue property.
+        // We previously relied on the `context` being the `contextValue` itself.
+        const ctx = ('contextValue' in context ? context.contextValue : context) as Context;
+
         for (const error of errors) {
           if (isGraphQLError(error) && error.originalError) {
-            console.log(error);
-            console.log(error.originalError);
+            console.error(error);
+            console.error(error.originalError);
             continue;
+          } else {
+            console.error(error);
           }
 
-          if (hasFastifyRequest(context)) {
-            context.req.log.error(error);
+          if (hasFastifyRequest(ctx)) {
+            ctx.req.log.error(error);
           } else {
             server.logger.error(error);
           }
@@ -355,4 +375,8 @@ async function verifySuperTokensSession(
     ...sessionInfo,
     externalUserId: sessionInfo.externalUserId ?? null,
   };
+}
+
+function isOperationDefinitionNode(def: DefinitionNode): def is OperationDefinitionNode {
+  return def.kind === Kind.OPERATION_DEFINITION;
 }

--- a/packages/web/app/src/components/ui/query-error.tsx
+++ b/packages/web/app/src/components/ui/query-error.tsx
@@ -36,7 +36,7 @@ export function QueryError({
           <h1 className="text-xl font-semibold">Oops, something went wrong.</h1>
           <div className="mt-2">
             {shouldShowError ? (
-              <div className="text-sm">{error?.message?.replace('[GraphQL] ', '')}</div>
+              <div className="text-sm">{error.graphQLErrors[0].message}</div>
             ) : (
               <div className="text-sm">
                 <p>Don't worry, our technical support got this error reported automatically.</p>


### PR DESCRIPTION
+ extract operation name from DocumentNode if not available on the request object
+ show only the first error message from `result.errors[]` instead of using `CombinedError` class from URQL (it combines error messages and usually they are more than one and we end up with duplicates)