### PR TITLE
Retry requests to /usage when it is not ready

### DIFF
--- a/deployment/services/proxy.ts
+++ b/deployment/services/proxy.ts
@@ -52,7 +52,7 @@ export function deployProxy({
         customRewrite: '/graphql',
         service: graphql.service,
         timeoutInSeconds: 60,
-        retryOnReset: true,
+        retriable: true,
       },
       {
         name: 'graphql-api',
@@ -60,13 +60,13 @@ export function deployProxy({
         customRewrite: '/graphql',
         service: graphql.service,
         timeoutInSeconds: 60,
-        retryOnReset: true,
+        retriable: true,
       },
       {
         name: 'usage',
         path: '/usage',
         service: usage.service,
-        retryOnReset: true,
+        retriable: true,
       },
     ])
     .get();

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -17,7 +17,7 @@ export class Proxy {
       path: string;
       service: k8s.core.v1.Service;
       timeoutInSeconds?: number;
-      retryOnReset?: boolean;
+      retriable?: boolean;
       customRewrite?: string;
       virtualHost?: Output<string>;
       httpsUpstream?: boolean;
@@ -94,7 +94,7 @@ export class Proxy {
                         },
                       }
                     : {}),
-                  ...(route.retryOnReset
+                  ...(route.retriable
                     ? {
                         retryPolicy: {
                           count: 2,

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -98,7 +98,8 @@ export class Proxy {
                     ? {
                         retryPolicy: {
                           count: 2,
-                          retryOn: ['reset'],
+                          retryOn: ['reset', 'retriable-status-codes'],
+                          retriableStatusCodes: [503],
                         },
                       }
                     : {}),

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -47,9 +47,6 @@ export class Proxy {
         apiVersion: 'projectcontour.io/v1',
         kind: 'HTTPProxy',
         metadata: {
-          annotations: {
-            'ingress.kubernetes.io/force-ssl-redirect': 'true',
-          },
           name: `ingress-${dns.record}`,
         },
         spec: {

--- a/packages/services/usage/src/metrics.ts
+++ b/packages/services/usage/src/metrics.ts
@@ -76,6 +76,7 @@ export const invalidRawOperations = new metrics.Counter({
 export const collectDuration = new metrics.Histogram({
   name: 'usage_raw_collect_duration_seconds',
   help: 'Collect duration in seconds',
+  labelNames: ['status'],
 });
 
 export const compressDuration = new metrics.Histogram({


### PR DESCRIPTION
Pod can be marked as not ready to accept requests but the gateway may not be aware yet. This PR adds a retry logic for such cases. Fastify (the http server framework we use) returns 503 after close() method is called so it matches our scenario as well.

https://projectcontour.io/docs/v1.7.0/api/#projectcontour.io/v1.RetryPolicy