### PR TITLE
fix `Should not import the named export 'dependencies'.'monaco-editor'`

### DIFF
--- a/packages/web/app/src/components/schema-editor.ts
+++ b/packages/web/app/src/components/schema-editor.ts
@@ -1,6 +1,6 @@
 import dynamic from 'next/dynamic';
 import { loader, DiffEditor as MonacoDiffEditor } from '@monaco-editor/react';
-import * as pkg from '../../package.json' assert { type: 'json' };
+import pkg from '../../package.json' assert { type: 'json' };
 
 loader.config({
   paths: {


### PR DESCRIPTION
![image](https://github.com/kamilkisiela/graphql-hive/assets/7361780/04b8c50c-0d9b-4cbd-b64b-57db86455691)
