### PR TITLE
Track responses and R2 calls

### DIFF
--- a/packages/services/cdn-worker/src/analytics.ts
+++ b/packages/services/cdn-worker/src/analytics.ts
@@ -49,6 +49,15 @@ type Event =
   | {
       type: 'error';
       value: [string, string] | [string];
+    }
+  | {
+      type: 'r2';
+      action: 'HEAD artifact' | 'GET cdn-legacy-keys' | 'GET cdn-access-token';
+      statusCode: number;
+    }
+  | {
+      type: 'response';
+      statusCode: number;
     };
 
 export function createAnalytics(
@@ -68,7 +77,7 @@ export function createAnalytics(
         case 'artifact':
           return engines.usage.writeDataPoint({
             blobs: [event.version, event.value, targetId],
-            indexes: [targetId.substr(0, 32)],
+            indexes: [targetId.substring(0, 32)],
           });
         case 'error':
           return engines.error.writeDataPoint({
@@ -83,7 +92,7 @@ export function createAnalytics(
                   event.value.version,
                   event.value.isValid ? 'valid' : 'invalid',
                 ],
-                indexes: [targetId.substr(0, 32)],
+                indexes: [targetId.substring(0, 32)],
               });
             case 'cache-write':
               return engines.keyValidation.writeDataPoint({
@@ -92,12 +101,12 @@ export function createAnalytics(
                   event.value.version,
                   event.value.isValid ? 'valid' : 'invalid',
                 ],
-                indexes: [targetId.substr(0, 32)],
+                indexes: [targetId.substring(0, 32)],
               });
             case 's3-key-validation':
               return engines.keyValidation.writeDataPoint({
                 blobs: ['s3-key-validation', event.value.version, event.value.status],
-                indexes: [targetId.substr(0, 32)],
+                indexes: [targetId.substring(0, 32)],
               });
           }
       }

--- a/packages/services/cdn-worker/src/artifact-storage-reader.ts
+++ b/packages/services/cdn-worker/src/artifact-storage-reader.ts
@@ -1,3 +1,4 @@
+import type { Analytics } from './analytics';
 import { AwsClient } from './aws';
 
 const presignedUrlExpirationSeconds = 60;
@@ -23,6 +24,7 @@ export class ArtifactStorageReader {
     },
     /** The public URL in case the public S3 endpoint differs from the internal S3 endpoint. E.g. within a docker network. */
     publicUrl: string | null,
+    private analytics: Analytics,
   ) {
     this.publicUrl = publicUrl ? new URL(publicUrl) : null;
   }
@@ -71,6 +73,14 @@ export class ArtifactStorageReader {
           signQuery: true,
         },
       },
+    );
+    this.analytics.track(
+      {
+        type: 'r2',
+        statusCode: response.status,
+        action: 'HEAD artifact',
+      },
+      targetId,
     );
 
     if (response.status === 200) {

--- a/packages/services/cdn-worker/src/artifact-storage-reader.ts
+++ b/packages/services/cdn-worker/src/artifact-storage-reader.ts
@@ -24,7 +24,7 @@ export class ArtifactStorageReader {
     },
     /** The public URL in case the public S3 endpoint differs from the internal S3 endpoint. E.g. within a docker network. */
     publicUrl: string | null,
-    private analytics: Analytics,
+    private analytics: Analytics | null,
   ) {
     this.publicUrl = publicUrl ? new URL(publicUrl) : null;
   }
@@ -74,7 +74,7 @@ export class ArtifactStorageReader {
         },
       },
     );
-    this.analytics.track(
+    this.analytics?.track(
       {
         type: 'r2',
         statusCode: response.status,

--- a/packages/services/cdn-worker/src/errors.ts
+++ b/packages/services/cdn-worker/src/errors.ts
@@ -20,6 +20,13 @@ export class MissingTargetIDErrorResponse extends Response {
     );
 
     analytics.track({ type: 'error', value: ['missing_target_id'] }, 'unknown');
+    analytics.track(
+      {
+        type: 'response',
+        statusCode: 400,
+      },
+      'unknown',
+    );
   }
 }
 
@@ -39,6 +46,13 @@ export class InvalidArtifactTypeResponse extends Response {
       },
     );
     analytics.track({ type: 'error', value: ['invalid_artifact_type', artifactType] }, 'unknown');
+    analytics.track(
+      {
+        type: 'response',
+        statusCode: 400,
+      },
+      'unknown',
+    );
   }
 }
 
@@ -58,6 +72,13 @@ export class MissingAuthKeyResponse extends Response {
       },
     );
     analytics.track({ type: 'error', value: ['missing_auth_key'] }, 'unknown');
+    analytics.track(
+      {
+        type: 'response',
+        statusCode: 400,
+      },
+      'unknown',
+    );
   }
 }
 
@@ -77,6 +98,13 @@ export class InvalidAuthKeyResponse extends Response {
       },
     );
     analytics.track({ type: 'error', value: ['invalid_auth_key'] }, 'unknown');
