### PR TITLE
Parse persisted operations with noLocation

### DIFF
--- a/packages/services/server/scripts/copy-persisted-operations.mts
+++ b/packages/services/server/scripts/copy-persisted-operations.mts
@@ -26,7 +26,12 @@ await fs.writeFile(
   persistedOperationsDistPath,
   JSON.stringify(
     Object.fromEntries(
-      Object.entries(persistedOperations).map(([hash, document]) => [hash, parse(document)]),
+      Object.entries(persistedOperations).map(([hash, document]) => [
+        hash,
+        parse(document, {
+          noLocation: true,
+        }),
+      ]),
     ),
     null,
     2,


### PR DESCRIPTION
Fixes an issue with `TypeError: Cannot read properties of undefined (reading 'body') at getLocation`