### PR TITLE
Use different resolution for different date ranges

### DIFF
--- a/packages/web/app/src/components/target/operations/Stats.tsx
+++ b/packages/web/app/src/components/target/operations/Stats.tsx
@@ -768,6 +768,7 @@ export function OperationsStats({
   period,
   operationsFilter,
   clientNamesFilter,
+  resolution,
 }: {
   organization: string;
   project: string;
@@ -776,10 +777,10 @@ export function OperationsStats({
     from: string;
     to: string;
   };
+  resolution: number;
   operationsFilter: string[];
   clientNamesFilter: Array<string>;
 }): ReactElement {
-  const resolution = 90;
   const [query, refetchQuery] = useQuery({
     query: Stats_GeneralOperationsStatsQuery,
     variables: {


### PR DESCRIPTION
Show up to 90d of collected data. Charts with resolution between 90 and 60 data points (depending on the date range).
Hide date range options shorter than the data retention period.

This is a preparation for big changes we're going to introduce soon (ClickHouse).