### PR TITLE
require `target:registry:write` permissions instead of `target:settin…

### DIFF
--- a/integration-tests/tests/api/collections/document-collections.spec.ts
+++ b/integration-tests/tests/api/collections/document-collections.spec.ts
@@ -141,7 +141,7 @@ describe('Document Collections', () => {
           }),
         ).rejects.toMatchInlineSnapshot(`
             [Error: Expected GraphQL response to have no errors, but got 1 errors:
-            	No access (reason: "Missing target:settings permission")
+            	No access (reason: "Missing target:registry:write permission")
             	endpoint: http://localhost:8082/graphql
             	query:
             mutation CreateCollection($selector: TargetSelectorInput!, $input: CreateDocumentCollectionInput!) {
@@ -183,7 +183,7 @@ describe('Document Collections', () => {
             {
               "errors": [
                 {
-                  "message": "No access (reason: \\"Missing target:settings permission\\")",
+                  "message": "No access (reason: \\"Missing target:registry:write permission\\")",
                   "locations": [
                     {
                       "line": 2,
@@ -226,7 +226,7 @@ describe('Document Collections', () => {
           }),
         ).rejects.toMatchInlineSnapshot(`
             [Error: Expected GraphQL response to have no errors, but got 1 errors:
-            	No access (reason: "Missing target:settings permission")
+            	No access (reason: "Missing target:registry:write permission")
             	endpoint: http://localhost:8082/graphql
             	query:
             mutation UpdateCollection($selector: TargetSelectorInput!, $input: UpdateDocumentCollectionInput!) {
@@ -268,7 +268,7 @@ describe('Document Collections', () => {
             {
               "errors": [
                 {
-                  "message": "No access (reason: \\"Missing target:settings permission\\")",
+                  "message": "No access (reason: \\"Missing target:registry:write permission\\")",
                   "locations": [
                     {
                       "line": 2,
@@ -309,7 +309,7 @@ describe('Document Collections', () => {
           }),
         ).rejects.toMatchInlineSnapshot(`
             [Error: Expected GraphQL response to have no errors, but got 1 errors:
-            	No access (reason: "Missing target:settings permission")
+            	No access (reason: "Missing target:registry:write permission")
             	endpoint: http://localhost:8082/graphql
             	query:
             mutation DeleteCollection($selector: TargetSelectorInput!, $id: ID!) {
@@ -337,7 +337,7 @@ describe('Document Collections', () => {
             {
               "errors": [
                 {
-                  "message": "No access (reason: \\"Missing target:settings permission\\")",
+                  "message": "No access (reason: \\"Missing target:registry:write permission\\")",
                   "locations": [
                     {
                       "line": 2,

--- a/packages/services/api/src/modules/collection/resolvers.ts
+++ b/packages/services/api/src/modules/collection/resolvers.ts
@@ -97,7 +97,11 @@ export const resolvers: CollectionModule.Resolvers = {
   },
   Mutation: {
     async createDocumentCollection(_, { selector, input }, { injector }) {
-      const target = await validateTargetAccess(injector, selector, TargetAccessScope.SETTINGS);
+      const target = await validateTargetAccess(
+        injector,
+        selector,
+        TargetAccessScope.REGISTRY_WRITE,
+      );
       const result = await injector.get(CollectionProvider).createCollection(target.id, input);
 
       return {
@@ -109,7 +113,11 @@ export const resolvers: CollectionModule.Resolvers = {
       };
     },
     async updateDocumentCollection(_, { selector, input }, { injector }) {
-      const target = await validateTargetAccess(injector, selector, TargetAccessScope.SETTINGS);
+      const target = await validateTargetAccess(
+        injector,
+        selector,
+        TargetAccessScope.REGISTRY_WRITE,
+      );
       const result = await injector.get(CollectionProvider).updateCollection(input);
 
       if (!result) {
@@ -130,7 +138,11 @@ export const resolvers: CollectionModule.Resolvers = {
       };
     },
     async deleteDocumentCollection(_, { selector, id }, { injector }) {
-      const target = await validateTargetAccess(injector, selector, TargetAccessScope.SETTINGS);
+      const target = await validateTargetAccess(
+        injector,
+        selector,
+        TargetAccessScope.REGISTRY_WRITE,
+      );
       await injector.get(CollectionProvider).deleteCollection(id);
 
       return {
@@ -144,7 +156,11 @@ export const resolvers: CollectionModule.Resolvers = {
     async createOperationInDocumentCollection(_, { selector, input }, { injector }) {
       try {
         OperationValidationInputModel.parse(input);
-        const target = await validateTargetAccess(injector, selector, TargetAccessScope.SETTINGS);
+        const target = await validateTargetAccess(
+          injector,
+          selector,
+          TargetAccessScope.REGISTRY_WRITE,
+        );
         const result = await injector.get(CollectionProvider).createOperation(input);
         const collection = await injector
           .get(CollectionProvider)
@@ -183,7 +199,11 @@ export const resolvers: CollectionModule.Resolvers = {
     async updateOperationInDocumentCollection(_, { selector, input }, { injector }) {
       try {
         OperationValidationInputModel.parse(input);
-        const target = await validateTargetAccess(injector, selector, TargetAccessScope.SETTINGS);
+        const target = await validateTargetAccess(
+          injector,
+          selector,
+          TargetAccessScope.REGISTRY_WRITE,
+        );
         const result = await injector.get(CollectionProvider).updateOperation(input);
 
         if (!result) {
@@ -221,7 +241,11 @@ export const resolvers: CollectionModule.Resolvers = {
       }
     },
     async deleteOperationInDocumentCollection(_, { selector, id }, { injector }) {
-      const target = await validateTargetAccess(injector, selector, TargetAccessScope.SETTINGS);
+      const target = await validateTargetAccess(
+        injector,
+        selector,
+        TargetAccessScope.REGISTRY_WRITE,
+      );
       const operation = await injector.get(CollectionProvider).getOperation(id);
 
       if (!operation) {


### PR DESCRIPTION
…gs` permissions for doing crud operations on operation collections

### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
