### PR TITLE
reintroduce GitHub repository access check

### DIFF
--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -877,22 +877,6 @@ export class SchemaPublisher {
           message: 'Invalid github repository name provided.',
         } as const;
       }
-      const hasAccessToGitHubRepository =
-        await this.gitHubIntegrationManager.hasAccessToGitHubRepository({
-          selector: {
-            organization: organization.id,
-          },
-          repositoryName: input.gitHub.repository,
-        });
-
-      if (!hasAccessToGitHubRepository) {
-        return {
-          __typename: 'GitHubSchemaPublishError',
-          message:
-            `Missing permissions for updating check-runs on GitHub repository '${input.gitHub.repository}'. ` +
-            'Please make sure that the GitHub App has access on the repository.',
-        } as const;
-      }
 
       github = {
         repository: input.gitHub.repository,
@@ -909,6 +893,25 @@ export class SchemaPublisher {
         repository: project.gitRepository,
         sha: input.commit,
       };
+    }
+
+    if (github) {
+      const hasAccessToGitHubRepository =
+        await this.gitHubIntegrationManager.hasAccessToGitHubRepository({
+          selector: {
+            organization: organization.id,
+          },
+          repositoryName: github.repository,
+        });
+
+      if (!hasAccessToGitHubRepository) {
+        return {
+          __typename: 'GitHubSchemaPublishError',
+          message:
+            `Missing permissions for updating check-runs on GitHub repository '${github.repository}'. ` +
+            'Please make sure that the GitHub App has access on the repository.',
+        } as const;
+      }
     }
 
     await this.schemaManager.completeGetStartedCheck({

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -239,6 +239,26 @@ export class SchemaPublisher {
       }
     }
 
+    if (github != null) {
+      // Verify that the GitHub repository can be accessed by the user
+      const hasAccessToGitHubRepository =
+        await this.gitHubIntegrationManager.hasAccessToGitHubRepository({
+          selector: {
+            organization: organization.id,
+          },
+          repositoryName: github.repository,
+        });
+
+      if (!hasAccessToGitHubRepository) {
+        return {
+          __typename: 'GitHubSchemaCheckError' as const,
+          message:
+            `Missing permissions for updating check-runs on GitHub repository '${github.repository}'. ` +
+            'Please make sure that the GitHub App has access on the repository.',
+        };
+      }
+    }
+
     await this.schemaManager.completeGetStartedCheck({
       organization: project.orgId,
       step: 'checkingSchema',
@@ -855,6 +875,22 @@ export class SchemaPublisher {
         return {
           __typename: 'GitHubSchemaPublishError' as const,
           message: 'Invalid github repository name provided.',
+        } as const;
+      }
+      const hasAccessToGitHubRepository =
+        await this.gitHubIntegrationManager.hasAccessToGitHubRepository({
+          selector: {
+            organization: organization.id,
+          },
+          repositoryName: input.gitHub.repository,
+        });
+
+      if (!hasAccessToGitHubRepository) {
+        return {
+          __typename: 'GitHubSchemaPublishError',
+          message:
+            `Missing permissions for updating check-runs on GitHub repository '${input.gitHub.repository}'. ` +
+            'Please make sure that the GitHub App has access on the repository.',
         } as const;
       }
 


### PR DESCRIPTION
### Description

Instead of creating a GitHub check run at the end of the pipeline, we try to create a GitHub check run before running any of the schema composition or schema check logic as some kind of way to verify we can access the repository and then, afterward update the existing check-run.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
