### PR TITLE
feat: bring back the lab mock api

### DIFF
--- a/packages/services/api/src/create.ts
+++ b/packages/services/api/src/create.ts
@@ -17,6 +17,7 @@ import {
   GITHUB_APP_CONFIG,
   GitHubApplicationConfig,
 } from './modules/integrations/providers/github-integration-manager';
+import { labModule } from './modules/lab';
 import { oidcIntegrationsModule } from './modules/oidc-integrations';
 import { OIDC_INTEGRATIONS_ENABLED } from './modules/oidc-integrations/providers/tokens';
 import { operationsModule } from './modules/operations';
@@ -73,6 +74,7 @@ const modules = [
   operationsModule,
   tokenModule,
   persistedOperationModule,
+  labModule,
   integrationsModule,
   alertsModule,
   feedbackModule,

--- a/packages/services/api/src/modules/lab/index.ts
+++ b/packages/services/api/src/modules/lab/index.ts
@@ -1,0 +1,11 @@
+import { createModule } from 'graphql-modules';
+import { resolvers } from './resolvers';
+import typeDefs from './module.graphql';
+
+export const labModule = createModule({
+  id: 'lab',
+  dirname: __dirname,
+  typeDefs,
+  resolvers,
+  providers: [],
+});

--- a/packages/services/api/src/modules/lab/module.graphql.ts
+++ b/packages/services/api/src/modules/lab/module.graphql.ts
@@ -1,0 +1,11 @@
+import { gql } from 'graphql-modules';
+
+export default gql`
+  extend type Query {
+    lab(selector: TargetSelectorInput!): Lab
+  }
+  type Lab {
+    schema: String!
+    mocks: JSON
+  }
+`;

--- a/packages/services/api/src/modules/lab/resolvers.ts
+++ b/packages/services/api/src/modules/lab/resolvers.ts
@@ -1,0 +1,67 @@
+import { AuthManager } from '../auth/providers/auth-manager';
+import { TargetAccessScope } from '../auth/providers/target-access';
+import { ProjectManager } from '../project/providers/project-manager';
+import { ensureSDL, SchemaHelper } from '../schema/providers/schema-helper';
+import { SchemaManager } from '../schema/providers/schema-manager';
+import { IdTranslator } from '../shared/providers/id-translator';
+import type { LabModule } from './__generated__/types';
+
+export const resolvers: LabModule.Resolvers = {
+  Query: {
+    async lab(_, { selector }, { injector }) {
+      const translator = injector.get(IdTranslator);
+      const [organization, project, target] = await Promise.all([
+        translator.translateOrganizationId(selector),
+        translator.translateProjectId(selector),
+        translator.translateTargetId(selector),
+      ]);
+
+      await injector.get(AuthManager).ensureTargetAccess({
+        organization,
+        project,
+        target,
+        scope: TargetAccessScope.REGISTRY_READ,
+      });
+
+      const schemaManager = injector.get(SchemaManager);
+
+      const latestSchema = await schemaManager.getMaybeLatestValidVersion({
+        organization,
+        project,
+        target,
+      });
+
+      if (!latestSchema) {
+        return null;
+      }
+
+      const [schemas, { type, externalComposition }] = await Promise.all([
+        schemaManager.getSchemasOfVersion({
+          organization,
+          project,
+          target,
+          version: latestSchema.id,
+        }),
+        injector.get(ProjectManager).getProject({
+          organization,
+          project,
+        }),
+      ]);
+
+      const orchestrator = schemaManager.matchOrchestrator(type);
+      const helper = injector.get(SchemaHelper);
+
+      const schema = await ensureSDL(
+        orchestrator.composeAndValidate(
+          schemas.map(s => helper.createSchemaObject(s)),
+          externalComposition,
+        ),
+      );
+
+      return {
+        schema: schema.raw,
+        mocks: {},
+      };
+    },
+  },
+};

--- a/packages/web/app/package.json
+++ b/packages/web/app/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@graphiql/react": "0.18.0-alpha.0",
     "@graphiql/toolkit": "0.8.4",
+    "@graphql-tools/mock": "9.0.0",
     "@headlessui/react": "1.7.15",
     "@monaco-editor/react": "4.5.1",
     "@n1ru4l/react-time-ago": "1.1.0",

--- a/packages/web/app/package.json
+++ b/packages/web/app/package.json
@@ -35,6 +35,7 @@
     "@radix-ui/react-toggle-group": "1.0.4",
     "@radix-ui/react-toolbar": "1.0.4",
     "@radix-ui/react-tooltip": "1.0.6",
+    "@repeaterjs/repeater": "3.0.4",
     "@sentry/nextjs": "7.59.3",
     "@sentry/types": "7.59.3",
     "@stripe/react-stripe-js": "2.1.1",

--- a/packages/web/app/pages/[orgId]/[projectId]/[targetId]/laboratory.tsx
+++ b/packages/web/app/pages/[orgId]/[projectId]/[targetId]/laboratory.tsx
@@ -10,6 +10,7 @@ import { CreateCollectionModal } from '@/components/target/laboratory/create-col
 import { CreateOperationModal } from '@/components/target/laboratory/create-operation-modal';
 import { DeleteCollectionModal } from '@/components/target/laboratory/delete-collection-modal';
 import { DeleteOperationModal } from '@/components/target/laboratory/delete-operation-modal';
+import { Button } from '@/components/ui/button';
 import { Subtitle, Title } from '@/components/ui/page';
 import {
   Accordion,
@@ -21,7 +22,6 @@ import {
   ToggleGroupItem,
   Tooltip,
 } from '@/components/v2';
-import { Button } from '@/components/v2/button';
 import { HiveLogo, PlusIcon, SaveIcon, ShareIcon } from '@/components/v2/icon';
 import { graphql } from '@/gql';
 import { TargetAccessScope } from '@/gql/graphql';
@@ -659,6 +659,7 @@ const TargetLaboratoryPageQuery = graphql(`
       ...TargetLayout_MeFragment
     }
     ...TargetLayout_IsCDNEnabledFragment
+    ...Laboratory_IsCDNEnabledFragment
   }
 `);
 
@@ -772,13 +773,13 @@ function LaboratoryPageContent() {
               <NextLink
                 href={`/${router.organizationId}/${router.projectId}/${router.targetId}/settings`}
               >
-                <Button variant="primary" className="mr-2">
+                <Button variant="outline" className="mr-2" size="sm">
                   Connect GraphQL API Endpoint
                 </Button>
               </NextLink>
             ) : null}
-            <Button variant="primary" onClick={toggleConnectLabModal}>
-              Consume Mock Schema externally
+            <Button onClick={toggleConnectLabModal} variant="ghost" size="sm">
+              Mock Data Endpoint
             </Button>
           </div>
           <div className="self-end pt-2">
@@ -883,6 +884,7 @@ function LaboratoryPageContent() {
         endpoint={mockEndpoint}
         close={toggleConnectLabModal}
         isOpen={isConnectLabModalOpen}
+        isCDNEnabled={query.data ?? null}
       />
     </TargetLayout>
   );

--- a/packages/web/app/pages/api/lab/[...lab].ts
+++ b/packages/web/app/pages/api/lab/[...lab].ts
@@ -1,0 +1,110 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { buildSchema, execute, GraphQLError, parse } from 'graphql';
+import { env } from '@/env/backend';
+import { extractAccessTokenFromRequest } from '@/lib/api/extract-access-token-from-request';
+import { addMocksToSchema } from '@graphql-tools/mock';
+
+async function lab(req: NextApiRequest, res: NextApiResponse) {
+  const url = env.graphqlEndpoint;
+  const labParams = req.query.lab || [];
+
+  if (labParams.length < 3) {
+    res.status(400).json({
+      error: 'Missing Lab Params',
+    });
+    return;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [organization, project, target, mock] = labParams as string[];
+  const headers: Record<string, string> = {};
+
+  if (req.headers['x-hive-key']) {
+    // TODO: change that to Authorization: Bearer
+    headers['X-API-Token'] = req.headers['x-hive-key'] as string;
+  } else {
+    try {
+      const accessToken = await extractAccessTokenFromRequest(req, res);
+
+      if (!accessToken) {
+        throw 'Invalid Token!';
+      }
+
+      headers['Authorization'] = `Bearer ${accessToken}`;
+    } catch (error) {
+      console.warn('Lab auth failed:', error);
+      res.status(200).send({
+        errors: [new GraphQLError('Invalid or missing X-Hive-Key authentication')],
+      });
+      return;
+    }
+  }
+
+  const body = {
+    operationName: 'lab',
+    query: /* GraphQL */ `
+      query lab($selector: TargetSelectorInput!) {
+        lab(selector: $selector) {
+          schema
+          mocks
+        }
+      }
+    `,
+    variables: {
+      selector: {
+        organization,
+        project,
+        target,
+      },
+    },
+  };
+
+  const response = await fetch(url, {
+    headers: {
+      'content-type': 'application/json',
+      ...headers,
+    },
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+
+  const parsedData = await response.json();
+
+  if (!parsedData.data?.lab?.schema) {
+    res.status(200).json({
+      errors: [new GraphQLError('Please publish your first schema to Hive')],
+    });
+
+    return;
+  }
+
+  if (parsedData.data?.errors?.length > 0) {
+    res.status(200).json(parsedData.data);
+  }
+
+  try {
+    const rawSchema = buildSchema(parsedData.data.lab?.schema);
+    const document = parse(req.body.query);
+
+    const mockedSchema = addMocksToSchema({
+      schema: rawSchema,
+      preserveResolvers: false,
+    });
+
+    const result = await execute({
+      schema: mockedSchema,
+      document,
+      variableValues: req.body.variables || {},
+      contextValue: {},
+    });
+
+    res.status(200).json(result);
+  } catch (e) {
+    console.log(e);
+    res.status(200).json({
+      errors: [e],
+    });
+  }
+}
+
+export default lab;

--- a/packages/web/app/src/components/layouts/target.tsx
+++ b/packages/web/app/src/components/layouts/target.tsx
@@ -265,7 +265,7 @@ export const TargetLayout = ({
             // eslint-disable-next-line unicorn/no-negated-condition
             connect != null ? (
               connect
-            ) : isCDNEnabled ? (
+            ) : isCDNEnabled?.isCDNEnabled ? (
               <>
                 <Button onClick={toggleModalOpen} variant="link" className="text-orange-500">
                   <Link size={16} className="mr-2" />

--- a/packages/web/app/src/components/target/laboratory/connect-lab-modal.tsx
+++ b/packages/web/app/src/components/target/laboratory/connect-lab-modal.tsx
@@ -1,13 +1,24 @@
 import { type ReactElement } from 'react';
-import { Button, CopyValue, Heading, Link, Modal, Tag } from '@/components/v2';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import { CopyValue, Heading, Link, Modal, Tag } from '@/components/v2';
+import { FragmentType, graphql, useFragment } from '@/gql';
 import { getDocsUrl } from '@/lib/docs-url';
+
+const Laboratory_IsCDNEnabledFragment = graphql(`
+  fragment Laboratory_IsCDNEnabledFragment on Query {
+    isCDNEnabled
+  }
+`);
 
 export const ConnectLabModal = (props: {
   isOpen: boolean;
   close: () => void;
   endpoint: string;
+  isCDNEnabled: FragmentType<typeof Laboratory_IsCDNEnabledFragment> | null;
 }): ReactElement => {
   const docsUrl = getDocsUrl('/management/targets#registry-access-tokens') || '';
+  const isCDNEnabled = useFragment(Laboratory_IsCDNEnabledFragment, props.isCDNEnabled);
 
   return (
     <Modal open={props.isOpen} onOpenChange={props.close} className="flex w-[750px] flex-col gap-5">
@@ -16,6 +27,15 @@ export const ConnectLabModal = (props: {
         Hive allow you to consume and use the Laboratory schema with your configured mocks while
         developing.
       </p>
+      {isCDNEnabled?.isCDNEnabled ? (
+        <Alert>
+          <AlertTitle>High-availability CDN</AlertTitle>
+          <AlertDescription>
+            If you want to consume the GraphQL schema for a tool like GraphQL Code Generator, we
+            instead recommend using the high-availability CDN instead.
+          </AlertDescription>
+        </Alert>
+      ) : null}
       <span className="text-sm text-gray-500">You can use the following endpoint:</span>
       <CopyValue value={props.endpoint} />
       <span className="text-sm text-gray-500">
@@ -34,13 +54,7 @@ export const ConnectLabModal = (props: {
         </Link>{' '}
         chapter in our documentation to create a Registry Access Token.
       </p>
-      <Button
-        type="button"
-        variant="secondary"
-        size="large"
-        onClick={props.close}
-        className="self-end"
-      >
+      <Button type="button" size="lg" onClick={props.close} className="self-end">
         Close
       </Button>
     </Modal>

--- a/packages/web/app/src/components/target/laboratory/connect-lab-modal.tsx
+++ b/packages/web/app/src/components/target/laboratory/connect-lab-modal.tsx
@@ -1,0 +1,48 @@
+import { type ReactElement } from 'react';
+import { Button, CopyValue, Heading, Link, Modal, Tag } from '@/components/v2';
+import { getDocsUrl } from '@/lib/docs-url';
+
+export const ConnectLabModal = (props: {
+  isOpen: boolean;
+  close: () => void;
+  endpoint: string;
+}): ReactElement => {
+  const docsUrl = getDocsUrl('/management/targets#registry-access-tokens') || '';
+
+  return (
+    <Modal open={props.isOpen} onOpenChange={props.close} className="flex w-[750px] flex-col gap-5">
+      <Heading className="text-center">Use GraphQL Schema Externally</Heading>
+      <p className="text-sm text-gray-500">
+        Hive allow you to consume and use the Laboratory schema with your configured mocks while
+        developing.
+      </p>
+      <span className="text-sm text-gray-500">You can use the following endpoint:</span>
+      <CopyValue value={props.endpoint} />
+      <span className="text-sm text-gray-500">
+        To authenticate, use the following HTTP headers, with a token that has `target:read` scope:
+      </span>
+      <Tag>
+        X-Hive-Key:{' '}
+        <Link variant="secondary" target="_blank" rel="noreferrer" href={docsUrl}>
+          YOUR_TOKEN_HERE
+        </Link>
+      </Tag>
+      <p className="text-sm text-gray-500">
+        Read the{' '}
+        <Link variant="primary" target="_blank" rel="noreferrer" href={docsUrl}>
+          Managing Tokens
+        </Link>{' '}
+        chapter in our documentation to create a Registry Access Token.
+      </p>
+      <Button
+        type="button"
+        variant="secondary"
+        size="large"
+        onClick={props.close}
+        className="self-end"
+      >
+        Close
+      </Button>
+    </Modal>
+  );
+};

--- a/packages/web/app/src/components/ui/alert.tsx
+++ b/packages/web/app/src/components/ui/alert.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const alertVariants = cva(
+  'relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground',
+  {
+    variants: {
+      variant: {
+        default: 'bg-background text-foreground',
+        destructive:
+          'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  },
+);
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div ref={ref} role="alert" className={cn(alertVariants({ variant }), className)} {...props} />
+));
+Alert.displayName = 'Alert';
+
+const AlertTitle = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLHeadingElement>>(
+  ({ className, ...props }, ref) => (
+    // eslint-disable-next-line jsx-a11y/heading-has-content
+    <h5
+      ref={ref}
+      className={cn('mb-1 font-medium leading-none tracking-tight', className)}
+      {...props}
+    />
+  ),
+);
+AlertTitle.displayName = 'AlertTitle';
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('text-sm [&_p]:leading-relaxed', className)} {...props} />
+));
+AlertDescription.displayName = 'AlertDescription';
+
+export { Alert, AlertTitle, AlertDescription };

--- a/packages/web/app/src/lib/hooks/use-reset-state.ts
+++ b/packages/web/app/src/lib/hooks/use-reset-state.ts
@@ -1,0 +1,55 @@
+import React, { Dispatch, SetStateAction } from 'react';
+
+// check whether all array items are equal
+const isEqual = (a: Array<unknown>, b: Array<unknown>) => {
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+};
+
+// returns a stateful value, that reinitializes once the dependencyList changes
+export const useResetState = <T>(
+  initialValueOrCreateValue: T | (() => T),
+  dependencyList: Array<unknown> = [],
+): [T, (value: T | ((value: T) => T)) => void] => {
+  // eslint-disable-next-line react/hook-use-state
+  const [, triggerRerender] = React.useState(0);
+  const stateRef = React.useRef({
+    state:
+      initialValueOrCreateValue instanceof Function
+        ? initialValueOrCreateValue()
+        : initialValueOrCreateValue,
+    deps: dependencyList,
+  });
+
+  // check if any of the dependencies has changed
+  // if so -> recreate state without causing an additional re-render
+  if (!isEqual(stateRef.current.deps, dependencyList)) {
+    stateRef.current.state =
+      initialValueOrCreateValue instanceof Function
+        ? initialValueOrCreateValue()
+        : initialValueOrCreateValue;
+    stateRef.current.deps = dependencyList;
+  }
+
+  // setState re-implementation that changes the ref and forces a re-render
+  const setState = React.useCallback<Dispatch<SetStateAction<T>>>(
+    newState => {
+      const oldState = stateRef.current.state;
+      if (newState instanceof Function) {
+        stateRef.current.state = newState(stateRef.current.state);
+      } else {
+        stateRef.current.state = newState;
+      }
+      // do not trigger render in case the state has not changed
+      if (oldState === stateRef.current.state) return;
+      triggerRerender(i => i + 1);
+    },
+    [triggerRerender],
+  );
+
+  return [stateRef.current.state, setState];
+};

--- a/packages/web/docs/src/pages/docs/features/laboratory.mdx
+++ b/packages/web/docs/src/pages/docs/features/laboratory.mdx
@@ -26,3 +26,67 @@ You can set the GraphQL endpoint URL within the target settings.
 Afterwards you can execute queries against your actual GraphQL API. Please make sure to set the
 according CORS headers on your server for allowing the Laboratory to access your API from within the
 browser.
+
+## Built-in Mocks
+
+You may execute operations directly from the built-in GraphQL, and the results will be fully
+mocked - powered by
+[GraphQL-Tools mocking capabilities](https://the-guild.dev/graphql/tools/docs/mocking).
+
+Hive allow you to consume and use the Laboratory schema with your configured mocks while developing,
+without running any GraphQL server or gateway.
+
+1. [Up-to-date GraphQL Introspection](https://graphql.org/learn/introspection/) for using with
+   develpoment tools.
+2. Mocks for executed GraphQL operations.
+
+### Mock Endpoint
+
+To get started with using the Laboratory mock schema externally, create a
+[Registry Access Token](/docs/management/targets#registry-access-tokens). You only need to have the
+`read` access to the target (or, use the **Schema Check Only** preset).
+
+Now, click on the **Use Schema Externally** button on the Laboratory page, and follow the
+instructions on the form:
+
+<NextImage alt="Lab Form" src={labFormImage} className="mt-6 max-w-xl drop-shadow-md" />
+
+To test access to your setup, try running a `curl` command to run a simple GraphQL query against
+your mocked schema:
+
+```bash
+curl -X POST -H "X-Hive-Key: HIVE_TOKEN_HERE" -H "Content-Type: application/json" \
+  LAB_ENDPOINT_HERE \
+  --data-raw '{"query": "{ __typename }"}'
+```
+
+### With GraphQL-Code-Generator
+
+<Callout>
+  We recommend using the CDN for consuming the GraphQL schema in your project. [See GraphQL Code
+  Generator Integration](/docs/integrations/graphql-code-generator).
+</Callout>
+
+Since the Laboratory schema is a valid GraphQL schema, and supports introspection, you may use it
+directly with tools like [GraphQL-Code-Generator](https://the-guild.dev/graphql/codegen). Here's a
+snippet for using it in a project:
+
+```ts filename="codegen.ts"
+import { CodegenConfig } from '@graphql-codegen/cli'
+
+const labEndpoint = 'LAB_ENDPOINT_HERE'
+const labToken = process.env.HIVE_LAB_TOKEN
+
+const config: CodegenConfig = {
+  schema: [
+    {
+      [labEndpoint]: {
+        headers: {
+          'X-Hive-Key': labToken
+        }
+      }
+    }
+  ]
+}
+export default config
+```

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1516,6 +1516,9 @@ importers:
       '@radix-ui/react-tooltip':
         specifier: 1.0.6
         version: 1.0.6(@types/react-dom@18.2.7)(@types/react@18.2.15)(react-dom@18.2.0)(react@18.2.0)
+      '@repeaterjs/repeater':
+        specifier: 3.0.4
+        version: 3.0.4
       '@sentry/nextjs':
         specifier: 7.59.3
         version: 7.59.3(next@13.4.11)(react@18.2.0)(webpack@5.75.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1459,6 +1459,9 @@ importers:
       '@graphiql/toolkit':
         specifier: 0.8.4
         version: 0.8.4(@types/node@18.16.19)(graphql@16.6.0)
+      '@graphql-tools/mock':
+        specifier: 9.0.0
+        version: 9.0.0(graphql@16.6.0)
       '@headlessui/react':
         specifier: 1.7.15
         version: 1.7.15(react-dom@18.2.0)(react@18.2.0)
@@ -7219,6 +7222,19 @@ packages:
       '@graphql-tools/utils': 10.0.3(graphql@16.6.0)
       graphql: 16.6.0
       tslib: 2.5.3
+
+  /@graphql-tools/mock@9.0.0(graphql@16.6.0):
+    resolution: {integrity: sha512-Vbb4RNTT9T3fXjmzACcflOh79vKBaC/J21eCJ0eug1ZdaM2QXVHQ3lxE6HNOlAENHXjwJINz1AnKsvF3bpeSKA==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
+    dependencies:
+      '@graphql-tools/schema': 10.0.0(graphql@16.6.0)
+      '@graphql-tools/utils': 10.0.3(graphql@16.6.0)
+      fast-json-stable-stringify: 2.1.0
+      graphql: 16.6.0
+      tslib: 2.5.3
+    dev: false
 
   /@graphql-tools/optimize@2.0.0(graphql@16.6.0):
     resolution: {integrity: sha512-nhdT+CRGDZ+bk68ic+Jw1OZ99YCDIKYA5AlVAnBHJvMawSx9YQqQAIj4refNc1/LRieGiuWvhbG3jvPVYho0Dg==}


### PR DESCRIPTION
### Background

We removed the laboratory mock API, as we thought nobody uses it. Actually, it is used. So we bring it back.

### Description

Closes https://github.com/kamilkisiela/graphql-hive/issues/2686

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
