### PR TITLE
Skip CLI when building docker images

### DIFF
--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -87,6 +87,7 @@ jobs:
       imageTag: ${{ needs.publish.outputs.version }}
       publishSourceMaps: false
       publishLatest: true
+      publishPrComment: false
       targets: cli
       uploadJavaScriptArtifacts: false
     secrets: inherit

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -10,6 +10,10 @@ jobs:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
+    outputs:
+      publish: ${{ steps.cli.outputs.publish }}
+      version: ${{ steps.cli.outputs.version }}
+
     steps:
       - name: checkout
         uses: actions/checkout@v3
@@ -74,3 +78,15 @@ jobs:
         run:
           pnpm oclif promote --no-xz --sha ${GITHUB_SHA:0:7} --version $VERSION --win || pnpm oclif
           promote --no-xz --sha ${GITHUB_SHA:0:8} --version $VERSION --win
+
+  publish_docker:
+    needs: publish
+    uses: ./.github/workflows/build-and-dockerize.yaml
+    if: needs.publish.outputs.publish == 'true'
+    with:
+      imageTag: ${{ needs.publish.outputs.version }}
+      publishSourceMaps: false
+      publishLatest: true
+      targets: cli
+      uploadJavaScriptArtifacts: false
+    secrets: inherit

--- a/docker/docker.hcl
+++ b/docker/docker.hcl
@@ -385,6 +385,25 @@ group "build" {
   ]
 }
 
+group "build" {
+  targets = [
+    "emails",
+    "rate-limit",
+    "schema",
+    "policy",
+    "storage",
+    "tokens",
+    "usage-estimator",
+    "usage-ingestor",
+    "usage",
+    "webhooks",
+    "server",
+    "stripe-billing",
+    "composition-federation-2",
+    "app"
+  ]
+}
+
 group "integration-tests" {
   targets = [
     "emails",

--- a/docker/docker.hcl
+++ b/docker/docker.hcl
@@ -380,26 +380,6 @@ group "build" {
     "server",
     "stripe-billing",
     "composition-federation-2",
-    "app",
-    "cli"
-  ]
-}
-
-group "build" {
-  targets = [
-    "emails",
-    "rate-limit",
-    "schema",
-    "policy",
-    "storage",
-    "tokens",
-    "usage-estimator",
-    "usage-ingestor",
-    "usage",
-    "webhooks",
-    "server",
-    "stripe-billing",
-    "composition-federation-2",
     "app"
   ]
 }


### PR DESCRIPTION
Build and Push docker image of CLI only when a new stable release is published.
This should speed up our CI.

Effect? "Only" 3 minutes (before it was ~10 minutes or more) spent on `build docker images` step.