### PR TITLE
feat: apply data retention constraint on schema checks

### DIFF
--- a/packages/migrations/src/actions/2023.08.01T11.44.36.schema-checks-expires-at.ts
+++ b/packages/migrations/src/actions/2023.08.01T11.44.36.schema-checks-expires-at.ts
@@ -1,0 +1,14 @@
+import { type MigrationExecutor } from '../pg-migrator';
+
+export default {
+  name: '2023.08.01T11.44.36.schema-checks-expires-at.ts',
+  run: ({ sql }) => sql`
+    ALTER TABLE "public"."schema_checks"
+      ADD COLUMN "expires_at" TIMESTAMP WITH TIME ZONE
+    ;
+
+    CREATE INDEX
+      "schema_checks_expires_at_pagination" ON "public"."schema_checks" ("expires_at" ASC)
+    ;
+  `,
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -49,6 +49,7 @@ import migration_2023_05_12T08_29_06_store_supergraph_on_schema_versions from '.
 import migration_2023_06_01T09_07_53_create_collections from './actions/2023.06.01T09.07.53.create_collections';
 import migration_2023_06_06T11_26_04_schema_checks from './actions/2023.06.06T11.26.04.schema-checks';
 import migration_2023_07_10T11_26_04_schema_checks_manual_approval from './actions/2023.07.10T11.26.04.schema-checks-manual-approval';
+import migration_2023_08_01T11_44_36_schema_checks_expires_at from './actions/2023.08.01T11.44.36.schema-checks-expires-at';
 import { runMigrations } from './pg-migrator';
 
 export const runPGMigrations = (args: { slonik: DatabasePool; runTo?: string }) =>
@@ -106,5 +107,6 @@ export const runPGMigrations = (args: { slonik: DatabasePool; runTo?: string }) 
       migration_2023_06_06T11_26_04_schema_checks,
       migration_2023_07_10T11_26_04_schema_checks_manual_approval,
       migration_2023_07_27T11_44_36_graphql_endpoint,
+      migration_2023_08_01T11_44_36_schema_checks_expires_at,
     ],
   });

--- a/packages/services/api/src/index.ts
+++ b/packages/services/api/src/index.ts
@@ -21,6 +21,7 @@ export type {
   OrganizationBilling,
   OrganizationInvitation,
 } from './shared/entities';
+export { createTaskRunner } from './modules/shared/lib/task-runner';
 export { minifySchema } from './shared/schema';
 export { HiveError } from './shared/errors';
 export { ProjectType } from './__generated__/types';

--- a/packages/services/api/src/modules/rate-limit/providers/rate-limit.provider.ts
+++ b/packages/services/api/src/modules/rate-limit/providers/rate-limit.provider.ts
@@ -51,4 +51,15 @@ export class RateLimitProvider {
 
     return await this.rateLimit.checkRateLimit.query(input);
   }
+
+  @sentry('RateLimitProvider.getRetention')
+  async getRetention(input: RateLimitApiInput['getRetention']) {
+    if (this.rateLimit === null) {
+      return null;
+    }
+
+    this.logger.debug(`Getting retention for target id="${input.targetId}"`);
+
+    return await this.rateLimit.getRetention.query(input);
+  }
 }

