### PR TITLE
Fix client usage info on Explorer page

### DIFF
--- a/packages/services/api/src/modules/operations/providers/operations-reader.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-reader.ts
@@ -750,7 +750,7 @@ export class OperationsReader {
               sql`( coordinate = ${args.typename} OR coordinate LIKE ${args.typename + '.%'} )`,
             ],
           })}
-          GROUP BY co.hash, co.coordinate
+          GROUP BY co.hash
           SETTINGS join_algorithm = 'parallel_hash'
         `,
       timeout: 15_000,


### PR DESCRIPTION
Grouping by `coordinate` and `hash` is incorrect, it should be just `coordinate`. It shows no clients when there is more than one.