### PR TITLE
Use KV storage to deduplicate SDLs from schema_checks

### DIFF
--- a/packages/libraries/client/src/version.ts
+++ b/packages/libraries/client/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.24.1';
+export const version = '0.24.2';

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -14,7 +14,7 @@
     "db:init": "pnpm db:create && pnpm migration:run",
     "db:migrator": "node --experimental-specifier-resolution=node --loader ts-node/esm src/index.ts",
     "migration:run": "pnpm db:migrator up",
-    "test": "node --experimental-specifier-resolution=node --loader ts-node/esm ./test/*.test.ts"
+    "test": "TS_NODE_TRANSPILE_ONLY=true node --experimental-specifier-resolution=node --loader ts-node/esm ./test/index.ts"
   },
   "devDependencies": {
     "@graphql-hive/core": "workspace:*",

--- a/packages/migrations/src/actions/2023.11.02T14.41.41.schema-checks-dedup.ts
+++ b/packages/migrations/src/actions/2023.11.02T14.41.41.schema-checks-dedup.ts
@@ -1,0 +1,50 @@
+import { type MigrationExecutor } from '../pg-migrator';
+
+export default {
+  name: '2023.10.25T14.41.41.schema-checks-dedup.ts',
+  run: ({ sql }) => [
+    {
+      name: 'create sdl_store and alter schema_checks',
+      query: sql`
+        CREATE TABLE "public"."sdl_store" (
+          "id" text PRIMARY KEY NOT NULL,
+          "sdl" text NOT NULL
+        );
+        
+        ALTER TABLE "public"."schema_checks"
+          ADD COLUMN "schema_sdl_store_id" text REFERENCES "public"."sdl_store" ("id"),
+          ADD COLUMN "supergraph_sdl_store_id" text REFERENCES "public"."sdl_store" ("id"),
+          ADD COLUMN "composite_schema_sdl_store_id" text REFERENCES "public"."sdl_store" ("id");
+
+        ALTER TABLE "public"."schema_checks"
+          ALTER COLUMN "schema_sdl" DROP NOT NULL,
+          ALTER COLUMN "supergraph_sdl" DROP NOT NULL,
+          ALTER COLUMN "composite_schema_sdl" DROP NOT NULL;
+      `,
+    },
+    {
+      name: 'Create sdl_store_unique_id index',
+      query: sql`
+        CREATE UNIQUE INDEX sdl_store_unique_id ON "public"."sdl_store" ("id");
+      `,
+    },
+    {
+      name: 'Create schema_check_by_schema_sdl_store_id index',
+      query: sql`
+        CREATE INDEX CONCURRENTLY "schema_check_by_schema_sdl_store_id" ON "public"."schema_checks" ("schema_sdl_store_id" ASC)
+      `,
+    },
+    {
+      name: 'Create schema_check_by_supergraph_sdl_store_id index',
+      query: sql`
+        CREATE INDEX CONCURRENTLY "schema_check_by_supergraph_sdl_store_id" ON "public"."schema_checks" ("supergraph_sdl_store_id" ASC)
+      `,
+    },
+    {
+      name: 'Create schema_check_by_composite_schema_sdl_store_id index',
+      query: sql`
+        CREATE INDEX CONCURRENTLY "schema_check_by_composite_schema_sdl_store_id" ON "public"."schema_checks" ("composite_schema_sdl_store_id" ASC);
+      `,
+    },
+  ],
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/actions/2023.11.02T14.41.41.schema-checks-dedup.ts
+++ b/packages/migrations/src/actions/2023.11.02T14.41.41.schema-checks-dedup.ts
@@ -2,6 +2,7 @@ import { type MigrationExecutor } from '../pg-migrator';
 
 export default {
   name: '2023.10.25T14.41.41.schema-checks-dedup.ts',
+  noTransaction: true,
   run: ({ sql }) => [
     {
       name: 'create sdl_store and alter schema_checks',

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -56,6 +56,7 @@ import migration_2023_09_28T14_14_14_native_fed_v2 from './actions/2023.09.28T14
 import migration_2023_10_05T11_44_36_schema_checks_github_repository from './actions/2023.10.05T11.44.36.schema-checks-github-repository';
 import migration_2023_10_26T12_44_36_schema_checks_filters_index from './actions/2023.10.26T12.44.36.schema-checks-filters-index';
 import migration_2023_10_30T00_00_00_drop_persisted_operations from './actions/2023.10.30T00-00-00.drop-persisted-operations';
+import migration_2023_11_02T14_41_41_schema_checks_dedup from './actions/2023.11.02T14.41.41.schema-checks-dedup';
 import { runMigrations } from './pg-migrator';
 
 export const runPGMigrations = (args: { slonik: DatabasePool; runTo?: string }) =>
@@ -120,5 +121,6 @@ export const runPGMigrations = (args: { slonik: DatabasePool; runTo?: string }) 
       migration_2023_10_05T11_44_36_schema_checks_github_repository,
       migration_2023_10_26T12_44_36_schema_checks_filters_index,
       migration_2023_10_30T00_00_00_drop_persisted_operations,
+      migration_2023_11_02T14_41_41_schema_checks_dedup,
     ],
   });

--- a/packages/migrations/test/2023.02.22T09.27.02.delete-personal-org.test.ts
+++ b/packages/migrations/test/2023.02.22T09.27.02.delete-personal-org.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { sql } from 'slonik';
 import { initMigrationTestingEnvironment } from './utils/testkit';
 
-await describe('migration: drop-personal-org', async () => {
+await describe('drop-personal-org', async () => {
   await test('should remove all existing personal orgs that does not have projects', async () => {
     const { db, runTo, complete, done, seed } = await initMigrationTestingEnvironment();
 

--- a/packages/migrations/test/2023.09.25T15.23.00.github-check-with-project-name.test.ts
+++ b/packages/migrations/test/2023.09.25T15.23.00.github-check-with-project-name.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { sql } from 'slonik';
 import { initMigrationTestingEnvironment } from './utils/testkit';
 
-await describe('migration: github-check-with-project-name', async () => {
+await describe('github-check-with-project-name', async () => {
   await test('should use FALSE for existing projects and TRUE for new', async () => {
     const { db, runTo, complete, done, seed } = await initMigrationTestingEnvironment();
 

--- a/packages/migrations/test/2023.10.25T14.41.41.schema-checks-dedup.test.ts
+++ b/packages/migrations/test/2023.10.25T14.41.41.schema-checks-dedup.test.ts
@@ -1,0 +1,237 @@
+import assert from 'node:assert';
+import { describe, test } from 'node:test';
+import { DatabasePool, sql } from 'slonik';
+import { createStorage } from '../../services/storage/src/index';
+import { initMigrationTestingEnvironment } from './utils/testkit';
+
+async function insertSchemaCheck(
+  pool: DatabasePool,
+  args: {
+    targetId: string;
+    schemaVersionId: string;
+    schemaSDL: string;
+    compositeSchemaSDL: string;
+    supergraphSDL: string;
+  },
+) {
+  return pool.one<{ id: string }>(sql`
+    INSERT INTO "public"."schema_checks" (
+        "schema_sdl"
+      , "target_id"
+      , "schema_version_id"
+      , "is_success"
+      , "composite_schema_sdl"
+      , "supergraph_sdl"
+      , "is_manually_approved"
+    )
+    VALUES (
+        ${args.schemaSDL}
+      , ${args.targetId}
+      , ${args.schemaVersionId}
+      , ${true}
+      , ${args.compositeSchemaSDL}
+      , ${args.supergraphSDL}
+      , ${false}
+    )
+    RETURNING id
+  `);
+}
+
+await describe('migration: schema-checks-dedup', async () => {
+  await test('should incrementally adopt sdl_store without corrupting existing and new data', async () => {
+    const { db, runTo, complete, done, seed, connectionString } =
+      await initMigrationTestingEnvironment();
+    const storage = await createStorage(connectionString, 1);
+    try {
+      // Run migrations all the way to the point before the one we are testing
+      await runTo('2023.08.03T11.44.36.schema-checks-github-repository.ts');
+
+      // Seed the database with some data (schema_sdl, supergraph_sdl, composite_schema_sdl)
+      const user = await seed.user();
+      const organization = await db.one<{
+        id: string;
+      }>(
+        sql`INSERT INTO public.organizations (clean_id, name, user_id) VALUES ('org-1', 'org-1', ${user.id}) RETURNING id;`,
+      );
+      const project = await db.one<{
+        id: string;
+      }>(
+        sql`INSERT INTO public.projects (clean_id, name, type, org_id) VALUES ('proj-1', 'proj-1', 'SINGLE', ${organization.id}) RETURNING id;`,
+      );
+      const target = await db.one<{
+        id: string;
+      }>(
+        sql`INSERT INTO public.targets (clean_id, name, project_id) VALUES ('proj-1', 'proj-1', ${project.id}) RETURNING id;`,
+      );
+
+      const compositeSchemaSDL = `composite schema 1`;
+      const schemaSDL = `schema 1`;
+      const supergraphSDL = `supergraph 1`;
+
+      const secondCompositeSchemaSDL = `composite schema 2`;
+      const secondSchemaSDL = `schema 2`;
+      const secondSupergraphSDL = `supergraph 2`;
+
+      const action = await db.one<{
+        id: string;
+      }>(
+        sql`
+          INSERT INTO public.schema_log
+              (
+                author,
+                commit,
+                sdl,
+                project_id,
+                target_id,
+                action
+              )
+            VALUES
+              (
+                ${'Author 1'},
+                ${'commit 1'}::text,
+                ${compositeSchemaSDL}::text,
+                ${project.id},
+                ${target.id},
+                'PUSH'
+              )
+            RETURNING id
+        `,
+      );
+
+      const version = await db.one<{
+        id: string;
+      }>(
+        sql`
+        INSERT INTO public.schema_versions
+        (
+          is_composable,
+          target_id,
+          action_id,
+          has_persisted_schema_changes,
+          composite_schema_sdl,
+          supergraph_sdl
+        )
+      VALUES
+        (
+          ${true},
+          ${target.id},
+          ${action.id},
+          ${false},
+          ${compositeSchemaSDL},
+          ${supergraphSDL}
+        )
+        RETURNING id
+        `,
+      );
+
+      const firstSchemaCheck = await insertSchemaCheck(db, {
+        targetId: target.id,
+        schemaVersionId: version.id,
+        schemaSDL,
+        compositeSchemaSDL,
+        supergraphSDL,
+      });
+
+      const secondSchemaCheck = await insertSchemaCheck(db, {
+        targetId: target.id,
+        schemaVersionId: version.id,
+        schemaSDL: secondSchemaSDL,
+        compositeSchemaSDL: secondCompositeSchemaSDL,
+        supergraphSDL: secondSupergraphSDL,
+      });
+
+      const thirdSchemaCheck = await insertSchemaCheck(db, {
+        targetId: target.id,
+        schemaVersionId: version.id,
+        schemaSDL,
+        compositeSchemaSDL,
+        supergraphSDL,
+      });
+
+      // Run the additional remaining migrations
+      await complete();
+
+      const newSchemaCheck: {
+        id: string;
+      } = await storage.createSchemaCheck({
+        targetId: target.id,
+        schemaVersionId: version.id,
+        isSuccess: true,
+        isManuallyApproved: false,
+        schemaSDL,
+        schemaSDLHash: 'schemaSDLHash', // serve exact same schema from different hash to make sure it's allowed
+        compositeSchemaSDL,
+        compositeSchemaSDLHash: 'compositeSchemaSDLHash',
+        supergraphSDL,
+        supergraphSDLHash: 'supergraphSDLHash',
+        serviceName: null,
+        manualApprovalUserId: null,
+        githubCheckRunId: null,
+        githubRepository: null,
+        githubSha: null,
+        meta: null,
+        schemaCompositionErrors: null,
+        breakingSchemaChanges: null,
+        safeSchemaChanges: null,
+        schemaPolicyWarnings: null,
+        schemaPolicyErrors: null,
+        expiresAt: null,
+      });
+
+      // make sure SQL statements from Storage are capable of serving SDLs directly from schema_checks
+      const firstCheckFromStorage = await storage.findSchemaCheck({
+        schemaCheckId: firstSchemaCheck.id,
+        targetId: target.id,
+      });
+      assert.strictEqual(firstCheckFromStorage?.schemaSDL, schemaSDL);
+      assert.strictEqual(firstCheckFromStorage?.compositeSchemaSDL, compositeSchemaSDL);
+      assert.strictEqual(firstCheckFromStorage?.supergraphSDL, supergraphSDL);
+      const secondCheckFromStorage = await storage.findSchemaCheck({
+        schemaCheckId: secondSchemaCheck.id,
+        targetId: target.id,
+      });
+      assert.strictEqual(secondCheckFromStorage?.schemaSDL, secondSchemaSDL);
+      assert.strictEqual(secondCheckFromStorage?.compositeSchemaSDL, secondCompositeSchemaSDL);
+      assert.strictEqual(secondCheckFromStorage?.supergraphSDL, secondSupergraphSDL);
+      const thirdCheckFromStorage = await storage.findSchemaCheck({
+        schemaCheckId: thirdSchemaCheck.id,
+        targetId: target.id,
+      });
+      assert.strictEqual(thirdCheckFromStorage?.schemaSDL, schemaSDL);
+      assert.strictEqual(thirdCheckFromStorage?.compositeSchemaSDL, compositeSchemaSDL);
+      assert.strictEqual(thirdCheckFromStorage?.supergraphSDL, supergraphSDL);
+
+      // make sure SQL statements from Storage are capable of serving SDLs from sdl_store
+      const newCheckFromStorage = await storage.findSchemaCheck({
+        schemaCheckId: newSchemaCheck.id,
+        targetId: target.id,
+      });
+      assert.strictEqual(newCheckFromStorage?.schemaSDL, schemaSDL);
+      assert.strictEqual(newCheckFromStorage?.compositeSchemaSDL, compositeSchemaSDL);
+      assert.strictEqual(newCheckFromStorage?.supergraphSDL, supergraphSDL);
+
+      // make sure SDLs in schema_checks are null for new schema checks
+      const schemaChecksWithAllNulls = await db.oneFirst<number>(sql`
+        SELECT count(*) as total FROM schema_checks
+        WHERE 
+          schema_sdl IS NULL
+          AND composite_schema_sdl IS NULL
+          AND supergraph_sdl IS NULL
+      `);
+      assert.strictEqual(
+        schemaChecksWithAllNulls,
+        1,
+        'only the new schema check should have nulls instead of SDLs',
+      );
+
+      const countSdlStore = await db.oneFirst<number>(sql`SELECT count(*) as total FROM sdl_store`);
+      assert.strictEqual(
+        countSdlStore,
+        3 /* 3 unique SDLs, only those from the newly created schema check */,
+      );
+    } finally {
+      await done();
+      await storage.destroy();
+    }
+  });
+});

--- a/packages/migrations/test/index.ts
+++ b/packages/migrations/test/index.ts
@@ -1,3 +1,3 @@
 import './2023.02.22T09.27.02.delete-personal-org.test';
 import './2023.09.25T15.23.00.github-check-with-project-name.test';
-import './2023.10.25T14.41.41.schema-checks-dedup.test';
+import './2023.11.02T14.41.41.schema-checks-dedup.test';

--- a/packages/migrations/test/index.ts
+++ b/packages/migrations/test/index.ts
@@ -1,0 +1,3 @@
+import './2023.02.22T09.27.02.delete-personal-org.test';
+import './2023.09.25T15.23.00.github-check-with-project-name.test';
+import './2023.10.25T14.41.41.schema-checks-dedup.test';

--- a/packages/migrations/test/utils/testkit.ts
+++ b/packages/migrations/test/utils/testkit.ts
@@ -9,8 +9,6 @@ import type * as DbTypes from '../../../services/storage/src/db/types';
 import { createConnectionString } from '../../src/connection-string';
 import { runPGMigrations } from '../../src/run-pg-migrations'
 
-export { DbTypes };
-
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
 config({
@@ -21,21 +19,21 @@ import { env } from '../../src/environment';
 
 export async function initMigrationTestingEnvironment() {
   const pgp = pgpFactory();
-  const db = pgp(
-    createConnectionString({
-      ...env.postgres,
-      db: 'postgres',
-    }),
-  );
-
-  const dbName = 'migration_test_' + Date.now();
+  const db = pgp(createConnectionString({
+    ...env.postgres,
+    db: 'postgres',
+  }));
+  
+  const dbName = 'migration_test_' + Date.now() + Math.random().toString(16).substring(2);
+  console.log('db name:', dbName)
   await db.query(`CREATE DATABASE ${dbName};`);
-
+  
+  const connectionString = createConnectionString({
+    ...env.postgres,
+    db: dbName,
+  });
   const slonik = await createPool(
-    createConnectionString({
-      ...env.postgres,
-      db: dbName,
-    }),
+    connectionString
   );
 
   const actionsDirectory = resolve(__dirname + '/../../src/actions/');
@@ -44,6 +42,7 @@ export async function initMigrationTestingEnvironment() {
 
 
   return {
+    connectionString,
     db: slonik,
     async runTo(name: string) {
       await runPGMigrations({ slonik, runTo: name });

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -677,6 +677,10 @@ export interface Storage {
    */
   purgeExpiredSchemaChecks(_: { expiresAt: Date }): Promise<number>;
   /**
+   * Delete rows from sdl_store that are not referenced by any schema check.
+   */
+  purgeUnusedSchemasInStore(): Promise<void>;
+  /**
    * Find schema check for a given ID and target.
    */
   findSchemaCheck(input: { schemaCheckId: string; targetId: string }): Promise<SchemaCheck | null>;

--- a/packages/services/api/src/shared/entities.ts
+++ b/packages/services/api/src/shared/entities.ts
@@ -1,4 +1,5 @@
-import { DocumentNode, GraphQLError, SourceLocation } from 'graphql';
+import { createHash } from 'node:crypto';
+import { DocumentNode, GraphQLError, print, SourceLocation } from 'graphql';
 import { z } from 'zod';
 import type { AvailableRulesResponse, PolicyConfigurationObject } from '@hive/policy';
 import type { CompositionFailureError } from '@hive/schema';
@@ -11,7 +12,7 @@ import type {
   ProjectAccessScope,
   TargetAccessScope,
 } from '../__generated__/types';
-import { parseGraphQLSource } from './schema';
+import { parseGraphQLSource, sortDocumentNode } from './schema';
 
 export const SingleSchemaModel = z
   .object({
@@ -118,6 +119,12 @@ export class GraphQLDocumentStringInvalidError extends Error {
     const locationString = location ? ` at line ${location.line}, column ${location.column}` : '';
     super(`The provided SDL is not valid${locationString}\n: ${message}`);
   }
+}
+
+export function hashSDL(sdl: DocumentNode): string {
+  const hasher = createHash('md5');
+  hasher.update(print(sortDocumentNode(sdl)));
+  return hasher.digest('hex');
 }
 
 export function createSchemaObject(

--- a/packages/services/server/src/index.ts
+++ b/packages/services/server/src/index.ts
@@ -103,7 +103,7 @@ export async function main() {
         await storage.purgeExpiredSchemaChecks({
           expiresAt: new Date(),
         });
-        await storage.purgeUnusedSchemasInStore();
+        // TODO: activate await storage.purgeUnusedSchemasInStore();
       },
       interval: env.hiveServices.usageEstimator.dateRetentionPurgeIntervalMinutes * 60 * 1000,
       logger: server.log,

--- a/packages/services/storage/src/db/types.ts
+++ b/packages/services/storage/src/db/types.ts
@@ -160,6 +160,7 @@ export interface projects {
 export interface schema_checks {
   breaking_schema_changes: any | null;
   composite_schema_sdl: string | null;
+  composite_schema_sdl_store_id: string | null;
   created_at: Date;
   expires_at: Date | null;
   github_check_run_id: string | null;
@@ -174,10 +175,12 @@ export interface schema_checks {
   schema_composition_errors: any | null;
   schema_policy_errors: any | null;
   schema_policy_warnings: any | null;
-  schema_sdl: string;
+  schema_sdl: string | null;
+  schema_sdl_store_id: string | null;
   schema_version_id: string | null;
   service_name: string | null;
   supergraph_sdl: string | null;
+  supergraph_sdl_store_id: string | null;
   target_id: string;
   updated_at: Date;
 }
@@ -233,6 +236,11 @@ export interface schema_versions {
   schema_composition_errors: any | null;
   supergraph_sdl: string | null;
   target_id: string;
+}
+
+export interface sdl_store {
+  id: string;
+  sdl: string;
 }
 
 export interface target_validation {
@@ -316,6 +324,7 @@ export interface DBTables {
   schema_version_changes: schema_version_changes;
   schema_version_to_log: schema_version_to_log;
   schema_versions: schema_versions;
+  sdl_store: sdl_store;
   target_validation: target_validation;
   targets: targets;
   tokens: tokens;


### PR DESCRIPTION
Closes https://github.com/kamilkisiela/graphql-hive/issues/2603

Adds `sdl_store` table with `id` (hash of sdl) and `sdl` columns.
Replaces `schema_sdl`, `supergraph_sdl`, `composite_schema_sdl` with `schema_sdl_store_id`, `supergraph_sdl_store_id` and `composite_schema_sdl_store_id`.