--- a/packages/services/api/src/modules/shared/lib/task-runner.ts
+++ b/packages/services/api/src/modules/shared/lib/task-runner.ts
@@ -1,0 +1,91 @@
+import { type Logger } from '../providers/logger';
+
+/**
+ * Create task runner that runs a task at at a given interval.
+ */
+export const createTaskRunner = (args: {
+  run: () => Promise<void>;
+  interval: number;
+  logger: Logger;
+}) => {
+  let task: ReturnType<typeof scheduleTask> | null = null;
+  let isStarted = false;
+  let isStopped = false;
+
+  async function loop() {
+    task = scheduleTask({
+      runAt: args.interval,
+      run: args.run,
+      logger: args.logger,
+      name: 'schema-purge',
+    });
+    task.done.finally(() => {
+      if (!isStopped) {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        loop();
+      }
+    });
+  }
+
+  return {
+    start() {
+      if (isStarted) {
+        return;
+      }
+      isStarted = true;
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      loop();
+    },
+    async stop() {
+      isStopped = true;
+      if (task) {
+        task.cancel();
+        await task.done;
+      }
+    },
+  };
+};
+
+const scheduleTask = (args: {
+  runAt: number;
+  run: () => Promise<void>;
+  name: string;
+  logger: Logger;
+}) => {
+  args.logger.info(
+    `Scheduling task "${args.name}" to run at ${new Date(args.runAt).toISOString()}`,
+  );
+  let timeout: null | NodeJS.Timeout = setTimeout(async () => {
+    timeout = null;
+    args.logger.info(`Running task "${args.name}" to run at ${new Date(args.runAt).toISOString()}`);
+    await args.run();
+    args.logger.info(
+      `Completed running task "${args.name}" to run at ${new Date(args.runAt).toISOString()}`,
+    );
+    deferred.resolve();
+  }, args.runAt);
+  const deferred = createDeferred();
+
+  return {
+    done: deferred.promise,
+    cancel: () => {
+      if (timeout) {
+        clearTimeout(timeout);
+        return;
+      }
+      deferred.resolve();
+    },
+  };
+};
+
+const createDeferred = () => {
+  let resolve: () => void;
+  const promise = new Promise<void>(r => {
+    resolve = r;
+  });
+
+  return {
+    resolve: () => resolve(),
+    promise,
+  };
+};

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -690,7 +690,11 @@ export interface Storage {
   /**
    * Persist a schema check record in the database.
    */
-  createSchemaCheck(input: SchemaCheckInput): Promise<SchemaCheck>;
+  createSchemaCheck(_: SchemaCheckInput & { expiresAt: Date | null }): Promise<SchemaCheck>;
+  /**
+   * Delete the expired schema checks from the database.
+   */
+  purgeExpiredSchemaChecks(_: { expiresAt: Date }): Promise<number>;
   /**
    * Find schema check for a given ID and target.
    */

--- a/packages/services/server/src/environment.ts
+++ b/packages/services/server/src/environment.ts
@@ -27,6 +27,7 @@ const EnvironmentModel = zod.object({
   SCHEMA_POLICY_ENDPOINT: emptyString(zod.string().url().optional()),
   TOKENS_ENDPOINT: zod.string().url(),
   USAGE_ESTIMATOR_ENDPOINT: emptyString(zod.string().url().optional()),
+  USAGE_ESTIMATOR_RETENTION_PURGE_INTERVAL_MINUTES: emptyString(NumberFromString.optional()),
   BILLING_ENDPOINT: emptyString(zod.string().url().optional()),
   EMAILS_ENDPOINT: emptyString(zod.string().url().optional()),
   WEBHOOKS_ENDPOINT: zod.string().url(),
@@ -115,6 +116,7 @@ const HiveModel = zod.union([
     HIVE_API_TOKEN: zod.string(),
     HIVE_USAGE: zod.union([zod.literal('0'), zod.literal('1')]).optional(),
     HIVE_USAGE_ENDPOINT: zod.string().url().optional(),
+    HIVE_USAGE_DATA_RETENTION_PURGE_INTERVAL_MINUTES: emptyString(NumberFromString.optional()),
     HIVE_REPORTING: zod.union([zod.literal('0'), zod.literal('1')]).optional(),
     HIVE_REPORTING_ENDPOINT: zod.string().url().optional(),
   }),
@@ -236,7 +238,12 @@ const hiveConfig =
         token: hive.HIVE_API_TOKEN,
         reporting:
           hive.HIVE_REPORTING === '1' ? { endpoint: hive.HIVE_REPORTING_ENDPOINT ?? null } : null,
-        usage: hive.HIVE_USAGE === '1' ? { endpoint: hive.HIVE_USAGE_ENDPOINT ?? null } : null,
+        usage:
+          hive.HIVE_USAGE === '1'
+            ? {
+                endpoint: hive.HIVE_USAGE_ENDPOINT ?? null,
+              }
+            : null,
       }
     : null;
 
@@ -266,7 +273,10 @@ export const env = {
         }
       : null,
     usageEstimator: base.USAGE_ESTIMATOR_ENDPOINT
-      ? { endpoint: base.USAGE_ESTIMATOR_ENDPOINT }
+      ? {
+          endpoint: base.USAGE_ESTIMATOR_ENDPOINT,
+          dateRetentionPurgeIntervalMinutes: 5,
+        }
       : null,
     billing: base.BILLING_ENDPOINT ? { endpoint: base.BILLING_ENDPOINT } : null,
     emails: base.EMAILS_ENDPOINT ? { endpoint: base.EMAILS_ENDPOINT } : null,

--- a/packages/services/server/src/index.ts
+++ b/packages/services/server/src/index.ts
@@ -87,9 +87,35 @@ export async function main() {
 
   const storage = await createPostgreSQLStorage(createConnectionString(env.postgres), 10);
 
+  let expiredSchemaCheckPurgeTaskRunner: null | ReturnType<typeof createTaskRunner> = null;
+
+  if (!env.hiveServices.usageEstimator) {
+    server.log.debug(
+      'Usage estimation is disabled. Skip scheduling purge tasks for expired schema checks.',
+    );
+  } else {
+    server.log.debug(
+      `Usage estimation is enabled. Start scheduling purge tasks for expired schema checks every ${env.hiveServices.usageEstimator.dateRetentionPurgeIntervalMinutes} minutes.`,
+    );
+    expiredSchemaCheckPurgeTaskRunner = createTaskRunner({
+      async run() {
+        await storage.purgeExpiredSchemaChecks({
+          expiresAt: new Date(),
+        });
+      },
+      interval: env.hiveServices.usageEstimator.dateRetentionPurgeIntervalMinutes * 60 * 1000,
+      logger: server.log,
+    });
+    expiredSchemaCheckPurgeTaskRunner.start();
+  }
+
   registerShutdown({
     logger: server.log,
     async onShutdown() {
+      if (expiredSchemaCheckPurgeTaskRunner) {
+        server.log.info('Stopping expired schema check purge task...');
+        await expiredSchemaCheckPurgeTaskRunner.stop();
+      }
       server.log.info('Stopping HTTP server listener...');
       await server.close();
       server.log.info('Stopping Storage handler...');
@@ -139,19 +165,6 @@ export async function main() {
     };
   }
 
-  if (env.hiveServices.usageEstimator) {
-    const storageTask = createTaskRunner({
-      async run() {
-        await storage.purgeExpiredSchemaChecks({
-          expiresAt: new Date(),
-        });
-      },
-      interval: 60_000,
-      logger: server.log,
-    });
-    storageTask.start();
-  }
-
   try {
     const errorHandler = createErrorHandler('error');
     const fatalHandler = createErrorHandler('fatal');
@@ -174,8 +187,7 @@ export async function main() {
         },
       };
     }
-
-    const graphqlLogger = createGraphQLLogger();
+    const logger = createGraphQLLogger();
     const registry = createRegistry({
       app: env.hiveServices.webApp
         ? {
@@ -204,7 +216,7 @@ export async function main() {
       schemaPolicyService: {
         endpoint: env.hiveServices.schemaPolicy ? env.hiveServices.schemaPolicy.endpoint : null,
       },
-      logger: graphqlLogger,
+      logger,
       storage,
       redis: {
         host: env.redis.host,
@@ -280,7 +292,7 @@ export async function main() {
       isProduction: env.environment === 'prod',
       release: env.release,
       hiveConfig: env.hive,
-      logger: graphqlLogger as any,
+      logger: logger as any,
       persistedOperations,
     });
 

--- a/packages/services/storage/src/db/types.ts
+++ b/packages/services/storage/src/db/types.ts
@@ -168,6 +168,7 @@ export interface schema_checks {
   breaking_schema_changes: any | null;
   composite_schema_sdl: string | null;
   created_at: Date;
+  expires_at: Date | null;
   github_check_run_id: string | null;
   id: string;
   is_manually_approved: boolean | null;

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -3501,6 +3501,7 @@ export async function createStorage(connection: string, maximumPoolSize: number)
           , "is_manually_approved"
           , "manual_approval_user_id"
           , "github_check_run_id"
+          , "expires_at"
         )
         VALUES (
           ${args.schemaSDL}
@@ -3519,6 +3520,7 @@ export async function createStorage(connection: string, maximumPoolSize: number)
           , ${args.isManuallyApproved}
           , ${args.manualApprovalUserId}
           , ${args.githubCheckRunId}
+          , ${args.expiresAt?.toISOString() ?? null}
         )
         RETURNING
           ${schemaCheckSQLFields}
@@ -3715,6 +3717,18 @@ export async function createStorage(connection: string, maximumPoolSize: number)
         ...TargetModel.parse(result),
         orgId: args.organizationId,
       };
+    },
+
+    async purgeExpiredSchemaChecks(args) {
+      await pool.query(sql`
+        DELETE
+        FROM
+          "public"."schema_checks"
+        WHERE
+          "expires_at" <= ${args.expiresAt.toISOString()}
+      `);
+
+      return 0;
     },
   };
 


### PR DESCRIPTION
### Background

See https://github.com/kamilkisiela/graphql-hive/issues/2690

### Description

Adds an `expires_at` column to the `schema_checks` pg table.
New records in the `schema_checks` table will be inserted with an `expires_at` data based on the data retention (if the usage service is configured).
A cron job runs within the server container for deleting `schema_checks` whose `expires_at` is reached.

Additional things to consider:
- For all the records we already have within our database we need to run an additional migration that populates the `expires_at` values. We don't need to automatically run this for the self-hosted database migrations.


### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
