### PR TITLE
Strip invalid comment in schema in the doc

### DIFF
--- a/packages/web/docs/src/pages/docs/specs/schema-reports.md
+++ b/packages/web/docs/src/pages/docs/specs/schema-reports.md
@@ -35,7 +35,6 @@ input SchemaPublishInput {
   Hive prevents from publishing breaking changes or broken schemas by default, use this flag to override this behavior.
   """
   force: Boolean @deprecated(reason: "No longer needed for new projects")
-  """
 }
 
 mutation schemaPublish($input: SchemaPublishInput!) {


### PR DESCRIPTION
### Background

The syntax highlighting of schema in [the doc](https://the-guild.dev/graphql/hive/docs/specs/schema-reports) is broken.

### Description

Strip invalid comment line to make the schema valid

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