+    analytics.track(
+      {
+        type: 'response',
+        statusCode: 403,
+      },
+      'unknown',
+    );
   }
 }
 
@@ -96,6 +124,13 @@ export class CDNArtifactNotFound extends Response {
       },
     );
     analytics.track({ type: 'error', value: ['artifact_not_found', artifactType] }, targetId);
+    analytics.track(
+      {
+        type: 'response',
+        statusCode: 404,
+      },
+      targetId,
+    );
   }
 }
 
@@ -115,6 +150,13 @@ export class InvalidArtifactMatch extends Response {
       },
     );
     analytics.track({ type: 'error', value: ['invalid_artifact_match', artifactType] }, targetId);
+    analytics.track(
+      {
+        type: 'response',
+        statusCode: 400,
+      },
+      targetId,
+    );
   }
 }
 
@@ -134,5 +176,12 @@ export class UnexpectedError extends Response {
       },
     );
     analytics.track({ type: 'error', value: ['unexpected_error'] }, 'unknown');
+    analytics.track(
+      {
+        type: 'response',
+        statusCode: 500,
+      },
+      'unknown',
+    );
   }
 }

--- a/packages/services/cdn-worker/src/index.ts
+++ b/packages/services/cdn-worker/src/index.ts
@@ -7,6 +7,7 @@ import { AwsClient } from './aws';
 import { UnexpectedError } from './errors';
 import { createRequestHandler } from './handler';
 import { createIsKeyValid } from './key-validation';
+import { createResponse } from './tracked-response';
 
 type Env = {
   S3_ENDPOINT: string;
@@ -130,7 +131,7 @@ const handler: ExportedHandler<Env> = {
         if (response) {
           return response;
         }
-        return new Response('Not found', { status: 404 });
+        return createResponse(analytics, 'Not found', { status: 404 }, 'unknown');
       });
     } catch (error) {
       console.error(error);

--- a/packages/services/cdn-worker/src/index.ts
+++ b/packages/services/cdn-worker/src/index.ts
@@ -46,13 +46,13 @@ const handler: ExportedHandler<Env> = {
       endpoint: env.S3_ENDPOINT,
     };
 
-    const artifactStorageReader = new ArtifactStorageReader(s3, null);
-
     const analytics = createAnalytics({
       usage: env.USAGE_ANALYTICS,
       error: env.ERROR_ANALYTICS,
       keyValidation: env.KEY_VALIDATION_ANALYTICS,
     });
+
+    const artifactStorageReader = new ArtifactStorageReader(s3, null, analytics);
 
     const isKeyValid = createIsKeyValid({
       waitUntil: p => ctx.waitUntil(p),

--- a/packages/services/cdn-worker/src/key-validation.ts
+++ b/packages/services/cdn-worker/src/key-validation.ts
@@ -126,6 +126,15 @@ const handleLegacyCDNAccessToken = async (args: {
     },
   );
 
+  args.analytics?.track(
+    {
+      type: 'r2',
+      statusCode: key.status,
+      action: 'GET cdn-legacy-keys',
+    },
+    args.targetId,
+  );
+
   if (key.status !== 200) {
     return withCache(false);
   }
@@ -236,6 +245,15 @@ async function handleCDNAccessToken(
     {
       method: 'GET',
     },
+  );
+
+  deps.analytics?.track(
+    {
+      type: 'r2',
+      statusCode: key.status,
+      action: 'GET cdn-access-token',
+    },
+    targetId,
   );
 
   if (key.status !== 200) {

--- a/packages/services/cdn-worker/src/tracked-response.ts
+++ b/packages/services/cdn-worker/src/tracked-response.ts
@@ -1,0 +1,21 @@
+import { createFetch } from '@whatwg-node/fetch';
+import type { Analytics } from './analytics';
+
+const { Response } = createFetch({ useNodeFetch: true });
+
+export function createResponse(
+  analytics: Analytics,
+  body: BodyInit | null,
+  init: ResponseInit,
+  targetId: string,
+) {
+  analytics.track(
+    {
+      type: 'response',
+      statusCode: init.status ?? 999 /* indicates unknown status code, for some reason... */,
+    },
+    targetId,
+  );
+
+  return new Response(body, init);
+}

--- a/packages/services/server/src/index.ts
+++ b/packages/services/server/src/index.ts
@@ -380,7 +380,7 @@ export async function main() {
         bucketName: env.s3.bucketName,
       };
 
-      const artifactStorageReader = new ArtifactStorageReader(s3, env.s3.publicUrl);
+      const artifactStorageReader = new ArtifactStorageReader(s3, env.s3.publicUrl, null);
 
       const artifactHandler = createArtifactRequestHandler({
         isKeyValid: createIsKeyValid({ s3, analytics: null, getCache: null, waitUntil: null }),


### PR DESCRIPTION
Introduces two new metrics: `r2` (calls to R2) and `response` (status code + targetId of all responses).