### PR TITLE
feat: disable leave organization for oidc members

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -167,6 +167,7 @@ services:
       CLIENTS_CONFIGURATION_PATH: /tmp/config/clients-config.json
     volumes:
       - ./configs/oidc-server-mock/clients-config.json:/tmp/config/clients-config.json:ro
+      - ./configs/oidc-server-mock/users-config.json:/tmp/config/users-config.json:ro
     networks:
       - 'stack'
 

--- a/packages/services/api/src/modules/organization/providers/organization-manager.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-manager.ts
@@ -109,6 +109,13 @@ export class OrganizationManager {
       };
     }
 
+    if (member.oidcIntegrationId !== null) {
+      return {
+        result: false,
+        reason: 'Cannot leave an organization as an OIDC member.',
+      };
+    }
+
     const membersCount = await this.countOrganizationMembers({
       organization: organizationId,
     });

--- a/packages/services/api/src/shared/entities.ts
+++ b/packages/services/api/src/shared/entities.ts
@@ -297,6 +297,7 @@ export interface Member {
   user: User;
   organization: string;
   scopes: Array<OrganizationAccessScope | ProjectAccessScope | TargetAccessScope>;
+  oidcIntegrationId: string | null;
 }
 
 export interface TargetSettings {

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -150,6 +150,7 @@ export async function createStorage(connection: string, maximumPoolSize: number)
       user: transformUser(user),
       scopes: (user.scopes as Member['scopes']) || [],
       organization: user.organization_id,
+      oidcIntegrationId: user.oidc_integration_id ?? null,
     };
   }
 


### PR DESCRIPTION
### Background

The `docker-compose.dev.yml` file was broken for the oidc service. While testing stuff I also noticed that you can leave an organization as an oidc member. This should not be the case.

### Description

brrrt

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
