### PR TITLE
Update apollo-studio.mdx

### DIFF
--- a/packages/web/docs/src/pages/docs/use-cases/apollo-studio.mdx
+++ b/packages/web/docs/src/pages/docs/use-cases/apollo-studio.mdx
@@ -40,7 +40,7 @@ identical.
 ## On-Premise and Cloud Hosting Options
 
 Whether you're working on a side project or managing a larger beast, GraphQL Hive caters to your
-hosting needs. The [self-hosting](docs/self-hosting/get-started) option is entirely free,
+hosting needs. The [self-hosting](/docs/self-hosting/get-started) option is entirely free,
 eliminating any limitations on usage. Furthermore,
 [GraphQL Hive Cloud](https://the-guild.dev/graphql/hive) offers a free Hobby plan, perfectly suited
 for most side projects. For those seeking more advanced features and capabilities, the Pro plan


### PR DESCRIPTION
The self hosting link is broken here: https://the-guild.dev/graphql/hive/docs/use-cases/apollo-studio#on-premise-and-cloud-hosting-options