### PR TITLE
Make hive/app dependent on hive/server, not the other way around

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "scripts": {
     "build": "pnpm turbo build --color",
     "build:libraries": "pnpm prebuild && pnpm graphql:generate && pnpm turbo build --filter=./packages/libraries/* --color",
-    "build:services": "pnpm prebuild && pnpm turbo build  --filter=./packages/services/**/* --filter=./packages/migrations --color",
+    "build:services": "pnpm prebuild && pnpm turbo build --filter=./packages/services/**/* --filter=./packages/migrations --color",
     "build:web": "pnpm prebuild && pnpm turbo build --filter=./packages/web/* --color",
     "cargo:fix": "bash ./scripts/fix-symbolic-link.sh",
     "docker:build": "docker buildx bake -f docker/docker.hcl --load build",

--- a/packages/web/app/package.json
+++ b/packages/web/app/package.json
@@ -98,6 +98,7 @@
     "@graphql-codegen/client-preset-swc-plugin": "0.2.0",
     "@graphql-typed-document-node/core": "3.2.0",
     "@hive/emails": "workspace:*",
+    "@hive/server": "workspace:*",
     "@next/bundle-analyzer": "13.4.11",
     "@sentry/types": "7.59.3",
     "@storybook/addon-essentials": "7.0.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1682,6 +1682,9 @@ importers:
       '@hive/emails':
         specifier: workspace:*
         version: link:../../services/emails
+      '@hive/server':
+        specifier: workspace:*
+        version: link:../../services/server
       '@next/bundle-analyzer':
         specifier: 13.4.11
         version: 13.4.11

--- a/turbo.json
+++ b/turbo.json
@@ -42,7 +42,7 @@
       "outputs": ["dist/**"]
     },
     "@hive/server#build": {
-      "dependsOn": ["^build", "@hive/app#build"],
+      "dependsOn": ["^build"],
       "outputs": ["dist/**"]
     },
     "check:build": {


### PR DESCRIPTION
Not sure why `@hive/server` depends on `@hive/app`. It should be the opposite.

It caused a build speed issue when running `pnpm build:services`. The `hive/app` was one of the dependencies of `hive/server` so whenever the `pnpm build:services` ran (integration-tests), the `hive/app` was built as well. The build output of `hive/app` is not cached and takes a lot of time (minutes) so it was slowing down the integration-test (1,2,3) jobs.

This Pull Request adds `@hive/server` as a devDependency of `@hive/app` and removes `@hive/app` from `@hive/server` dependencies.