### PR TITLE
Publishing schema with a deprecated "github: false" should be successful

### DIFF
--- a/integration-tests/testkit/seed.ts
+++ b/integration-tests/testkit/seed.ts
@@ -533,6 +533,10 @@ export function initSeed() {
                       service?: string;
                       url?: string;
                       metadata?: string;
+                      /**
+                       * @deprecated
+                       */
+                      github?: boolean | null;
                     }) {
                       return await publishSchema(
                         {
@@ -545,6 +549,7 @@ export function initSeed() {
                           metadata: options.metadata,
                           experimental_acceptBreakingChanges:
                             options.experimental_acceptBreakingChanges,
+                          github: options.github,
                         },
                         secret,
                         options.headerName || 'authorization',

--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -3562,3 +3562,30 @@ test.concurrent(
     }
   },
 );
+
+test.concurrent(
+  'publishing schema with a deprecated "github: false" should be successful',
+  async ({ expect }) => {
+    const { createOrg } = await initSeed().createOwner();
+    const { createProject } = await createOrg();
+    const { createToken } = await createProject(ProjectType.Single);
+    const readWriteToken = await createToken({
+      targetScopes: [TargetAccessScope.RegistryRead, TargetAccessScope.RegistryWrite],
+      projectScopes: [],
+      organizationScopes: [],
+    });
+
+    const result = await readWriteToken
+      .publishSchema({
+        sdl: /* GraphQL */ `
+          type Query {
+            ping: String
+          }
+        `,
+        github: false,
+      })
+      .then(r => r.expectNoGraphQLErrors());
+
+    expect(result.schemaPublish.__typename).toBe('SchemaPublishSuccess');
+  },
+);

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -862,7 +862,7 @@ export class SchemaPublisher {
         repository: input.gitHub.repository,
         sha: input.gitHub.commit,
       };
-    } else if (input.github === true) {
+    } else if (input.github != null) {
       if (!project.gitRepository) {
         return {
           __typename: 'GitHubSchemaPublishError',

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -862,7 +862,7 @@ export class SchemaPublisher {
         repository: input.gitHub.repository,
         sha: input.gitHub.commit,
       };
-    } else if (input.github != null) {
+    } else if (input.github === true) {
       if (!project.gitRepository) {
         return {
           __typename: 'GitHubSchemaPublishError',


### PR DESCRIPTION
To prove it was a bug: https://github.com/kamilkisiela/graphql-hive/actions/runs/6494033401/job/17636446607?pr=3040