### PR TITLE
fix: opencontainer label for images

### DIFF
--- a/docker/app.dockerfile
+++ b/docker/app.dockerfile
@@ -15,6 +15,7 @@ LABEL org.opencontainers.image.description=$IMAGE_DESCRIPTION
 LABEL org.opencontainers.image.authors="The Guild"
 LABEL org.opencontainers.image.vendor="Kamil Kisiela"
 LABEL org.opencontainers.image.url="https://github.com/kamilkisiela/graphql-hive"
+LABEL org.opencontainers.image.source="https://github.com/kamilkisiela/graphql-hive"
 
 ENV ENVIRONMENT production
 ENV RELEASE $RELEASE

--- a/docker/cli.dockerfile
+++ b/docker/cli.dockerfile
@@ -16,6 +16,7 @@ LABEL org.opencontainers.image.description=$IMAGE_DESCRIPTION
 LABEL org.opencontainers.image.authors="The Guild"
 LABEL org.opencontainers.image.vendor="Kamil Kisiela"
 LABEL org.opencontainers.image.url="https://github.com/kamilkisiela/graphql-hive"
+LABEL org.opencontainers.image.source="https://github.com/kamilkisiela/graphql-hive"
 
 ENV ENVIRONMENT production
 ENV RELEASE $RELEASE

--- a/docker/migrations.dockerfile
+++ b/docker/migrations.dockerfile
@@ -8,4 +8,12 @@ COPY . /usr/src/app/
 ENV ENVIRONMENT production
 ENV NODE_ENV production
 
+LABEL org.opencontainers.image.title=$IMAGE_TITLE
+LABEL org.opencontainers.image.version=$RELEASE
+LABEL org.opencontainers.image.description=$IMAGE_DESCRIPTION
+LABEL org.opencontainers.image.authors="The Guild"
+LABEL org.opencontainers.image.vendor="Kamil Kisiela"
+LABEL org.opencontainers.image.url="https://github.com/kamilkisiela/graphql-hive"
+LABEL org.opencontainers.image.source="https://github.com/kamilkisiela/graphql-hive"
+
 CMD ["node", "index.js"]

--- a/docker/router.dockerfile
+++ b/docker/router.dockerfile
@@ -43,6 +43,7 @@ LABEL org.opencontainers.image.description=$IMAGE_DESCRIPTION
 LABEL org.opencontainers.image.authors="The Guild"
 LABEL org.opencontainers.image.vendor="Kamil Kisiela"
 LABEL org.opencontainers.image.url="https://github.com/kamilkisiela/graphql-hive"
+LABEL org.opencontainers.image.source="https://github.com/kamilkisiela/graphql-hive"
 
 RUN mkdir -p /dist/config
 RUN mkdir /dist/schema

--- a/docker/services.dockerfile
+++ b/docker/services.dockerfile
@@ -11,6 +11,7 @@ LABEL org.opencontainers.image.description=$IMAGE_DESCRIPTION
 LABEL org.opencontainers.image.authors="The Guild"
 LABEL org.opencontainers.image.vendor="Kamil Kisiela"
 LABEL org.opencontainers.image.url="https://github.com/kamilkisiela/graphql-hive"
+LABEL org.opencontainers.image.source="https://github.com/kamilkisiela/graphql-hive"
 
 ENV ENVIRONMENT production
 ENV RELEASE $RELEASE


### PR DESCRIPTION
### Background

![CleanShot 2023-10-11 at 12 46 23](https://github.com/kamilkisiela/graphql-hive/assets/44710980/a99c93fe-a209-4e12-8fa7-8bca14f5825d)
https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry

### Description

As per the `opencontainers/image-spec` setting the correct label for source of repository.
