### PR TITLE
Remove Github Integration from project settings

### DIFF
--- a/packages/web/app/pages/[organizationId]/[projectId]/view/settings.tsx
+++ b/packages/web/app/pages/[organizationId]/[projectId]/view/settings.tsx
@@ -19,7 +19,7 @@ import {
 } from '@/components/ui/card';
 import { Subtitle, Title } from '@/components/ui/page';
 import { QueryError } from '@/components/ui/query-error';
-import { DocsLink, Input, Link, MetaTitle, Tag } from '@/components/v2';
+import { DocsLink, Input, MetaTitle } from '@/components/v2';
 import { HiveLogo } from '@/components/v2/icon';
 import { DeleteProjectModal } from '@/components/v2/modals';
 import { graphql, useFragment } from '@/gql';
@@ -55,7 +55,6 @@ export const GithubIntegration_EnableProjectNameInGitHubCheckMutation = graphql(
 `);
 
 function GitHubIntegration(props: {
-  isProjectNameInGitHubCheckEnabled: boolean;
   organizationName: string;
   projectName: string;
 }): ReactElement | null {
@@ -81,144 +80,85 @@ function GitHubIntegration(props: {
 
   const githubIntegration = integrationQuery.data?.organization?.organization.gitHubIntegration;
 
+  if (!githubIntegration) {
+    return null;
+  }
+
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Git Repository</CardTitle>
+        <CardTitle>Use project's name in GitHub Check</CardTitle>
         <CardDescription>
-          Associate your project with a Git repository to enable commit linking and to allow CI
-          integration.
-          <br />
-          <DocsLink
-            className="text-muted-foreground text-sm"
-            href="/management/projects#github-repository"
-          >
-            Learn more about GitHub integration
-          </DocsLink>
+          Prevents GitHub Check name collisions when running{' '}
+          <NextLink href={docksLink}>
+            <span className="mx-1 text-orange-700 hover:underline hover:underline-offset-4">
+              $ hive schema:check --github
+            </span>
+          </NextLink>
+          for more than one project.
         </CardDescription>
       </CardHeader>
       <CardContent>
-        {githubIntegration ? (
-          <>
-            {props.isProjectNameInGitHubCheckEnabled ? null : (
-              <div className="flex flex-row justify-between items-center rounded-sm p-4 mb-4 gap-x-4 text-sm bg-gray-500/10 text-gray-500">
-                <div className="space-y-2">
-                  <div>
-                    <div className="text-gray-300 font-bold">
-                      Use project's name in GitHub Check
-                    </div>
-                    <div>
-                      Prevents GitHub Check name collisions when running{' '}
-                      <NextLink href={docksLink}>
-                        <span className="mx-1 text-orange-700 hover:underline hover:underline-offset-4">
-                          $ hive schema:check --github
-                        </span>
-                      </NextLink>
-                      for more than one project.
-                    </div>
-                  </div>
-                  <div>
-                    <div className="mt-4 mb-2">
-                      Here's how it will look like in your CI pipeline:
-                    </div>
-                    <div className="flex items-center gap-x-2 pl-1">
-                      <CheckIcon className="w-4 h-4 text-emerald-500" />
-                      <div className="bg-white w-6 h-6 flex items-center justify-center rounded-sm">
-                        <HiveLogo className="w-[80%] h-[80%]" />
-                      </div>
-
-                      <div className="font-semibold text-[#adbac7]">
-                        {props.organizationName} &gt; schema:check &gt; staging
-                      </div>
-                      <div className="text-gray-500">— No changes</div>
-                    </div>
-                  </div>
-                  <div>
-                    <ArrowBigDownDashIcon className="w-6 h-6" />
-                  </div>
-                  <div>
-                    <div className="flex items-center gap-x-2 pl-1">
-                      <CheckIcon className="w-4 h-4 text-emerald-500" />
-                      <div className="bg-white w-6 h-6 flex items-center justify-center rounded-sm">
-                        <HiveLogo className="w-[80%] h-[80%]" />
-                      </div>
-
-                      <div className="font-semibold text-[#adbac7]">
-                        {props.organizationName} &gt; schema:check &gt; {props.projectName} &gt;
-                        staging
-                      </div>
-                      <div className="text-gray-500">— No changes</div>
-                    </div>
-                  </div>
+        <div className="flex flex-row justify-between items-center rounded-sm mb-4 gap-x-4 text-sm text-muted-foreground">
+          <div className="space-y-2">
+            <div>
+              <div className="mb-4">Here's how it will look like in your CI pipeline.</div>
+              <div className="flex items-center gap-x-2 pl-1">
+                <CheckIcon className="w-4 h-4 text-emerald-500" />
+                <div className="bg-white w-6 h-6 flex items-center justify-center rounded-sm">
+                  <HiveLogo className="w-[80%] h-[80%]" />
                 </div>
-                <div className="pr-6">
-                  <Button
-                    disabled={ghCheckMutation.fetching}
-                    onClick={() => {
-                      void ghCheckMutate({
-                        input: {
-                          organization: router.organizationId,
-                          project: router.projectId,
-                        },
-                      }).then(
-                        result => {
-                          if (result.error) {
-                            notify('Failed to enable', 'error');
-                          } else {
-                            notify('Migration completed', 'success');
-                          }
-                        },
-                        _ => {
-                          notify('Failed to enable', 'error');
-                        },
-                      );
-                    }}
-                  >
-                    I want to migrate
-                  </Button>
+
+                <div className="font-semibold text-[#adbac7]">
+                  {props.organizationName} &gt; schema:check &gt; staging
                 </div>
+                <div className="text-gray-500">— No changes</div>
               </div>
-            )}
-            <p className="text-gray-300">
-              This project can access and update check-runs of the following GitHub repositories.
-            </p>
-            <Tag className="!p-4">
-              The list of repositories can be adjusted in the organization settings.
-              <Link
-                variant="primary"
-                href={{
-                  pathname: '/[organizationId]/view/settings',
-                  query: {
-                    organizationId: router.organizationId,
+            </div>
+            <div>
+              <ArrowBigDownDashIcon className="w-6 h-6" />
+            </div>
+            <div>
+              <div className="flex items-center gap-x-2 pl-1">
+                <CheckIcon className="w-4 h-4 text-emerald-500" />
+                <div className="bg-white w-6 h-6 flex items-center justify-center rounded-sm">
+                  <HiveLogo className="w-[80%] h-[80%]" />
+                </div>
+
+                <div className="font-semibold text-[#adbac7]">
+                  {props.organizationName} &gt; schema:check &gt; {props.projectName} &gt; staging
+                </div>
+                <div className="text-gray-500">— No changes</div>
+              </div>
+            </div>
+          </div>
+          <div className="pr-6">
+            <Button
+              disabled={ghCheckMutation.fetching}
+              onClick={() => {
+                void ghCheckMutate({
+                  input: {
+                    organization: router.organizationId,
+                    project: router.projectId,
                   },
-                }}
-              >
-                Visit settings
-              </Link>
-            </Tag>
-            <ul className="text-gray-300 mt-2">
-              {githubIntegration.repositories.map(repository => (
-                <li key={repository.nameWithOwner}>{repository.nameWithOwner}</li>
-              ))}
-            </ul>
-          </>
-        ) : (
-          <Tag className="!p-4 mt-2">
-            The organization is not connected to our GitHub Application.
-            <Link
-              variant="primary"
-              href={{
-                pathname: '/[organizationId]/view/settings',
-                query: {
-                  organizationId: router.organizationId,
-                },
+                }).then(
+                  result => {
+                    if (result.error) {
+                      notify('Failed to enable', 'error');
+                    } else {
+                      notify('Migration completed', 'success');
+                    }
+                  },
+                  _ => {
+                    notify('Failed to enable', 'error');
+                  },
+                );
               }}
             >
-              Visit settings
-            </Link>
-            to configure it.
-          </Tag>
-        )}
+              I want to migrate
+            </Button>
+          </div>
+        </div>
       </CardContent>
     </Card>
   );
@@ -411,11 +351,11 @@ function ProjectSettingsContent() {
                 </Card>
               </form>
 
-              {query.data?.isGitHubIntegrationFeatureEnabled ? (
+              {query.data?.isGitHubIntegrationFeatureEnabled &&
+              !project.isProjectNameInGitHubCheckEnabled ? (
                 <GitHubIntegration
                   organizationName={organization.name}
                   projectName={project.name}
-                  isProjectNameInGitHubCheckEnabled={project.isProjectNameInGitHubCheckEnabled}
                 />
               ) : null}
 


### PR DESCRIPTION
@n1ru4l it is no longer needed I think, the only purpose is to display either "No github connected" or "here's a list of repositories". I think it's fine to remove it as there is no action button.

I left there only the "use project's name in check" migration.