### PR TITLE
Use Node's Fetch API

### DIFF
--- a/docker/docker-compose.community.yml
+++ b/docker/docker-compose.community.yml
@@ -127,6 +127,13 @@ services:
       POSTGRESQL_HOST: db
       POSTGRESQL_PORT: 5432
       API_KEYS: '${SUPERTOKENS_API_KEY}'
+    healthcheck:
+      test: >
+        bash -c 'exec 3<>/dev/tcp/127.0.0.1/3567 && echo -e "GET /hello HTTP/1.1\r\nhost:
+        127.0.0.1:3567\r\nConnection: close\r\n\r\n" >&3 && cat <&3 | grep "Hello"'
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   s3:
     image: quay.io/minio/minio:RELEASE.2022-11-29T23-40-49Z
@@ -169,6 +176,13 @@ services:
     ports:
       - '8083:8083'
     command: caddy reverse-proxy --from :8083 --to s3:9000 --change-host-header
+    healthcheck:
+      # https://stackoverflow.com/a/47722899/5008962
+      test: ['CMD', 'wget', '--spider', '-q', 'http://localhost:8083/minio/health/live']
+      interval: 5s
+      timeout: 10s
+      retries: 6
+      start_period: 5s
 
   migrations:
     image: '${DOCKER_REGISTRY}storage${DOCKER_TAG}'

--- a/integration-tests/docker-compose.integration.yaml
+++ b/integration-tests/docker-compose.integration.yaml
@@ -264,8 +264,24 @@ services:
   app:
     image: node:21.3.0-alpine3.17
     command: ['npx', 'http-server']
+    environment:
+      PORT: 2182
+    healthcheck:
+      test: ['CMD', 'wget', '--spider', '-q', 'localhost:2182']
+      interval: 5s
+      timeout: 5s
+      retries: 6
+      start_period: 5s
 
   # Redpand is used for integration tests, instead of Kafka. Zookeeper is no longer needed
   zookeeper:
     image: node:21.3.0-alpine3.17
     command: ['npx', 'http-server']
+    environment:
+      PORT: 2181
+    healthcheck:
+      test: ['CMD', 'wget', '--spider', '-q', 'localhost:2181']
+      interval: 5s
+      timeout: 5s
+      retries: 6
+      start_period: 5s

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -22,7 +22,6 @@
     "@trpc/server": "10.44.1",
     "@types/dockerode": "3.3.23",
     "@types/ioredis": "4.28.10",
-    "@whatwg-node/fetch": "0.9.13",
     "bcryptjs": "2.4.3",
     "date-fns": "2.30.0",
     "dockerode": "4.0.0",

--- a/integration-tests/testkit/auth.ts
+++ b/integration-tests/testkit/auth.ts
@@ -1,13 +1,8 @@
 import { z } from 'zod';
 import type { InternalApi } from '@hive/server';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
-import { createFetch } from '@whatwg-node/fetch';
 import { ensureEnv } from './env';
 import { getServiceHost } from './utils';
-
-const { fetch } = createFetch({
-  useNodeFetch: true,
-});
 
 const SignUpSignInUserResponseModel = z
   .object({

--- a/integration-tests/testkit/cli.ts
+++ b/integration-tests/testkit/cli.ts
@@ -23,6 +23,9 @@ async function exec(cmd: string) {
   const outout = await execaCommand(`${binPath} ${cmd}`, {
     shell: true,
     env: {
+      // Disable deprecation warnings for the tests
+      // Node v21 gives deprecation warning about the punycode usage in some of our dependencies.
+      NODE_OPTIONS: '--no-deprecation',
       OCLIF_CLI_CUSTOM_PATH: cliDir,
     },
   });

--- a/integration-tests/testkit/clickhouse.ts
+++ b/integration-tests/testkit/clickhouse.ts
@@ -1,5 +1,4 @@
 /* eslint-disable no-process-env */
-import { fetch } from '@whatwg-node/fetch';
 import { ensureEnv } from './env';
 import { getServiceHost } from './utils';
 

--- a/integration-tests/testkit/emails.ts
+++ b/integration-tests/testkit/emails.ts
@@ -1,4 +1,3 @@
-import { fetch } from '@whatwg-node/fetch';
 import { getServiceHost } from './utils';
 
 export interface Email {

--- a/integration-tests/testkit/external-composition.ts
+++ b/integration-tests/testkit/external-composition.ts
@@ -1,4 +1,3 @@
-import { fetch } from '@whatwg-node/fetch';
 import { getServiceHost } from './utils';
 
 export const serviceName = 'external_composition';

--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -1,4 +1,3 @@
-import { fetch } from '@whatwg-node/fetch';
 import { graphql } from './gql';
 import type {
   AnswerOrganizationTransferRequestInput,

--- a/integration-tests/testkit/graphql.ts
+++ b/integration-tests/testkit/graphql.ts
@@ -1,11 +1,6 @@
 import { ExecutionResult, print } from 'graphql';
 import { TypedDocumentNode } from '@graphql-typed-document-node/core';
-import { createFetch } from '@whatwg-node/fetch';
 import { getServiceHost } from './utils';
-
-const { fetch } = createFetch({
-  useNodeFetch: true,
-});
 
 export async function execute<TResult, TVariables>(
   params: {

--- a/integration-tests/testkit/usage.ts
+++ b/integration-tests/testkit/usage.ts
@@ -1,4 +1,3 @@
-import { fetch } from '@whatwg-node/fetch';
 import { getServiceHost } from './utils';
 
 export interface CollectedOperation {

--- a/integration-tests/tests/api/artifacts-cdn.spec.ts
+++ b/integration-tests/tests/api/artifacts-cdn.spec.ts
@@ -11,7 +11,6 @@ import {
   S3Client,
 } from '@aws-sdk/client-s3';
 import { createSupergraphManager } from '@graphql-hive/client';
-import { fetch } from '@whatwg-node/fetch';
 import { graphql } from '../../testkit/gql';
 import { execute } from '../../testkit/graphql';
 import { initSeed } from '../../testkit/seed';

--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -6,7 +6,6 @@ import { execute } from 'testkit/graphql';
 import { ProjectAccessScope, ProjectType, TargetAccessScope } from '@app/gql/graphql';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { createStorage } from '@hive/storage';
-import { fetch } from '@whatwg-node/fetch';
 import {
   createTarget,
   enableExternalSchemaComposition,

--- a/packages/libraries/cli/package.json
+++ b/packages/libraries/cli/package.json
@@ -56,7 +56,7 @@
     "@oclif/core": "^2.8.5",
     "@oclif/plugin-help": "5.2.20",
     "@oclif/plugin-update": "3.2.4",
-    "node-fetch": "3.3.2",
+    "@whatwg-node/node-fetch": "0.5.1",
     "colors": "1.4.0",
     "env-ci": "7.3.0",
     "graphql": "^16.8.1",

--- a/packages/libraries/cli/package.json
+++ b/packages/libraries/cli/package.json
@@ -56,7 +56,7 @@
     "@oclif/core": "^2.8.5",
     "@oclif/plugin-help": "5.2.20",
     "@oclif/plugin-update": "3.2.4",
-    "@whatwg-node/fetch": "0.9.13",
+    "node-fetch": "3.3.2",
     "colors": "1.4.0",
     "env-ci": "7.3.0",
     "graphql": "^16.8.1",

--- a/packages/libraries/cli/src/base-command.ts
+++ b/packages/libraries/cli/src/base-command.ts
@@ -4,7 +4,6 @@ import type { ExecutionResult } from 'graphql';
 import symbols from 'log-symbols';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { Command, Errors, Config as OclifConfig } from '@oclif/core';
-import fetch from 'node-fetch';
 import { Config, GetConfigurationValueType, ValidConfigurationKeys } from './helpers/config';
 
 type OmitNever<T> = { [K in keyof T as T[K] extends never ? never : K]: T[K] };
@@ -159,6 +158,7 @@ export default abstract class extends Command {
         operation: TypedDocumentNode<TResult, TVariables>,
         ...[variables]: TVariables extends Record<string, never> ? [] : [TVariables]
       ): Promise<TResult> {
+        const fetch = await import('node-fetch').then(m => m.default);
         const response = await fetch(registry, {
           headers: requestHeaders,
           method: 'POST',

--- a/packages/libraries/cli/src/base-command.ts
+++ b/packages/libraries/cli/src/base-command.ts
@@ -5,6 +5,7 @@ import symbols from 'log-symbols';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { Command, Errors, Config as OclifConfig } from '@oclif/core';
 import { Config, GetConfigurationValueType, ValidConfigurationKeys } from './helpers/config';
+import { fetch } from '@whatwg-node/node-fetch';
 
 type OmitNever<T> = { [K in keyof T as T[K] extends never ? never : K]: T[K] };
 
@@ -158,7 +159,6 @@ export default abstract class extends Command {
         operation: TypedDocumentNode<TResult, TVariables>,
         ...[variables]: TVariables extends Record<string, never> ? [] : [TVariables]
       ): Promise<TResult> {
-        const fetch = await import('node-fetch').then(m => m.default);
         const response = await fetch(registry, {
           headers: requestHeaders,
           method: 'POST',

--- a/packages/libraries/cli/src/base-command.ts
+++ b/packages/libraries/cli/src/base-command.ts
@@ -4,7 +4,7 @@ import type { ExecutionResult } from 'graphql';
 import symbols from 'log-symbols';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { Command, Errors, Config as OclifConfig } from '@oclif/core';
-import { fetch } from '@whatwg-node/fetch';
+import fetch from 'node-fetch';
 import { Config, GetConfigurationValueType, ValidConfigurationKeys } from './helpers/config';
 
 type OmitNever<T> = { [K in keyof T as T[K] extends never ? never : K]: T[K] };
@@ -181,7 +181,7 @@ export default abstract class extends Command {
               .join('\n')}`,
             {
               errors: jsonData.errors,
-              headers: response.headers,
+              headers: response.headers as any,
             },
           );
         }

--- a/packages/libraries/cli/src/commands/artifact/fetch.ts
+++ b/packages/libraries/cli/src/commands/artifact/fetch.ts
@@ -1,6 +1,7 @@
 import { Flags } from '@oclif/core';
 import { URL } from 'url';
 import Command from '../../base-command';
+import { fetch } from '@whatwg-node/node-fetch';
 
 export default class ArtifactsFetch extends Command {
   static description = 'fetch artifacts from the CDN';
@@ -40,7 +41,6 @@ export default class ArtifactsFetch extends Command {
 
     const url = new URL(`${cdnEndpoint}/${artifactType}`);
 
-    const fetch = await import('node-fetch').then(m => m.default);
     const response = await fetch(url.toString(), {
       headers: {
         'x-hive-cdn-key': token,

--- a/packages/libraries/cli/src/commands/artifact/fetch.ts
+++ b/packages/libraries/cli/src/commands/artifact/fetch.ts
@@ -1,5 +1,6 @@
 import { Flags } from '@oclif/core';
-import { fetch, URL } from '@whatwg-node/fetch';
+import { URL } from 'url';
+import fetch from 'node-fetch';
 import Command from '../../base-command';
 
 export default class ArtifactsFetch extends Command {

--- a/packages/libraries/cli/src/commands/artifact/fetch.ts
+++ b/packages/libraries/cli/src/commands/artifact/fetch.ts
@@ -1,6 +1,5 @@
 import { Flags } from '@oclif/core';
 import { URL } from 'url';
-import fetch from 'node-fetch';
 import Command from '../../base-command';
 
 export default class ArtifactsFetch extends Command {
@@ -41,6 +40,7 @@ export default class ArtifactsFetch extends Command {
 
     const url = new URL(`${cdnEndpoint}/${artifactType}`);
 
+    const fetch = await import('node-fetch').then(m => m.default);
     const response = await fetch(url.toString(), {
       headers: {
         'x-hive-cdn-key': token,

--- a/packages/libraries/client/src/version.ts
+++ b/packages/libraries/client/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.26.0';
+export const version = '0.27.0';

--- a/packages/migrations/package.json
+++ b/packages/migrations/package.json
@@ -21,7 +21,6 @@
     "@types/bcryptjs": "2.4.6",
     "@types/node": "20.10.3",
     "@types/pg": "8.10.9",
-    "@whatwg-node/fetch": "0.9.13",
     "bcryptjs": "2.4.3",
     "copyfiles": "2.4.1",
     "dotenv": "16.3.1",

--- a/packages/migrations/src/actions/2023.01.17T10.46.28.import-legacy-s3-keys-to-database.ts
+++ b/packages/migrations/src/actions/2023.01.17T10.46.28.import-legacy-s3-keys-to-database.ts
@@ -2,7 +2,6 @@ import { createHmac } from 'crypto';
 import bcryptjs from 'bcryptjs';
 import pLimit from 'p-limit';
 import * as zod from 'zod';
-import { crypto, fetch, Headers, Request, TextEncoder } from '@whatwg-node/fetch';
 import { type MigrationExecutor } from '../pg-migrator';
 
 // treat an empty string (`''`) as undefined

--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -35,7 +35,6 @@
     "@types/lodash": "4.14.202",
     "@types/ms": "0.7.34",
     "@types/object-hash": "3.0.6",
-    "@whatwg-node/fetch": "0.9.13",
     "agentkeepalive": "4.5.0",
     "bcryptjs": "2.4.3",
     "dataloader": "2.2.2",

--- a/packages/services/api/src/modules/alerts/providers/adapters/webhook.ts
+++ b/packages/services/api/src/modules/alerts/providers/adapters/webhook.ts
@@ -1,7 +1,6 @@
 import { CONTEXT, Inject, Injectable, Scope } from 'graphql-modules';
 import type { WebhooksApi } from '@hive/webhooks';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
-import { fetch } from '@whatwg-node/fetch';
 import { HttpClient } from '../../../shared/providers/http-client';
 import { Logger } from '../../../shared/providers/logger';
 import type { WebhooksConfig } from '../tokens';

--- a/packages/services/api/src/modules/billing/providers/billing.provider.ts
+++ b/packages/services/api/src/modules/billing/providers/billing.provider.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable, Scope } from 'graphql-modules';
 import type { StripeBillingApi, StripeBillingApiInput } from '@hive/stripe-billing';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
-import { fetch } from '@whatwg-node/fetch';
 import { OrganizationSelector } from '../../../__generated__/types';
 import { OrganizationBilling } from '../../../shared/entities';
 import { Logger } from '../../shared/providers/logger';

--- a/packages/services/api/src/modules/cdn/providers/cdn.provider.ts
+++ b/packages/services/api/src/modules/cdn/providers/cdn.provider.ts
@@ -2,7 +2,6 @@ import bcryptjs from 'bcryptjs';
 import { Inject, Injectable, Scope } from 'graphql-modules';
 import { z } from 'zod';
 import { encodeCdnToken, generatePrivateKey } from '@hive/cdn-script/cdn-token';
-import { crypto } from '@whatwg-node/fetch';
 import { HiveError } from '../../../shared/errors';
 import { isUUID } from '../../../shared/is-uuid';
 import { AuthManager } from '../../auth/providers/auth-manager';

--- a/packages/services/api/src/modules/policy/providers/schema-policy-api.provider.ts
+++ b/packages/services/api/src/modules/policy/providers/schema-policy-api.provider.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable, Scope } from 'graphql-modules';
 import type { AvailableRulesResponse, SchemaPolicyApi, SchemaPolicyApiInput } from '@hive/policy';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
-import { fetch } from '@whatwg-node/fetch';
 import { sentry } from '../../../shared/sentry';
 import { Logger } from '../../shared/providers/logger';
 import type { SchemaPolicyServiceConfig } from './tokens';

--- a/packages/services/api/src/modules/rate-limit/providers/rate-limit.provider.ts
+++ b/packages/services/api/src/modules/rate-limit/providers/rate-limit.provider.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable, Scope } from 'graphql-modules';
 import type { RateLimitApi, RateLimitApiInput } from '@hive/rate-limit';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
-import { fetch } from '@whatwg-node/fetch';
 import { sentry } from '../../../shared/sentry';
 import { Logger } from '../../shared/providers/logger';
 import type { RateLimitServiceConfig } from './tokens';

--- a/packages/services/api/src/modules/schema/providers/orchestrators/federation.ts
+++ b/packages/services/api/src/modules/schema/providers/orchestrators/federation.ts
@@ -1,7 +1,6 @@
 import { CONTEXT, Inject, Injectable, Scope } from 'graphql-modules';
 import type { SchemaBuilderApi } from '@hive/schema';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
-import { fetch } from '@whatwg-node/fetch';
 import { Orchestrator, Project, ProjectType, SchemaObject } from '../../../../shared/entities';
 import { sentry } from '../../../../shared/sentry';
 import { Logger } from '../../../shared/providers/logger';

--- a/packages/services/api/src/modules/schema/providers/orchestrators/single.ts
+++ b/packages/services/api/src/modules/schema/providers/orchestrators/single.ts
@@ -1,7 +1,6 @@
 import { CONTEXT, Inject, Injectable, Scope } from 'graphql-modules';
 import type { SchemaBuilderApi } from '@hive/schema';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
-import { fetch } from '@whatwg-node/fetch';
 import { Orchestrator, ProjectType, SchemaObject } from '../../../../shared/entities';
 import { sentry } from '../../../../shared/sentry';
 import { Logger } from '../../../shared/providers/logger';

--- a/packages/services/api/src/modules/schema/providers/orchestrators/stitching.ts
+++ b/packages/services/api/src/modules/schema/providers/orchestrators/stitching.ts
@@ -1,7 +1,6 @@
 import { CONTEXT, Inject, Injectable, Scope } from 'graphql-modules';
 import type { SchemaBuilderApi } from '@hive/schema';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
-import { fetch } from '@whatwg-node/fetch';
 import { Orchestrator, ProjectType, SchemaObject } from '../../../../shared/entities';
 import { sentry } from '../../../../shared/sentry';
 import { Logger } from '../../../shared/providers/logger';

--- a/packages/services/api/src/modules/shared/providers/emails.ts
+++ b/packages/services/api/src/modules/shared/providers/emails.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable, InjectionToken, Optional } from 'graphql-modules';
 import type { EmailsApi, EmailsApiInput } from '@hive/emails';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
-import { fetch } from '@whatwg-node/fetch';
 
 export const EMAILS_ENDPOINT = new InjectionToken<string>('EMAILS_ENDPOINT');
 

--- a/packages/services/api/src/modules/token/providers/token-storage.ts
+++ b/packages/services/api/src/modules/token/providers/token-storage.ts
@@ -1,7 +1,6 @@
 import { CONTEXT, Inject, Injectable, Scope } from 'graphql-modules';
 import type { TokensApi } from '@hive/tokens';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
-import { fetch } from '@whatwg-node/fetch';
 import type { Token } from '../../../shared/entities';
 import { HiveError } from '../../../shared/errors';
 import { atomic } from '../../../shared/helpers';

--- a/packages/services/api/src/modules/usage-estimation/providers/usage-estimation.provider.ts
+++ b/packages/services/api/src/modules/usage-estimation/providers/usage-estimation.provider.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable, Scope } from 'graphql-modules';
 import type { UsageEstimatorApi, UsageEstimatorApiInput } from '@hive/usage-estimator';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
-import { fetch } from '@whatwg-node/fetch';
 import { sentry } from '../../../shared/sentry';
 import { Logger } from '../../shared/providers/logger';
 import type { UsageEstimationServiceConfig } from './tokens';

--- a/packages/services/broker-worker/package.json
+++ b/packages/services/broker-worker/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "4.20231121.0",
     "@types/service-worker-mock": "2.0.4",
-    "@whatwg-node/server": "0.9.10",
+    "@whatwg-node/server": "0.9.18",
     "esbuild": "0.19.8",
     "itty-router": "4.0.23",
     "toucan-js": "3.3.1",

--- a/packages/services/broker-worker/package.json
+++ b/packages/services/broker-worker/package.json
@@ -11,12 +11,12 @@
   "devDependencies": {
     "@cloudflare/workers-types": "4.20231121.0",
     "@types/service-worker-mock": "2.0.4",
-    "@whatwg-node/fetch": "0.9.13",
     "@whatwg-node/server": "0.9.10",
     "esbuild": "0.19.8",
     "itty-router": "4.0.23",
-    "nock": "13.4.0",
     "toucan-js": "3.3.1",
+    "undici": "5.26.3",
+    "vitest": "0.34.6",
     "workers-loki-logger": "0.1.15",
     "zod": "3.22.4"
   }

--- a/packages/services/broker-worker/package.json
+++ b/packages/services/broker-worker/package.json
@@ -11,7 +11,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "4.20231121.0",
     "@types/service-worker-mock": "2.0.4",
-    "@whatwg-node/server": "0.9.18",
+    "@whatwg-node/server": "0.9.10",
     "esbuild": "0.19.8",
     "itty-router": "4.0.23",
     "toucan-js": "3.3.1",

--- a/packages/services/broker-worker/src/dev-polyfill.ts
+++ b/packages/services/broker-worker/src/dev-polyfill.ts
@@ -1,24 +1,4 @@
-import { createFetch, Headers, ReadableStream, Request, Response } from '@whatwg-node/fetch';
 import type { Env } from './env';
-
-const nodeFetch = createFetch({
-  useNodeFetch: true,
-});
-
-if (!globalThis.Response) {
-  globalThis.Response = Response;
-}
-if (!globalThis.Request) {
-  globalThis.Request = Request;
-}
-if (!globalThis.Headers) {
-  globalThis.Headers = Headers;
-}
-if (!globalThis.ReadableStream) {
-  globalThis.ReadableStream = ReadableStream;
-}
-
-globalThis.fetch = nodeFetch.fetch;
 
 export const env: Env = {
   // eslint-disable-next-line no-process-env

--- a/packages/services/cdn-worker/package.json
+++ b/packages/services/cdn-worker/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "4.20231121.0",
     "@types/service-worker-mock": "2.0.4",
-    "@whatwg-node/server": "0.9.18",
+    "@whatwg-node/server": "0.9.10",
     "bcryptjs": "2.4.3",
     "dotenv": "16.3.1",
     "esbuild": "0.19.8",

--- a/packages/services/cdn-worker/package.json
+++ b/packages/services/cdn-worker/package.json
@@ -19,7 +19,6 @@
   "devDependencies": {
     "@cloudflare/workers-types": "4.20231121.0",
     "@types/service-worker-mock": "2.0.4",
-    "@whatwg-node/fetch": "0.9.13",
     "@whatwg-node/server": "0.9.10",
     "bcryptjs": "2.4.3",
     "dotenv": "16.3.1",

--- a/packages/services/cdn-worker/package.json
+++ b/packages/services/cdn-worker/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@cloudflare/workers-types": "4.20231121.0",
     "@types/service-worker-mock": "2.0.4",
-    "@whatwg-node/server": "0.9.10",
+    "@whatwg-node/server": "0.9.18",
     "bcryptjs": "2.4.3",
     "dotenv": "16.3.1",
     "esbuild": "0.19.8",

--- a/packages/services/cdn-worker/src/artifact-handler.ts
+++ b/packages/services/cdn-worker/src/artifact-handler.ts
@@ -1,6 +1,5 @@
 import * as itty from 'itty-router';
 import zod from 'zod';
-import { type Request } from '@whatwg-node/fetch';
 import { createAnalytics, type Analytics } from './analytics';
 import { type ArtifactsType } from './artifact-storage-reader';
 import { InvalidAuthKeyResponse, MissingAuthKeyResponse, UnexpectedError } from './errors';
@@ -125,7 +124,7 @@ export const createArtifactRequestHandler = (deps: ArtifactRequestHandler) => {
     if (result.type === 'notModified') {
       return createResponse(
         analytics,
-        '',
+        null,
         {
           status: 304,
         },

--- a/packages/services/cdn-worker/src/aws.ts
+++ b/packages/services/cdn-worker/src/aws.ts
@@ -1,9 +1,3 @@
-/**
- * This is a copy of https://github.com/mhart/aws4fetch which is licensed MIT
- * See https://github.com/mhart/aws4fetch/issues/22
- */
-import { crypto, fetch, Headers, Request, TextEncoder } from '@whatwg-node/fetch';
-
 const encoder = new TextEncoder();
 
 const HOST_SERVICES: Record<string, string | void> = {

--- a/packages/services/cdn-worker/src/cdn-token.ts
+++ b/packages/services/cdn-worker/src/cdn-token.ts
@@ -2,7 +2,6 @@
  * Note: This file needs to run both on Node.js and Cloudflare Workers.
  */
 import * as bc from 'bcryptjs';
-import { crypto } from '@whatwg-node/fetch';
 
 export interface CDNToken {
   keyId: string;

--- a/packages/services/cdn-worker/src/dev-polyfill.ts
+++ b/packages/services/cdn-worker/src/dev-polyfill.ts
@@ -1,24 +1,7 @@
 import 'dotenv/config';
-import { crypto, fetch, Headers, ReadableStream, Request, Response } from '@whatwg-node/fetch';
 import type { Env } from './env';
 
-if (!globalThis.Response) {
-  globalThis.Response = Response;
-}
-if (!globalThis.Request) {
-  globalThis.Request = Request;
-}
-if (!globalThis.Headers) {
-  globalThis.Headers = Headers;
-}
-if (!globalThis.ReadableStream) {
-  globalThis.ReadableStream = ReadableStream;
-}
-if (!globalThis.crypto) {
-  globalThis.crypto = crypto;
-}
-
-export { fetch };
+export const devStorage = new Map<string, string>();
 
 export const env: Env = {
   // eslint-disable-next-line no-process-env

--- a/packages/services/cdn-worker/src/dev.ts
+++ b/packages/services/cdn-worker/src/dev.ts
@@ -5,7 +5,7 @@ import { createArtifactRequestHandler } from './artifact-handler';
 import { ArtifactStorageReader } from './artifact-storage-reader';
 import { AwsClient } from './aws';
 import './dev-polyfill';
-import { env, fetch } from './dev-polyfill';
+import { env } from './dev-polyfill';
 import { createRequestHandler } from './handler';
 import { createIsKeyValid } from './key-validation';
 

--- a/packages/services/cdn-worker/src/errors.ts
+++ b/packages/services/cdn-worker/src/errors.ts
@@ -1,4 +1,3 @@
-import { Response } from '@whatwg-node/fetch';
 import { Analytics } from './analytics';
 
 const description = `Please refer to the documentation for more details: https://docs.graphql-hive.com/features/registry-usage`;

--- a/packages/services/cdn-worker/src/index.ts
+++ b/packages/services/cdn-worker/src/index.ts
@@ -1,6 +1,5 @@
 import * as itty from 'itty-router';
 import { Toucan } from 'toucan-js';
-import { fetch } from '@whatwg-node/fetch';
 import { AnalyticsEngine, createAnalytics } from './analytics';
 import { createArtifactRequestHandler } from './artifact-handler';
 import { ArtifactStorageReader } from './artifact-storage-reader';

--- a/packages/services/cdn-worker/src/key-validation.ts
+++ b/packages/services/cdn-worker/src/key-validation.ts
@@ -1,5 +1,4 @@
 import bcrypt from 'bcryptjs';
-import { Request, Response } from '@whatwg-node/fetch';
 import { Analytics } from './analytics';
 import { type AwsClient } from './aws';
 import { decodeCdnAccessTokenSafe, isCDNAccessToken } from './cdn-token';

--- a/packages/services/cdn-worker/src/tracked-response.ts
+++ b/packages/services/cdn-worker/src/tracked-response.ts
@@ -1,7 +1,4 @@
-import { createFetch } from '@whatwg-node/fetch';
 import type { Analytics } from './analytics';
-
-const { Response } = createFetch({ useNodeFetch: true });
 
 export function createResponse(
   analytics: Analytics,

--- a/packages/services/emails/package.json
+++ b/packages/services/emails/package.json
@@ -17,7 +17,6 @@
     "@types/mjml": "4.7.1",
     "@types/nodemailer": "6.4.14",
     "@types/sendmail": "1.4.7",
-    "@whatwg-node/fetch": "0.9.13",
     "bullmq": "4.14.4",
     "copyfiles": "2.4.1",
     "dotenv": "16.3.1",

--- a/packages/services/emails/src/providers.ts
+++ b/packages/services/emails/src/providers.ts
@@ -1,6 +1,5 @@
 import nodemailer from 'nodemailer';
 import sm from 'sendmail';
-import { fetch } from '@whatwg-node/fetch';
 import type {
   EmailProviderConfig,
   MockEmailProviderConfig,

--- a/packages/services/external-composition/federation-2/package.json
+++ b/packages/services/external-composition/federation-2/package.json
@@ -11,7 +11,6 @@
     "@apollo/composition": "2.6.1",
     "@apollo/federation-internals": "2.6.1",
     "@graphql-hive/external-composition": "workspace:*",
-    "@whatwg-node/fetch": "0.9.13",
     "@whatwg-node/server": "0.9.10",
     "graphql": "16.8.1",
     "lru-cache": "^7.17.0",

--- a/packages/services/external-composition/federation-2/package.json
+++ b/packages/services/external-composition/federation-2/package.json
@@ -11,7 +11,7 @@
     "@apollo/composition": "2.6.1",
     "@apollo/federation-internals": "2.6.1",
     "@graphql-hive/external-composition": "workspace:*",
-    "@whatwg-node/server": "0.9.18",
+    "@whatwg-node/server": "0.9.10",
     "graphql": "16.8.1",
     "lru-cache": "^7.17.0",
     "zod": "3.22.4"

--- a/packages/services/external-composition/federation-2/package.json
+++ b/packages/services/external-composition/federation-2/package.json
@@ -11,7 +11,7 @@
     "@apollo/composition": "2.6.1",
     "@apollo/federation-internals": "2.6.1",
     "@graphql-hive/external-composition": "workspace:*",
-    "@whatwg-node/server": "0.9.10",
+    "@whatwg-node/server": "0.9.18",
     "graphql": "16.8.1",
     "lru-cache": "^7.17.0",
     "zod": "3.22.4"

--- a/packages/services/external-composition/federation-2/src/server.ts
+++ b/packages/services/external-composition/federation-2/src/server.ts
@@ -3,7 +3,6 @@ import LRU from 'lru-cache';
 import { composeServices } from '@apollo/composition';
 import { Supergraph } from '@apollo/federation-internals';
 import { compose, signatureHeaderName, verifyRequest } from '@graphql-hive/external-composition';
-import { Response } from '@whatwg-node/fetch';
 import { createServerAdapter } from '@whatwg-node/server';
 import { ResolvedEnv } from './environment';
 

--- a/packages/services/policy/package.json
+++ b/packages/services/policy/package.json
@@ -15,7 +15,6 @@
     "@sentry/node": "7.85.0",
     "@sentry/tracing": "7.85.0",
     "@trpc/server": "10.44.1",
-    "@whatwg-node/fetch": "0.9.13",
     "ajv": "8.12.0",
     "dotenv": "16.3.1",
     "eslint": "8.55.0",

--- a/packages/services/rate-limit/package.json
+++ b/packages/services/rate-limit/package.json
@@ -17,7 +17,6 @@
     "@sentry/node": "7.85.0",
     "@trpc/client": "10.44.1",
     "@trpc/server": "10.44.1",
-    "@whatwg-node/fetch": "0.9.13",
     "date-fns": "2.30.0",
     "dotenv": "16.3.1",
     "got": "12.6.1",

--- a/packages/services/rate-limit/src/emails.ts
+++ b/packages/services/rate-limit/src/emails.ts
@@ -1,6 +1,5 @@
 import type { EmailsApi } from '@hive/emails';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
-import { fetch } from '@whatwg-node/fetch';
 import { env } from './environment';
 
 export function createEmailScheduler(config?: { endpoint: string }) {

--- a/packages/services/rate-limit/src/limiter.ts
+++ b/packages/services/rate-limit/src/limiter.ts
@@ -4,7 +4,6 @@ import { createStorage as createPostgreSQLStorage } from '@hive/storage';
 import type { UsageEstimatorApi } from '@hive/usage-estimator';
 import * as Sentry from '@sentry/node';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
-import { fetch } from '@whatwg-node/fetch';
 import type { RateLimitInput } from './api';
 import { createEmailScheduler } from './emails';
 import { rateLimitOperationsEventOrg } from './metrics';

--- a/packages/services/schema/package.json
+++ b/packages/services/schema/package.json
@@ -20,7 +20,6 @@
     "@trpc/server": "10.44.1",
     "@types/async-retry": "1.4.8",
     "@types/ioredis-mock": "8.2.5",
-    "@whatwg-node/fetch": "0.9.13",
     "dotenv": "16.3.1",
     "fast-json-stable-stringify": "2.1.0",
     "fastify": "3.29.5",

--- a/packages/services/server/package.json
+++ b/packages/services/server/package.json
@@ -31,7 +31,7 @@
     "@sentry/node": "7.85.0",
     "@swc/core": "1.3.100",
     "@trpc/server": "10.44.1",
-    "@whatwg-node/server": "0.9.10",
+    "@whatwg-node/server": "0.9.18",
     "dotenv": "16.3.1",
     "fastify": "3.29.5",
     "got": "12.6.1",

--- a/packages/services/server/package.json
+++ b/packages/services/server/package.json
@@ -31,7 +31,6 @@
     "@sentry/node": "7.85.0",
     "@swc/core": "1.3.100",
     "@trpc/server": "10.44.1",
-    "@whatwg-node/fetch": "0.9.13",
     "@whatwg-node/server": "0.9.10",
     "dotenv": "16.3.1",
     "fastify": "3.29.5",

--- a/packages/services/server/package.json
+++ b/packages/services/server/package.json
@@ -31,7 +31,7 @@
     "@sentry/node": "7.85.0",
     "@swc/core": "1.3.100",
     "@trpc/server": "10.44.1",
-    "@whatwg-node/server": "0.9.18",
+    "@whatwg-node/server": "0.9.10",
     "dotenv": "16.3.1",
     "fastify": "3.29.5",
     "got": "12.6.1",

--- a/packages/services/server/src/graphql-handler.ts
+++ b/packages/services/server/src/graphql-handler.ts
@@ -29,7 +29,6 @@ import { useResponseCache } from '@graphql-yoga/plugin-response-cache';
 import { HiveError, Registry, RegistryContext } from '@hive/api';
 import { cleanRequestId } from '@hive/service-common';
 import { runWithAsyncContext } from '@sentry/node';
-import { fetch } from '@whatwg-node/fetch';
 import { asyncStorage } from './async-storage';
 import type { HiveConfig } from './environment';
 import { useArmor } from './use-armor';

--- a/packages/services/service-common/package.json
+++ b/packages/services/service-common/package.json
@@ -13,7 +13,6 @@
     "@sentry/node": "7.85.0",
     "@sentry/types": "7.85.0",
     "@sentry/utils": "7.85.0",
-    "@whatwg-node/fetch": "0.9.13",
     "fastify": "3.29.5",
     "fastify-cors": "6.0.3",
     "fastify-plugin": "4.5.1",

--- a/packages/services/stripe-billing/package.json
+++ b/packages/services/stripe-billing/package.json
@@ -16,7 +16,6 @@
     "@sentry/node": "7.85.0",
     "@trpc/client": "10.44.1",
     "@trpc/server": "10.44.1",
-    "@whatwg-node/fetch": "0.9.13",
     "date-fns": "2.30.0",
     "dotenv": "16.3.1",
     "got": "12.6.1",

--- a/packages/services/usage-estimator/package.json
+++ b/packages/services/usage-estimator/package.json
@@ -15,7 +15,6 @@
     "@hive/service-common": "workspace:*",
     "@sentry/node": "7.85.0",
     "@trpc/server": "10.44.1",
-    "@whatwg-node/fetch": "0.9.13",
     "dotenv": "16.3.1",
     "got": "12.6.1",
     "pino-pretty": "10.2.3",

--- a/packages/services/usage/package.json
+++ b/packages/services/usage/package.json
@@ -16,7 +16,6 @@
     "@sentry/node": "7.85.0",
     "@trpc/client": "10.44.1",
     "@trpc/server": "10.44.1",
-    "@whatwg-node/fetch": "0.9.13",
     "ajv": "8.12.0",
     "dotenv": "16.3.1",
     "got": "12.6.1",

--- a/packages/services/usage/src/rate-limit.ts
+++ b/packages/services/usage/src/rate-limit.ts
@@ -2,7 +2,6 @@ import LRU from 'tiny-lru';
 import type { RateLimitApi, RateLimitApiInput, RateLimitApiOutput } from '@hive/rate-limit';
 import { FastifyLoggerInstance } from '@hive/service-common';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
-import { fetch } from '@whatwg-node/fetch';
 
 export function createUsageRateLimit(config: {
   endpoint: string | null;

--- a/packages/services/usage/src/tokens.ts
+++ b/packages/services/usage/src/tokens.ts
@@ -2,7 +2,6 @@ import LRU from 'tiny-lru';
 import { FastifyLoggerInstance } from '@hive/service-common';
 import type { TokensApi } from '@hive/tokens';
 import { createTRPCProxyClient, httpLink } from '@trpc/client';
-import { fetch } from '@whatwg-node/fetch';
 import { tokenCacheHits, tokenRequests } from './metrics';
 
 export enum TokenStatus {

--- a/packages/web/app/package.json
+++ b/packages/web/app/package.json
@@ -53,7 +53,6 @@
     "@urql/core": "4.1.4",
     "@urql/exchange-graphcache": "6.3.3",
     "@urql/exchange-persisted": "4.1.0",
-    "@whatwg-node/fetch": "0.9.13",
     "class-variance-authority": "0.7.0",
     "clsx": "2.0.0",
     "cmdk": "0.2.0",

--- a/patches/oclif@3.17.2.patch
+++ b/patches/oclif@3.17.2.patch
@@ -183,10 +183,10 @@ index 64bee4efe80de5dfa51810585ff22f027ecf6eb9..57eb39fe3fb89940d8939b9179fb72d4
                  await aws_1.default.s3.uploadFile(localExe, Object.assign(Object.assign({}, S3Options), { CacheControl: 'max-age=86400', Key: cloudKey }));
          };
 diff --git a/lib/tarballs/bin.js b/lib/tarballs/bin.js
-index 8301c7be4c3101de9caf1c1b127cf1f940a1706c..e7d955d29ce3d002a260ef7f4a1355fcdc95e018 100644
+index 8301c7be4c3101de9caf1c1b127cf1f940a1706c..a5244ed11aa4a72b76390ee659fec186043a56b6 100644
 --- a/lib/tarballs/bin.js
 +++ b/lib/tarballs/bin.js
-@@ -7,85 +7,65 @@ const node_child_process_1 = require("node:child_process");
+@@ -7,85 +7,66 @@ const node_child_process_1 = require("node:child_process");
  const node_util_1 = require("node:util");
  const exec = (0, node_util_1.promisify)(node_child_process_1.exec);
  async function writeBinScripts({ config, baseWorkspace, nodeVersion }) {
@@ -293,7 +293,8 @@ index 8301c7be4c3101de9caf1c1b127cf1f940a1706c..e7d955d29ce3d002a260ef7f4a1355fc
 -            exec(`ln -sf ${config.bin} ${alias}`, { cwd: path.join(baseWorkspace, 'bin') }))) !== null && _b !== void 0 ? _b : [],
 -    ]);
 +
-+"\$NODE" "\$DIR/run" "\$@"
++
++"\$NODE" "--no-deprecation" "\$DIR/run" "\$@"
 +`,
 +      { mode: 0o755 }
 +    );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -686,8 +686,8 @@ importers:
         specifier: 2.0.4
         version: 2.0.4
       '@whatwg-node/server':
-        specifier: 0.9.18
-        version: 0.9.18
+        specifier: 0.9.10
+        version: 0.9.10
       esbuild:
         specifier: 0.19.8
         version: 0.19.8
@@ -719,8 +719,8 @@ importers:
         specifier: 2.0.4
         version: 2.0.4
       '@whatwg-node/server':
-        specifier: 0.9.18
-        version: 0.9.18
+        specifier: 0.9.10
+        version: 0.9.10
       bcryptjs:
         specifier: 2.4.3
         version: 2.4.3
@@ -815,8 +815,8 @@ importers:
         specifier: workspace:*
         version: link:../../../libraries/external-composition/dist
       '@whatwg-node/server':
-        specifier: 0.9.18
-        version: 0.9.18
+        specifier: 0.9.10
+        version: 0.9.10
       graphql:
         specifier: 16.8.1
         version: 16.8.1
@@ -1040,8 +1040,8 @@ importers:
         specifier: 10.44.1
         version: 10.44.1
       '@whatwg-node/server':
-        specifier: 0.9.18
-        version: 0.9.18
+        specifier: 0.9.10
+        version: 0.9.10
       dotenv:
         specifier: 16.3.1
         version: 16.3.1
@@ -14803,14 +14803,6 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /@whatwg-node/server@0.9.18:
-    resolution: {integrity: sha512-rfI2ZhKWakfkhyVA4v95cnkMF5k5B4k57yLH4bYkEORnLJj+SL7sger0q4hyA47bdp1KOY1raeIBIBEXSpwTvw==}
-    engines: {node: '>=16.0.0'}
-    dependencies:
-      '@whatwg-node/fetch': 0.9.13
-      tslib: 2.6.2
-    dev: true
-
   /@xtuc/ieee754@1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -20976,7 +20968,7 @@ packages:
       '@graphql-yoga/logger': 1.0.0
       '@graphql-yoga/subscription': 4.0.0
       '@whatwg-node/fetch': 0.9.13
-      '@whatwg-node/server': 0.9.18
+      '@whatwg-node/server': 0.9.10
       dset: 3.1.2
       graphql: 16.8.1
       lru-cache: 10.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,7 +51,7 @@ patchedDependencies:
     hash: hxh4emx3aynf2jzsz5rahc4b4y
     path: patches/nextra@2.12.3.patch
   oclif@3.17.2:
-    hash: p4jeiorqjhwzipwrwepbyei4ba
+    hash: 6wsfogmtwtxtr5stv4pzgb472e
     path: patches/oclif@3.17.2.patch
 
 importers:
@@ -356,6 +356,9 @@ importers:
       '@oclif/plugin-update':
         specifier: 3.2.4
         version: 3.2.4(@swc/core@1.3.100)(@types/node@20.10.3)(typescript@5.3.2)
+      '@whatwg-node/node-fetch':
+        specifier: 0.5.1
+        version: 0.5.1
       colors:
         specifier: 1.4.0
         version: 1.4.0
@@ -374,9 +377,6 @@ importers:
       mkdirp:
         specifier: 2.1.6
         version: 2.1.6
-      node-fetch:
-        specifier: 3.3.2
-        version: 3.3.2
       tslib:
         specifier: 2.6.2
         version: 2.6.2
@@ -392,7 +392,7 @@ importers:
         version: 1.0.2
       oclif:
         specifier: 3.17.2
-        version: 3.17.2(patch_hash=p4jeiorqjhwzipwrwepbyei4ba)(@swc/core@1.3.100)(@types/node@20.10.3)(typescript@5.3.2)
+        version: 3.17.2(patch_hash=6wsfogmtwtxtr5stv4pzgb472e)(@swc/core@1.3.100)(@types/node@20.10.3)(typescript@5.3.2)
       rimraf:
         specifier: 4.4.1
         version: 4.4.1
@@ -686,8 +686,8 @@ importers:
         specifier: 2.0.4
         version: 2.0.4
       '@whatwg-node/server':
-        specifier: 0.9.10
-        version: 0.9.10
+        specifier: 0.9.18
+        version: 0.9.18
       esbuild:
         specifier: 0.19.8
         version: 0.19.8
@@ -719,8 +719,8 @@ importers:
         specifier: 2.0.4
         version: 2.0.4
       '@whatwg-node/server':
-        specifier: 0.9.10
-        version: 0.9.10
+        specifier: 0.9.18
+        version: 0.9.18
       bcryptjs:
         specifier: 2.4.3
         version: 2.4.3
@@ -815,8 +815,8 @@ importers:
         specifier: workspace:*
         version: link:../../../libraries/external-composition/dist
       '@whatwg-node/server':
-        specifier: 0.9.10
-        version: 0.9.10
+        specifier: 0.9.18
+        version: 0.9.18
       graphql:
         specifier: 16.8.1
         version: 16.8.1
@@ -1040,8 +1040,8 @@ importers:
         specifier: 10.44.1
         version: 10.44.1
       '@whatwg-node/server':
-        specifier: 0.9.10
-        version: 0.9.10
+        specifier: 0.9.18
+        version: 0.9.18
       dotenv:
         specifier: 16.3.1
         version: 16.3.1
@@ -14784,8 +14784,27 @@ packages:
       fast-url-parser: 1.1.3
       tslib: 2.6.2
 
+  /@whatwg-node/node-fetch@0.5.1:
+    resolution: {integrity: sha512-sQz/s3NyyzIZxQ7PHxDFUMM1k4kQQbi2jU8ILdTbt5+S59ME8aI7XF30O9qohRIIYdSrUvm/OwKQmVP1y6e2WQ==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@whatwg-node/events': 0.1.1
+      busboy: 1.6.0
+      fast-querystring: 1.1.1
+      fast-url-parser: 1.1.3
+      tslib: 2.6.2
+    dev: false
+
   /@whatwg-node/server@0.9.10:
     resolution: {integrity: sha512-CoFEflKASUL+gCDF21TwRmQ8kUIYcE++09h3D20XuWP+dsjiA4FBBGFNjIafKM5MNqiK6ncX0YBpRqeAwIFlbw==}
+    engines: {node: '>=16.0.0'}
+    dependencies:
+      '@whatwg-node/fetch': 0.9.13
+      tslib: 2.6.2
+    dev: true
+
+  /@whatwg-node/server@0.9.18:
+    resolution: {integrity: sha512-rfI2ZhKWakfkhyVA4v95cnkMF5k5B4k57yLH4bYkEORnLJj+SL7sger0q4hyA47bdp1KOY1raeIBIBEXSpwTvw==}
     engines: {node: '>=16.0.0'}
     dependencies:
       '@whatwg-node/fetch': 0.9.13
@@ -17813,11 +17832,6 @@ packages:
       assert-plus: 1.0.0
     dev: true
 
-  /data-uri-to-buffer@4.0.1:
-    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
-    engines: {node: '>= 12'}
-    dev: false
-
   /dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
     dev: true
@@ -19730,14 +19744,6 @@ packages:
       tmp: 0.0.33
     dev: true
 
-  /fetch-blob@3.2.0:
-    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
-    engines: {node: ^12.20 || >= 14.13}
-    dependencies:
-      node-domexception: 1.0.0
-      web-streams-polyfill: 3.2.1
-    dev: false
-
   /fetch-retry@5.0.4:
     resolution: {integrity: sha512-LXcdgpdcVedccGg0AZqg+S8lX/FCdwXD92WNZ5k5qsb0irRhSFsBOpcJt7oevyqT2/C2nEE0zSFNdBEpj3YOSw==}
     dev: true
@@ -20076,13 +20082,6 @@ packages:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
     dev: true
-
-  /formdata-polyfill@4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
-    engines: {node: '>=12.20.0'}
-    dependencies:
-      fetch-blob: 3.2.0
-    dev: false
 
   /formik@2.4.5(react@18.2.0):
     resolution: {integrity: sha512-Gxlht0TD3vVdzMDHwkiNZqJ7Mvg77xQNfmBRrNtvzcHZs72TJppSTDKHpImCMJZwcWPBJ8jSQQ95GJzXFf1nAQ==}
@@ -20977,7 +20976,7 @@ packages:
       '@graphql-yoga/logger': 1.0.0
       '@graphql-yoga/subscription': 4.0.0
       '@whatwg-node/fetch': 0.9.13
-      '@whatwg-node/server': 0.9.10
+      '@whatwg-node/server': 0.9.18
       dset: 3.1.2
       graphql: 16.8.1
       lru-cache: 10.0.0
@@ -25535,11 +25534,6 @@ packages:
       minimatch: 3.1.2
     dev: true
 
-  /node-domexception@1.0.0:
-    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
-    engines: {node: '>=10.5.0'}
-    dev: false
-
   /node-fetch-native@1.0.2:
     resolution: {integrity: sha512-KIkvH1jl6b3O7es/0ShyCgWLcfXxlBrLBbP3rOr23WArC66IMcU4DeZEeYEOwnopYhawLTn7/y+YtmASe8DFVQ==}
     dev: true
@@ -25554,15 +25548,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-
-  /node-fetch@3.3.2:
-    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      data-uri-to-buffer: 4.0.1
-      fetch-blob: 3.2.0
-      formdata-polyfill: 4.0.10
-    dev: false
 
   /node-gyp-build-optional-packages@5.0.3:
     resolution: {integrity: sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==}
@@ -26080,7 +26065,7 @@ packages:
     resolution: {integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==}
     dev: true
 
-  /oclif@3.17.2(patch_hash=p4jeiorqjhwzipwrwepbyei4ba)(@swc/core@1.3.100)(@types/node@20.10.3)(typescript@5.3.2):
+  /oclif@3.17.2(patch_hash=6wsfogmtwtxtr5stv4pzgb472e)(@swc/core@1.3.100)(@types/node@20.10.3)(typescript@5.3.2):
     resolution: {integrity: sha512-+vFXxgmR7dGGz+g6YiqSZu2LXVkBMaS9/rhtsLGkYw45e53CW/3kBgPRnOvxcTDM3Td9JPeBD2JWxXnPKGQW3A==}
     engines: {node: '>=12.0.0'}
     hasBin: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,7 +72,7 @@ importers:
         version: 5.0.0(graphql@16.8.1)
       '@graphql-codegen/cli':
         specifier: 5.0.0
-        version: 5.0.0(@babel/core@7.23.0)(@types/node@20.10.3)(graphql@16.8.1)
+        version: 5.0.0(@babel/core@7.23.5)(@types/node@20.10.3)(graphql@16.8.1)
       '@graphql-codegen/client-preset':
         specifier: 4.1.0
         version: 4.1.0(graphql@16.8.1)
@@ -96,7 +96,7 @@ importers:
         version: 3.0.0(graphql@16.8.1)
       '@graphql-eslint/eslint-plugin':
         specifier: 3.20.1
-        version: 3.20.1(patch_hash=n437g5o7zq7pnxdxldn52uql2q)(@babel/core@7.23.0)(@types/node@20.10.3)(graphql@16.8.1)
+        version: 3.20.1(patch_hash=n437g5o7zq7pnxdxldn52uql2q)(@babel/core@7.23.5)(@types/node@20.10.3)(graphql@16.8.1)
       '@graphql-inspector/cli':
         specifier: 4.0.3
         version: 4.0.3(@types/node@20.10.3)(graphql@16.8.1)
@@ -281,9 +281,6 @@ importers:
       '@types/ioredis':
         specifier: 4.28.10
         version: 4.28.10
-      '@whatwg-node/fetch':
-        specifier: 0.9.13
-        version: 0.9.13
       bcryptjs:
         specifier: 2.4.3
         version: 2.4.3
@@ -331,7 +328,7 @@ importers:
         version: 5.0.2(graphql@16.8.1)
       '@graphql-tools/code-file-loader':
         specifier: ~8.0.0
-        version: 8.0.0(@babel/core@7.23.0)(graphql@16.8.1)
+        version: 8.0.0(@babel/core@7.23.5)(graphql@16.8.1)
       '@graphql-tools/graphql-file-loader':
         specifier: ~8.0.0
         version: 8.0.0(graphql@16.8.1)
@@ -498,9 +495,6 @@ importers:
       '@types/pg':
         specifier: 8.10.9
         version: 8.10.9
-      '@whatwg-node/fetch':
-        specifier: 0.9.13
-        version: 0.9.13
       bcryptjs:
         specifier: 2.4.3
         version: 2.4.3
@@ -610,9 +604,6 @@ importers:
       '@types/object-hash':
         specifier: 3.0.6
         version: 3.0.6
-      '@whatwg-node/fetch':
-        specifier: 0.9.13
-        version: 0.9.13
       agentkeepalive:
         specifier: 4.5.0
         version: 4.5.0
@@ -694,9 +685,6 @@ importers:
       '@types/service-worker-mock':
         specifier: 2.0.4
         version: 2.0.4
-      '@whatwg-node/fetch':
-        specifier: 0.9.13
-        version: 0.9.13
       '@whatwg-node/server':
         specifier: 0.9.10
         version: 0.9.10
@@ -706,12 +694,15 @@ importers:
       itty-router:
         specifier: 4.0.23
         version: 4.0.23
-      nock:
-        specifier: 13.4.0
-        version: 13.4.0
       toucan-js:
         specifier: 3.3.1
         version: 3.3.1
+      undici:
+        specifier: 5.26.3
+        version: 5.26.3
+      vitest:
+        specifier: 0.34.6
+        version: 0.34.6
       workers-loki-logger:
         specifier: 0.1.15
         version: 0.1.15
@@ -727,9 +718,6 @@ importers:
       '@types/service-worker-mock':
         specifier: 2.0.4
         version: 2.0.4
-      '@whatwg-node/fetch':
-        specifier: 0.9.13
-        version: 0.9.13
       '@whatwg-node/server':
         specifier: 0.9.10
         version: 0.9.10
@@ -781,9 +769,6 @@ importers:
       '@types/sendmail':
         specifier: 1.4.7
         version: 1.4.7
-      '@whatwg-node/fetch':
-        specifier: 0.9.13
-        version: 0.9.13
       bullmq:
         specifier: 4.14.4
         version: 4.14.4(patch_hash=kobtuuqaglbtaadx3jiqtahl3i)
@@ -829,9 +814,6 @@ importers:
       '@graphql-hive/external-composition':
         specifier: workspace:*
         version: link:../../../libraries/external-composition/dist
-      '@whatwg-node/fetch':
-        specifier: 0.9.13
-        version: 0.9.13
       '@whatwg-node/server':
         specifier: 0.9.10
         version: 0.9.10
@@ -849,7 +831,7 @@ importers:
     devDependencies:
       '@graphql-eslint/eslint-plugin':
         specifier: 3.20.1
-        version: 3.20.1(patch_hash=n437g5o7zq7pnxdxldn52uql2q)(@babel/core@7.23.0)(@types/node@20.10.3)(graphql@16.8.1)
+        version: 3.20.1(patch_hash=n437g5o7zq7pnxdxldn52uql2q)(@babel/core@7.23.5)(@types/node@20.10.3)(graphql@16.8.1)
       '@hive/service-common':
         specifier: workspace:*
         version: link:../service-common
@@ -862,9 +844,6 @@ importers:
       '@trpc/server':
         specifier: 10.44.1
         version: 10.44.1
-      '@whatwg-node/fetch':
-        specifier: 0.9.13
-        version: 0.9.13
       ajv:
         specifier: 8.12.0
         version: 8.12.0
@@ -910,9 +889,6 @@ importers:
       '@trpc/server':
         specifier: 10.44.1
         version: 10.44.1
-      '@whatwg-node/fetch':
-        specifier: 0.9.13
-        version: 0.9.13
       date-fns:
         specifier: 2.30.0
         version: 2.30.0
@@ -967,9 +943,6 @@ importers:
       '@types/ioredis-mock':
         specifier: 8.2.5
         version: 8.2.5
-      '@whatwg-node/fetch':
-        specifier: 0.9.13
-        version: 0.9.13
       dotenv:
         specifier: 16.3.1
         version: 16.3.1
@@ -1066,9 +1039,6 @@ importers:
       '@trpc/server':
         specifier: 10.44.1
         version: 10.44.1
-      '@whatwg-node/fetch':
-        specifier: 0.9.13
-        version: 0.9.13
       '@whatwg-node/server':
         specifier: 0.9.10
         version: 0.9.10
@@ -1121,9 +1091,6 @@ importers:
       '@sentry/utils':
         specifier: 7.85.0
         version: 7.85.0
-      '@whatwg-node/fetch':
-        specifier: 0.9.13
-        version: 0.9.13
       fastify:
         specifier: 3.29.5
         version: 3.29.5
@@ -1217,9 +1184,6 @@ importers:
       '@trpc/server':
         specifier: 10.44.1
         version: 10.44.1
-      '@whatwg-node/fetch':
-        specifier: 0.9.13
-        version: 0.9.13
       date-fns:
         specifier: 2.30.0
         version: 2.30.0
@@ -1310,9 +1274,6 @@ importers:
       '@trpc/server':
         specifier: 10.44.1
         version: 10.44.1
-      '@whatwg-node/fetch':
-        specifier: 0.9.13
-        version: 0.9.13
       ajv:
         specifier: 8.12.0
         version: 8.12.0
@@ -1358,9 +1319,6 @@ importers:
       '@trpc/server':
         specifier: 10.44.1
         version: 10.44.1
-      '@whatwg-node/fetch':
-        specifier: 0.9.13
-        version: 0.9.13
       dotenv:
         specifier: 16.3.1
         version: 16.3.1
@@ -1583,9 +1541,6 @@ importers:
       '@urql/exchange-persisted':
         specifier: 4.1.0
         version: 4.1.0(graphql@16.8.1)
-      '@whatwg-node/fetch':
-        specifier: 0.9.13
-        version: 0.9.13
       class-variance-authority:
         specifier: 0.7.0
         version: 0.7.0
@@ -1645,7 +1600,7 @@ importers:
         version: 0.4.4
       next:
         specifier: 13.5.6
-        version: 13.5.6(@babel/core@7.23.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.5.6(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0)
       nextjs-cors:
         specifier: 2.1.2
         version: 2.1.2(next@13.5.6)
@@ -1672,7 +1627,7 @@ importers:
         version: 4.12.0(react@18.2.0)
       react-select:
         specifier: 5.8.0
-        version: 5.8.0(@babel/core@7.23.0)(@types/react@18.2.42)(react-dom@18.2.0)(react@18.2.0)
+        version: 5.8.0(@babel/core@7.23.5)(@types/react@18.2.42)(react-dom@18.2.0)(react@18.2.0)
       react-string-replace:
         specifier: 1.1.1
         version: 1.1.1
@@ -1844,7 +1799,7 @@ importers:
         version: 4.0.3
       next:
         specifier: 13.5.6
-        version: 13.5.6(@babel/core@7.23.0)(react-dom@18.2.0)(react@18.2.0)
+        version: 13.5.6(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0)
       next-themes:
         specifier: '*'
         version: 0.2.1(next@13.5.6)(react-dom@18.2.0)(react@18.2.0)
@@ -1853,7 +1808,7 @@ importers:
         version: 18.2.0
       react-avatar:
         specifier: 5.0.3
-        version: 5.0.3(@babel/runtime@7.23.1)(core-js-pure@3.28.0)(prop-types@15.8.1)(react@18.2.0)
+        version: 5.0.3(@babel/runtime@7.23.5)(core-js-pure@3.28.0)(prop-types@15.8.1)(react@18.2.0)
       react-countup:
         specifier: 6.5.0
         version: 6.5.0(react@18.2.0)
@@ -3130,7 +3085,6 @@ packages:
     dependencies:
       '@babel/highlight': 7.23.4
       chalk: 2.4.2
-    dev: true
 
   /@babel/compat-data@7.22.20:
     resolution: {integrity: sha512-BQYjKbpXjoXwFW5jGqiizJQQT/aC7pFm9Ok1OWssonuguICi264lbgMzRp2ZMmRSlfkX6DsWDDcsrctK8Rwfiw==}
@@ -3185,6 +3139,7 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/core@7.23.5:
     resolution: {integrity: sha512-Cwc2XjUrG4ilcfOw4wBAK+enbdgwAcAJCfGUItPBKR7Mjw4aEfAFYrLxeRp4jWgtNIKn3n2AlBOfwwafl+42/g==}
@@ -3207,7 +3162,6 @@ packages:
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/generator@7.21.5:
     resolution: {integrity: sha512-SrKK/sRv8GesIW1bDagf9cCG38IOMYZusoe1dfg0D8aiUe3Amvoj1QtjTPAWcfrZFvIwlleLb0gxzQidL9w14w==}
@@ -3236,7 +3190,6 @@ packages:
       '@jridgewell/gen-mapping': 0.3.3
       '@jridgewell/trace-mapping': 0.3.19
       jsesc: 2.5.2
-    dev: true
 
   /@babel/helper-annotate-as-pure@7.22.5:
     resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
@@ -3399,6 +3352,7 @@ packages:
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
+    dev: true
 
   /@babel/helper-module-transforms@7.23.0(@babel/core@7.23.5):
     resolution: {integrity: sha512-WhDWw1tdrlT0gMgUJSlX0IQvoO1eN279zrAUbVB+KpV2c3Tylz8+GnKOLllCS6Z/iZQEyVYxhZVUdPTqs2YYPw==}
@@ -3426,7 +3380,6 @@ packages:
       '@babel/helper-simple-access': 7.22.5
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/helper-validator-identifier': 7.22.20
-    dev: true
 
   /@babel/helper-optimise-call-expression@7.22.5:
     resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
@@ -3506,7 +3459,6 @@ packages:
   /@babel/helper-string-parser@7.23.4:
     resolution: {integrity: sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==}
     engines: {node: '>=6.9.0'}
-    dev: true
 
   /@babel/helper-validator-identifier@7.22.20:
     resolution: {integrity: sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==}
@@ -3539,6 +3491,7 @@ packages:
       '@babel/types': 7.23.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/helpers@7.23.5:
     resolution: {integrity: sha512-oO7us8FzTEsG3U6ag9MfdF1iA/7Z6dz+MtFhifZk8C8o453rGJFFWUP1t+ULM9TUIAzC9uxXEiXjOiVMyd7QPg==}
@@ -3549,7 +3502,6 @@ packages:
       '@babel/types': 7.23.5
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/highlight@7.22.20:
     resolution: {integrity: sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==}
@@ -3566,7 +3518,6 @@ packages:
       '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
       js-tokens: 4.0.0
-    dev: true
 
   /@babel/parser@7.21.8:
     resolution: {integrity: sha512-6zavDGdzG3gUqAdWvlLFfk+36RilI+Pwyuuh7HItyeScCWP3k6i8vKclAQ0bM/0y/Kz/xiwvxhMv9MgTJP5gmA==}
@@ -3588,7 +3539,6 @@ packages:
     hasBin: true
     dependencies:
       '@babel/types': 7.23.5
-    dev: true
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.23.3(@babel/core@7.23.5):
     resolution: {integrity: sha512-iRkKcCqb7iGnq9+3G6rZ+Ciz5VywC4XNRHe57lKM+jOeYAoR0lVqdeeDRfh0tQcTfw/+vBhHn926FmQhLtlFLQ==}
@@ -3753,15 +3703,6 @@ packages:
       '@babel/helper-plugin-utils': 7.22.5
     dev: true
 
-  /@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.23.0):
-    resolution: {integrity: sha512-rdV97N7KqsRzeNGoWUOK6yUsWarLjE5Su/Snk9IYPU9CwkWHs4t+rTGOvffTR8XGkJMTAdLfO0xVnXm8wugIJg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.23.0
-      '@babel/helper-plugin-utils': 7.22.5
-
   /@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.23.5):
     resolution: {integrity: sha512-rdV97N7KqsRzeNGoWUOK6yUsWarLjE5Su/Snk9IYPU9CwkWHs4t+rTGOvffTR8XGkJMTAdLfO0xVnXm8wugIJg==}
     engines: {node: '>=6.9.0'}
@@ -3770,7 +3711,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.5
       '@babel/helper-plugin-utils': 7.22.5
-    dev: true
 
   /@babel/plugin-syntax-import-assertions@7.23.3(@babel/core@7.23.5):
     resolution: {integrity: sha512-lPgDSU+SJLK3xmFDTV2ZRQAiM7UuUjGidwBywFavObCiZc1BeAAcMtHJKUya92hPHO+at63JJPLygilZard8jw==}
@@ -3818,6 +3758,7 @@ packages:
     dependencies:
       '@babel/core': 7.23.0
       '@babel/helper-plugin-utils': 7.22.5
+    dev: true
 
   /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.23.5):
     resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==}
@@ -3827,7 +3768,6 @@ packages:
     dependencies:
       '@babel/core': 7.23.5
       '@babel/helper-plugin-utils': 7.22.5
-    dev: true
 
   /@babel/plugin-syntax-jsx@7.23.3(@babel/core@7.23.5):
     resolution: {integrity: sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==}
@@ -5157,6 +5097,7 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
 
   /@babel/traverse@7.23.5:
     resolution: {integrity: sha512-czx7Xy5a6sapWWRx61m1Ke1Ra4vczu1mCTtJam5zRTBOonfdJ+S/B6HYmGYu3fJtr8GGET3si6IhgWVBhJ/m8w==}
@@ -5174,7 +5115,6 @@ packages:
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
-    dev: true
 
   /@babel/types@7.21.5:
     resolution: {integrity: sha512-m4AfNvVF2mVC/F7fDEdH2El3HzUg9It/XsCxZiOTTA3m3qYfcSVSbTfM6Q9xG+hYDniZssYhlXKKUMD5m8tF4Q==}
@@ -5199,7 +5139,6 @@ packages:
       '@babel/helper-string-parser': 7.23.4
       '@babel/helper-validator-identifier': 7.22.20
       to-fast-properties: 2.0.0
-    dev: true
 
   /@balena/dockerignore@1.0.2:
     resolution: {integrity: sha512-wMue2Sy4GAVTk6Ic4tJVcnfdau+gx2EnG7S+uAEe+TWJFqE4YoWN4/H8MSLj4eYJKxGg26lZwboEniNiNwZQ6Q==}
@@ -5497,14 +5436,14 @@ packages:
     engines: {node: '>=10.0.0'}
     dev: true
 
-  /@emotion/babel-plugin@11.10.5(@babel/core@7.23.0):
+  /@emotion/babel-plugin@11.10.5(@babel/core@7.23.5):
     resolution: {integrity: sha512-xE7/hyLHJac7D2Ve9dKroBBZqBT7WuPQmWcq7HSGb84sUuP4mlOWoB8dvVfD9yk5DHkU1m6RW7xSoDtnQHNQeA==}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.5
       '@babel/helper-module-imports': 7.22.15
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.0)
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.23.5)
       '@babel/runtime': 7.23.1
       '@emotion/hash': 0.9.0
       '@emotion/memoize': 0.8.0
@@ -5549,7 +5488,7 @@ packages:
     resolution: {integrity: sha512-G/YwXTkv7Den9mXDO7AhLWkE3q+I92B+VqAE+dYG4NGPaHZGvt3G8Q0p9vmE+sq7rTGphUbAvmQ9YpbfMQGGlA==}
     dev: false
 
-  /@emotion/react@11.10.5(@babel/core@7.23.0)(@types/react@18.2.42)(react@18.2.0):
+  /@emotion/react@11.10.5(@babel/core@7.23.5)(@types/react@18.2.42)(react@18.2.0):
     resolution: {integrity: sha512-TZs6235tCJ/7iF6/rvTaOH4oxQg2gMAcdHemjwLKIjKz4rRuYe1HJ2TQJKnAcRAfOUDdU8XoDadCe1rl72iv8A==}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -5561,9 +5500,9 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/core': 7.23.0
+      '@babel/core': 7.23.5
       '@babel/runtime': 7.23.1
-      '@emotion/babel-plugin': 11.10.5(@babel/core@7.23.0)
+      '@emotion/babel-plugin': 11.10.5(@babel/core@7.23.5)
       '@emotion/cache': 11.10.5
       '@emotion/serialize': 1.1.1
       '@emotion/use-insertion-effect-with-fallbacks': 1.0.0(react@18.2.0)
@@ -6444,6 +6383,11 @@ packages:
       ajv: 6.12.6
     dev: true
 
+  /@fastify/busboy@2.0.0:
+    resolution: {integrity: sha512-JUFJad5lv7jxj926GPgymrWQxxjPYuJNiNjNMzqT+HiuP6Vl3dk5xzG+8sTX96np0ZAluvaMzPsjhHZ5rNuNQQ==}
+    engines: {node: '>=14'}
+    dev: true
+
   /@fastify/error@2.0.0:
     resolution: {integrity: sha512-wI3fpfDT0t7p8E6dA2eTECzzOd+bZsZCJ2Hcv+Onn2b7ZwK3RwD27uW2QDaMtQhAfWQQP+WNK7nKf0twLsBf9w==}
     dev: true
@@ -6556,7 +6500,7 @@ packages:
       tslib: 2.5.3
     dev: true
 
-  /@graphql-codegen/cli@5.0.0(@babel/core@7.23.0)(@types/node@20.10.3)(graphql@16.8.1):
+  /@graphql-codegen/cli@5.0.0(@babel/core@7.23.5)(@types/node@20.10.3)(graphql@16.8.1):
     resolution: {integrity: sha512-A7J7+be/a6e+/ul2KI5sfJlpoqeqwX8EzktaKCeduyVKgOLA6W5t+NUGf6QumBDXU8PEOqXk3o3F+RAwCWOiqA==}
     hasBin: true
     peerDependencies:
@@ -6572,9 +6516,9 @@ packages:
       '@graphql-codegen/core': 4.0.0(graphql@16.8.1)
       '@graphql-codegen/plugin-helpers': 5.0.1(graphql@16.8.1)
       '@graphql-tools/apollo-engine-loader': 8.0.0(graphql@16.8.1)
-      '@graphql-tools/code-file-loader': 8.0.0(@babel/core@7.23.0)(graphql@16.8.1)
-      '@graphql-tools/git-loader': 8.0.1(@babel/core@7.23.0)(graphql@16.8.1)
-      '@graphql-tools/github-loader': 8.0.0(@babel/core@7.23.0)(@types/node@20.10.3)(graphql@16.8.1)
+      '@graphql-tools/code-file-loader': 8.0.0(@babel/core@7.23.5)(graphql@16.8.1)
+      '@graphql-tools/git-loader': 8.0.1(@babel/core@7.23.5)(graphql@16.8.1)
+      '@graphql-tools/github-loader': 8.0.0(@babel/core@7.23.5)(@types/node@20.10.3)(graphql@16.8.1)
       '@graphql-tools/graphql-file-loader': 8.0.0(graphql@16.8.1)
       '@graphql-tools/json-file-loader': 8.0.0(graphql@16.8.1)
       '@graphql-tools/load': 8.0.0(graphql@16.8.1)
@@ -6836,15 +6780,15 @@ packages:
       - supports-color
     dev: true
 
-  /@graphql-eslint/eslint-plugin@3.20.1(patch_hash=n437g5o7zq7pnxdxldn52uql2q)(@babel/core@7.23.0)(@types/node@20.10.3)(graphql@16.8.1):
+  /@graphql-eslint/eslint-plugin@3.20.1(patch_hash=n437g5o7zq7pnxdxldn52uql2q)(@babel/core@7.23.5)(@types/node@20.10.3)(graphql@16.8.1):
     resolution: {integrity: sha512-RbwVlz1gcYG62sECR1u0XqMh8w5e5XMCCZoMvPQ3nJzEBCTfXLGX727GBoRmSvY1x4gJmqNZ1lsOX7lZY14RIw==}
     engines: {node: '>=12'}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
       '@babel/code-frame': 7.21.4
-      '@graphql-tools/code-file-loader': 7.3.23(@babel/core@7.23.0)(graphql@16.8.1)
-      '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.23.0)(graphql@16.8.1)
+      '@graphql-tools/code-file-loader': 7.3.23(@babel/core@7.23.5)(graphql@16.8.1)
+      '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.23.5)(graphql@16.8.1)
       '@graphql-tools/utils': 9.2.1(graphql@16.8.1)
       chalk: 4.1.2
       debug: 4.3.4(supports-color@8.1.1)
@@ -6904,7 +6848,7 @@ packages:
       '@graphql-inspector/graphql-loader': 4.0.2(graphql@16.8.1)
       '@graphql-inspector/introspect-command': 4.0.3(@graphql-inspector/config@4.0.2)(@graphql-inspector/loaders@4.0.3)(graphql@16.8.1)(yargs@17.7.2)
       '@graphql-inspector/json-loader': 4.0.2(graphql@16.8.1)
-      '@graphql-inspector/loaders': 4.0.3(@babel/core@7.23.0)(@graphql-inspector/config@4.0.2)(graphql@16.8.1)
+      '@graphql-inspector/loaders': 4.0.3(@babel/core@7.23.5)(@graphql-inspector/config@4.0.2)(graphql@16.8.1)
       '@graphql-inspector/serve-command': 4.0.3(@graphql-inspector/config@4.0.2)(@graphql-inspector/loaders@4.0.3)(graphql@16.8.1)(yargs@17.7.2)
       '@graphql-inspector/similar-command': 4.0.3(@graphql-inspector/config@4.0.2)(@graphql-inspector/loaders@4.0.3)(graphql@16.8.1)(yargs@17.7.2)
       '@graphql-inspector/url-loader': 4.0.2(@types/node@20.10.3)(graphql@16.8.1)
@@ -6944,7 +6888,7 @@ packages:
       yargs: 17.7.2
     dependencies:
       '@graphql-inspector/config': 4.0.2(graphql@16.8.1)
-      '@graphql-inspector/loaders': 4.0.3(@babel/core@7.23.0)(@graphql-inspector/config@4.0.2)(graphql@16.8.1)
+      '@graphql-inspector/loaders': 4.0.3(@babel/core@7.23.5)(@graphql-inspector/config@4.0.2)(graphql@16.8.1)
       graphql: 16.8.1
       tslib: 2.6.2
       yargs: 17.7.2
@@ -7091,7 +7035,7 @@ packages:
       tslib: 2.6.2
     dev: true
 
-  /@graphql-inspector/loaders@4.0.3(@babel/core@7.23.0)(@graphql-inspector/config@4.0.2)(graphql@16.8.1):
+  /@graphql-inspector/loaders@4.0.3(@babel/core@7.23.5)(@graphql-inspector/config@4.0.2)(graphql@16.8.1):
     resolution: {integrity: sha512-V9T+IUJgmneWx1kEaSbFHLcjMs929TKLs6m3p544/CMPdFIsRYmYhd2jfUBhzXC8P6avnsLxxzVEOR45wJgOYA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -7099,7 +7043,7 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
       '@graphql-inspector/config': 4.0.2(graphql@16.8.1)
-      '@graphql-tools/code-file-loader': 8.0.1(@babel/core@7.23.0)(graphql@16.8.1)
+      '@graphql-tools/code-file-loader': 8.0.1(@babel/core@7.23.5)(graphql@16.8.1)
       '@graphql-tools/load': 8.0.0(graphql@16.8.1)
       '@graphql-tools/utils': 10.0.3(graphql@16.8.1)
       graphql: 16.8.1
@@ -7254,12 +7198,12 @@ packages:
       value-or-promise: 1.0.12
     dev: true
 
-  /@graphql-tools/code-file-loader@7.3.23(@babel/core@7.23.0)(graphql@16.8.1):
+  /@graphql-tools/code-file-loader@7.3.23(@babel/core@7.23.5)(graphql@16.8.1):
     resolution: {integrity: sha512-8Wt1rTtyTEs0p47uzsPJ1vAtfAx0jmxPifiNdmo9EOCuUPyQGEbMaik/YkqZ7QUFIEYEQu+Vgfo8tElwOPtx5Q==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.23.0)(graphql@16.8.1)
+      '@graphql-tools/graphql-tag-pluck': 7.5.2(@babel/core@7.23.5)(graphql@16.8.1)
       '@graphql-tools/utils': 9.2.1(graphql@16.8.1)
       globby: 11.1.0
       graphql: 16.8.1
@@ -7270,13 +7214,13 @@ packages:
       - supports-color
     dev: true
 
-  /@graphql-tools/code-file-loader@8.0.0(@babel/core@7.23.0)(graphql@16.8.1):
+  /@graphql-tools/code-file-loader@8.0.0(@babel/core@7.23.5)(graphql@16.8.1):
     resolution: {integrity: sha512-nq36yQnUVp6Roti+RFatInRogZzbwdFKZK1YBCmP3XpUvoOBbWaHaLKxVE9mU5lb9nL99zKzhq6gfh5syzxjJQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/graphql-tag-pluck': 8.0.0(@babel/core@7.23.0)(graphql@16.8.1)
+      '@graphql-tools/graphql-tag-pluck': 8.0.0(@babel/core@7.23.5)(graphql@16.8.1)
       '@graphql-tools/utils': 10.0.11(graphql@16.8.1)
       globby: 11.1.0
       graphql: 16.8.1
@@ -7303,13 +7247,13 @@ packages:
       - supports-color
     dev: true
 
-  /@graphql-tools/code-file-loader@8.0.1(@babel/core@7.23.0)(graphql@16.8.1):
+  /@graphql-tools/code-file-loader@8.0.1(@babel/core@7.23.5)(graphql@16.8.1):
     resolution: {integrity: sha512-pmg81lsIXGW3uW+nFSCIG0lFQIxWVbgDjeBkSWlnP8CZsrHTQEkB53DT7t4BHLryoxDS4G4cPxM52yNINDSL8w==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/graphql-tag-pluck': 8.0.1(@babel/core@7.23.0)(graphql@16.8.1)
+      '@graphql-tools/graphql-tag-pluck': 8.0.1(@babel/core@7.23.5)(graphql@16.8.1)
       '@graphql-tools/utils': 10.0.11(graphql@16.8.1)
       globby: 11.1.0
       graphql: 16.8.1
@@ -7519,13 +7463,13 @@ packages:
       - supports-color
     dev: true
 
-  /@graphql-tools/git-loader@8.0.1(@babel/core@7.23.0)(graphql@16.8.1):
+  /@graphql-tools/git-loader@8.0.1(@babel/core@7.23.5)(graphql@16.8.1):
     resolution: {integrity: sha512-ivNtxD+iEfpPONYKip0kbpZMRdMCNR3HrIui8NCURmUdvBYGaGcbB3VrGMhxwZuzc+ybhs2ralPt1F8Oxq2jLA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/graphql-tag-pluck': 8.0.1(@babel/core@7.23.0)(graphql@16.8.1)
+      '@graphql-tools/graphql-tag-pluck': 8.0.1(@babel/core@7.23.5)(graphql@16.8.1)
       '@graphql-tools/utils': 10.0.11(graphql@16.8.1)
       graphql: 16.8.1
       is-glob: 4.0.3
@@ -7558,7 +7502,7 @@ packages:
       - supports-color
     dev: true
 
-  /@graphql-tools/github-loader@8.0.0(@babel/core@7.23.0)(@types/node@20.10.3)(graphql@16.8.1):
+  /@graphql-tools/github-loader@8.0.0(@babel/core@7.23.5)(@types/node@20.10.3)(graphql@16.8.1):
     resolution: {integrity: sha512-VuroArWKcG4yaOWzV0r19ElVIV6iH6UKDQn1MXemND0xu5TzrFme0kf3U9o0YwNo0kUYEk9CyFM0BYg4he17FA==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
@@ -7566,7 +7510,7 @@ packages:
     dependencies:
       '@ardatan/sync-fetch': 0.0.1
       '@graphql-tools/executor-http': 1.0.0(@types/node@20.10.3)(graphql@16.8.1)
-      '@graphql-tools/graphql-tag-pluck': 8.0.1(@babel/core@7.23.0)(graphql@16.8.1)
+      '@graphql-tools/graphql-tag-pluck': 8.0.1(@babel/core@7.23.5)(graphql@16.8.1)
       '@graphql-tools/utils': 10.0.11(graphql@16.8.1)
       '@whatwg-node/fetch': 0.9.13
       graphql: 16.8.1
@@ -7604,13 +7548,13 @@ packages:
       tslib: 2.6.2
       unixify: 1.0.0
 
-  /@graphql-tools/graphql-tag-pluck@7.5.2(@babel/core@7.23.0)(graphql@16.8.1):
+  /@graphql-tools/graphql-tag-pluck@7.5.2(@babel/core@7.23.5)(graphql@16.8.1):
     resolution: {integrity: sha512-RW+H8FqOOLQw0BPXaahYepVSRjuOHw+7IL8Opaa5G5uYGOBxoXR7DceyQ7BcpMgktAOOmpDNQ2WtcboChOJSRA==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@babel/parser': 7.23.0
-      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.23.0)
+      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.23.5)
       '@babel/traverse': 7.23.0
       '@babel/types': 7.23.0
       '@graphql-tools/utils': 9.2.1(graphql@16.8.1)
@@ -7621,14 +7565,14 @@ packages:
       - supports-color
     dev: true
 
-  /@graphql-tools/graphql-tag-pluck@8.0.0(@babel/core@7.23.0)(graphql@16.8.1):
+  /@graphql-tools/graphql-tag-pluck@8.0.0(@babel/core@7.23.5)(graphql@16.8.1):
     resolution: {integrity: sha512-/xFXF7RwWf1UDAnUN/984Q1clRxRcWwO7lxi+BDzuwN14DJb424FVAmFOroBeeFWQNdj8qtNGLWhAbx23khvHQ==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@babel/parser': 7.21.8
-      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.23.0)
+      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.23.5)
       '@babel/traverse': 7.21.5
       '@babel/types': 7.21.5
       '@graphql-tools/utils': 10.0.11(graphql@16.8.1)
@@ -7656,14 +7600,14 @@ packages:
       - supports-color
     dev: true
 
-  /@graphql-tools/graphql-tag-pluck@8.0.1(@babel/core@7.23.0)(graphql@16.8.1):
+  /@graphql-tools/graphql-tag-pluck@8.0.1(@babel/core@7.23.5)(graphql@16.8.1):
     resolution: {integrity: sha512-4sfBJSoXxVB4rRCCp2GTFhAYsUJgAPSKxSV+E3Voc600mK52JO+KsHCCTnPgCeyJFMNR9l94J6+tqxVKmlqKvw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@babel/parser': 7.23.0
-      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.23.0)
+      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.23.5)
       '@babel/traverse': 7.23.0
       '@babel/types': 7.23.0
       '@graphql-tools/utils': 10.0.11(graphql@16.8.1)
@@ -11613,7 +11557,7 @@ packages:
       '@sentry/vercel-edge': 7.85.0
       '@sentry/webpack-plugin': 1.21.0
       chalk: 3.0.0
-      next: 13.5.6(@babel/core@7.23.0)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.5.6(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       resolve: 1.22.8
       rollup: 2.78.0
@@ -13033,7 +12977,7 @@ packages:
       fs-extra: 11.2.0
       image-size: 1.0.2
       loader-utils: 3.2.1
-      next: 13.5.6(@babel/core@7.23.0)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.5.6(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.88.2)
       pnp-webpack-plugin: 1.7.0(typescript@5.3.2)
       postcss: 8.4.32
@@ -13523,7 +13467,7 @@ packages:
       clsx: 2.0.0
       focus-trap-react: 10.2.1(prop-types@15.8.1)(react-dom@18.2.0)(react@18.2.0)
       fuzzy: 0.1.3
-      next: 13.5.6(@babel/core@7.23.0)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.5.6(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0)
       next-videos: 1.5.0(webpack@4.47.0)
       nextra: 2.12.3(patch_hash=hxh4emx3aynf2jzsz5rahc4b4y)(next@13.5.6)(react-dom@18.2.0)(react@18.2.0)
       nextra-theme-docs: 2.12.3(patch_hash=eb56dwi3xee5yymywh7ts2dw44)(next@13.5.6)(nextra@2.12.3)(react-dom@18.2.0)(react@18.2.0)
@@ -13772,6 +13716,16 @@ packages:
       '@types/keyv': 3.1.4
       '@types/node': 20.10.3
       '@types/responselike': 1.0.0
+    dev: true
+
+  /@types/chai-subset@1.3.5:
+    resolution: {integrity: sha512-c2mPnw+xHtXDoHmdtcCXGwyLMiauiAyxWMzhGpqHC4nqI/Y5G2XhTampslK2rb59kpcuHon03UH8W6iYUzw88A==}
+    dependencies:
+      '@types/chai': 4.3.11
+    dev: true
+
+  /@types/chai@4.3.11:
+    resolution: {integrity: sha512-qQR1dr2rGIHYlJulmr8Ioq3De0Le9E4MJ5AiaeAETJJpndT1uUNHsGFK3L/UIu+rbkQSdj8J/w2bCsBZc/Y5fQ==}
     dev: true
 
   /@types/cli-progress@3.11.0:
@@ -14494,12 +14448,28 @@ packages:
       graphql: 16.8.1
     dev: true
 
+  /@vitest/expect@0.34.6:
+    resolution: {integrity: sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==}
+    dependencies:
+      '@vitest/spy': 0.34.6
+      '@vitest/utils': 0.34.6
+      chai: 4.3.10
+    dev: true
+
   /@vitest/expect@1.0.1:
     resolution: {integrity: sha512-3cdrb/eKD/0tygDX75YscuHEHMUJ70u3UoLSq2eqhWks57AyzvsDQbyn53IhZ0tBN7gA8Jj2VhXiOV2lef7thw==}
     dependencies:
       '@vitest/spy': 1.0.1
       '@vitest/utils': 1.0.1
       chai: 4.3.10
+    dev: true
+
+  /@vitest/runner@0.34.6:
+    resolution: {integrity: sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==}
+    dependencies:
+      '@vitest/utils': 0.34.6
+      p-limit: 4.0.0
+      pathe: 1.1.1
     dev: true
 
   /@vitest/runner@1.0.1:
@@ -14510,6 +14480,14 @@ packages:
       pathe: 1.1.1
     dev: true
 
+  /@vitest/snapshot@0.34.6:
+    resolution: {integrity: sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==}
+    dependencies:
+      magic-string: 0.30.5
+      pathe: 1.1.1
+      pretty-format: 29.7.0
+    dev: true
+
   /@vitest/snapshot@1.0.1:
     resolution: {integrity: sha512-wIPtPDGSxEZ+DpNMc94AsybX6LV6uN6sosf5TojyP1m2QbKwiRuLV/5RSsjt1oWViHsTj8mlcwrQQ1zHGO0fMw==}
     dependencies:
@@ -14518,10 +14496,24 @@ packages:
       pretty-format: 29.7.0
     dev: true
 
+  /@vitest/spy@0.34.6:
+    resolution: {integrity: sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==}
+    dependencies:
+      tinyspy: 2.2.0
+    dev: true
+
   /@vitest/spy@1.0.1:
     resolution: {integrity: sha512-yXwm1uKhBVr/5MhVeSmtNqK+0q2RXIchJt8kokEKdrWLtkPeDgdbZ6SjR1VQGZuNdWL6sSBnLayIyVvcS0qLfA==}
     dependencies:
       tinyspy: 2.2.0
+    dev: true
+
+  /@vitest/utils@0.34.6:
+    resolution: {integrity: sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==}
+    dependencies:
+      diff-sequences: 29.6.3
+      loupe: 2.3.7
+      pretty-format: 29.7.0
     dev: true
 
   /@vitest/utils@1.0.1:
@@ -16351,7 +16343,7 @@ packages:
       check-error: 1.0.3
       deep-eql: 4.1.3
       get-func-name: 2.0.2
-      loupe: 2.3.6
+      loupe: 2.3.7
       pathval: 1.1.1
       type-detect: 4.0.8
     dev: true
@@ -19624,7 +19616,7 @@ packages:
   /fast-url-parser@1.1.3:
     resolution: {integrity: sha512-5jOCVXADYNuRkKFzNJ0dCCewsZiYo0dz8QNYljkOpFC6r2U4OBmKtvm/Tsuh4w1YYdDqDb31a8TVhBJ2OJKdqQ==}
     dependencies:
-      punycode: 1.3.2
+      punycode: 1.4.1
 
   /fast-xml-parser@4.2.5:
     resolution: {integrity: sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==}
@@ -23272,6 +23264,11 @@ packages:
     engines: {node: '>= 12.13.0'}
     dev: true
 
+  /local-pkg@0.4.3:
+    resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
+    engines: {node: '>=14'}
+    dev: true
+
   /local-pkg@0.5.0:
     resolution: {integrity: sha512-ok6z3qlYyCDS4ZEU27HaU6x/xZa9Whf8jD4ptH5UZTQYZVYeb9bnZ3ojVhiJNLiXK1Hfc0GNbLXcmZ5plLDDBg==}
     engines: {node: '>=14'}
@@ -23448,13 +23445,6 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
-
-  /loupe@2.3.6:
-    resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
-    deprecated: Please upgrade to 2.3.7 which fixes GHSA-4q6p-r6v2-jvc5
-    dependencies:
-      get-func-name: 2.0.2
-    dev: true
 
   /loupe@2.3.7:
     resolution: {integrity: sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==}
@@ -25321,7 +25311,7 @@ packages:
       react: '>=16.0.0'
       react-dom: '>=16.0.0'
     dependencies:
-      next: 13.5.6(@babel/core@7.23.0)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.5.6(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -25337,7 +25327,7 @@ packages:
       '@next/env': 13.5.6
       fast-glob: 3.3.1
       minimist: 1.2.8
-      next: 13.5.6(@babel/core@7.23.0)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.5.6(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0)
     dev: true
 
   /next-themes@0.2.1(next@13.5.6)(react-dom@18.2.0)(react@18.2.0):
@@ -25347,7 +25337,7 @@ packages:
       react: '*'
       react-dom: '*'
     dependencies:
-      next: 13.5.6(@babel/core@7.23.0)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.5.6(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
     dev: false
@@ -25360,7 +25350,7 @@ packages:
       - webpack
     dev: false
 
-  /next@13.5.6(@babel/core@7.23.0)(react-dom@18.2.0)(react@18.2.0):
+  /next@13.5.6(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-Y2wTcTbO4WwEsVb4A8VSnOsG1I9ok+h74q0ZdxkwM3EODqrs4pasq7O0iUxbcS9VtWMicG7f3+HAj0r1+NtKSw==}
     engines: {node: '>=16.14.0'}
     hasBin: true
@@ -25382,7 +25372,7 @@ packages:
       postcss: 8.4.31
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.23.0)(react@18.2.0)
+      styled-jsx: 5.1.1(@babel/core@7.23.5)(react@18.2.0)
       watchpack: 2.4.0
     optionalDependencies:
       '@next/swc-darwin-arm64': 13.5.6
@@ -25404,7 +25394,7 @@ packages:
       next: ^8.1.1-canary.54 || ^9.0.0 || ^10.0.0-0 || ^11.0.0 || ^12.0.0 || ^13.0.0
     dependencies:
       cors: 2.8.5
-      next: 13.5.6(@babel/core@7.23.0)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.5.6(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0)
     dev: false
 
   /nextra-theme-docs@2.12.3(patch_hash=eb56dwi3xee5yymywh7ts2dw44)(next@13.5.6)(nextra@2.12.3)(react-dom@18.2.0)(react@18.2.0):
@@ -25424,7 +25414,7 @@ packages:
       git-url-parse: 13.1.0
       intersection-observer: 0.12.2
       match-sorter: 6.3.1
-      next: 13.5.6(@babel/core@7.23.0)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.5.6(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0)
       next-seo: 6.0.0(next@13.5.6)(react-dom@18.2.0)(react@18.2.0)
       next-themes: 0.2.1(next@13.5.6)(react-dom@18.2.0)(react@18.2.0)
       nextra: 2.12.3(patch_hash=hxh4emx3aynf2jzsz5rahc4b4y)(next@13.5.6)(react-dom@18.2.0)(react@18.2.0)
@@ -25455,7 +25445,7 @@ packages:
       gray-matter: 4.0.3
       katex: 0.16.8
       lodash.get: 4.4.2
-      next: 13.5.6(@babel/core@7.23.0)(react-dom@18.2.0)(react@18.2.0)
+      next: 13.5.6(@babel/core@7.23.5)(react-dom@18.2.0)(react@18.2.0)
       next-mdx-remote: 4.2.1(react-dom@18.2.0)(react@18.2.0)
       p-limit: 3.1.0
       react: 18.2.0
@@ -27847,6 +27837,7 @@ packages:
 
   /punycode@1.3.2:
     resolution: {integrity: sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw==}
+    dev: true
 
   /punycode@1.4.1:
     resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
@@ -27996,7 +27987,7 @@ packages:
       strip-json-comments: 2.0.1
     dev: true
 
-  /react-avatar@5.0.3(@babel/runtime@7.23.1)(core-js-pure@3.28.0)(prop-types@15.8.1)(react@18.2.0):
+  /react-avatar@5.0.3(@babel/runtime@7.23.5)(core-js-pure@3.28.0)(prop-types@15.8.1)(react@18.2.0):
     resolution: {integrity: sha512-DNc+qkWH9QehSEZqHBhqpXWsPY+rU9W7kD68QFHfu8Atfsvx/3ML0DzAePgTUd96nCXQQ3KZMcC3LKYT8FiBIg==}
     peerDependencies:
       '@babel/runtime': '>=7'
@@ -28004,7 +27995,7 @@ packages:
       prop-types: ^15.0.0 || ^16.0.0
       react: ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@babel/runtime': 7.23.1
+      '@babel/runtime': 7.23.5
       core-js-pure: 3.28.0
       is-retina: 1.0.3
       md5: 2.3.0
@@ -28237,7 +28228,7 @@ packages:
       use-callback-ref: 1.3.0(@types/react@18.2.42)(react@18.2.0)
       use-sidecar: 1.1.2(@types/react@18.2.42)(react@18.2.0)
 
-  /react-select@5.8.0(@babel/core@7.23.0)(@types/react@18.2.42)(react-dom@18.2.0)(react@18.2.0):
+  /react-select@5.8.0(@babel/core@7.23.5)(@types/react@18.2.42)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-TfjLDo58XrhP6VG5M/Mi56Us0Yt8X7xD6cDybC7yoRMUNm7BGO7qk8J0TLQOua/prb8vUOtsfnXZwfm30HGsAA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -28245,7 +28236,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.23.1
       '@emotion/cache': 11.10.5
-      '@emotion/react': 11.10.5(@babel/core@7.23.0)(@types/react@18.2.42)(react@18.2.0)
+      '@emotion/react': 11.10.5(@babel/core@7.23.5)(@types/react@18.2.42)(react@18.2.0)
       '@floating-ui/dom': 1.2.9
       '@types/react-transition-group': 4.4.5
       memoize-one: 6.0.0
@@ -30300,23 +30291,6 @@ packages:
       tslib: 2.6.2
     dev: false
 
-  /styled-jsx@5.1.1(@babel/core@7.23.0)(react@18.2.0):
-    resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
-    engines: {node: '>= 12.0.0'}
-    peerDependencies:
-      '@babel/core': '*'
-      babel-plugin-macros: '*'
-      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0'
-    peerDependenciesMeta:
-      '@babel/core':
-        optional: true
-      babel-plugin-macros:
-        optional: true
-    dependencies:
-      '@babel/core': 7.23.0
-      client-only: 0.0.1
-      react: 18.2.0
-
   /styled-jsx@5.1.1(@babel/core@7.23.5)(react@18.2.0):
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
     engines: {node: '>= 12.0.0'}
@@ -30333,7 +30307,6 @@ packages:
       '@babel/core': 7.23.5
       client-only: 0.0.1
       react: 18.2.0
-    dev: true
 
   /stylehacks@6.0.0(postcss@8.4.32):
     resolution: {integrity: sha512-+UT589qhHPwz6mTlCLSt/vMNTJx8dopeJlZAlBMJPWA3ORqu6wmQY7FBXf+qD+FsqoBJODyqNxOUP3jdntFRdw==}
@@ -30812,6 +30785,11 @@ packages:
 
   /tinybench@2.5.1:
     resolution: {integrity: sha512-65NKvSuAVDP/n4CqH+a9w2kTlLReS9vhsAP06MWx+/89nMinJyB2icyl58RIcqCmIggpojIGeuJGhjU1aGMBSg==}
+    dev: true
+
+  /tinypool@0.7.0:
+    resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
+    engines: {node: '>=14.0.0'}
     dev: true
 
   /tinypool@0.8.1:
@@ -31416,6 +31394,13 @@ packages:
 
   /undici-types@5.26.5:
     resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
+  /undici@5.26.3:
+    resolution: {integrity: sha512-H7n2zmKEWgOllKkIUkLvFmsJQj062lSm3uA4EYApG8gLuiOM0/go9bIoC3HVaSnfg4xunowDE2i9p8drkXuvDw==}
+    engines: {node: '>=14.0'}
+    dependencies:
+      '@fastify/busboy': 2.0.0
+    dev: true
 
   /unicode-canonical-property-names-ecmascript@2.0.0:
     resolution: {integrity: sha512-yY5PpDlfVIU5+y/BSCxAJRBIS1Zc2dDG3Ujq+sR0U+JjUevW2JhocOF+soROYDSaAezOzOKuyyixhD6mBknSmQ==}
@@ -32125,6 +32110,28 @@ packages:
       replace-ext: 1.0.1
     dev: true
 
+  /vite-node@0.34.6(@types/node@20.10.3):
+    resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4(supports-color@8.1.1)
+      mlly: 1.4.2
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      vite: 5.0.5(@types/node@20.10.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
   /vite-node@1.0.1(@types/node@20.10.3):
     resolution: {integrity: sha512-Y2Jnz4cr2azsOMMYuVPrQkp3KMnS/0WV8ezZjCy4hU7O5mUHCAVOnFmoEvs1nvix/4mYm74Len8bYRWZJMNP6g==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -32180,6 +32187,71 @@ packages:
       rollup: 4.6.1
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
+
+  /vitest@0.34.6:
+    resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+      playwright: '*'
+      safaridriver: '*'
+      webdriverio: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.11
+      '@types/chai-subset': 1.3.5
+      '@types/node': 20.10.3
+      '@vitest/expect': 0.34.6
+      '@vitest/runner': 0.34.6
+      '@vitest/snapshot': 0.34.6
+      '@vitest/spy': 0.34.6
+      '@vitest/utils': 0.34.6
+      acorn: 8.10.0
+      acorn-walk: 8.3.0
+      cac: 6.7.14
+      chai: 4.3.10
+      debug: 4.3.4(supports-color@8.1.1)
+      local-pkg: 0.4.3
+      magic-string: 0.30.5
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      std-env: 3.6.0
+      strip-literal: 1.3.0
+      tinybench: 2.5.1
+      tinypool: 0.7.0
+      vite: 5.0.5(@types/node@20.10.3)
+      vite-node: 0.34.6(@types/node@20.10.3)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
     dev: true
 
   /vitest@1.0.1(@types/node@20.10.3):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,9 +356,6 @@ importers:
       '@oclif/plugin-update':
         specifier: 3.2.4
         version: 3.2.4(@swc/core@1.3.100)(@types/node@20.10.3)(typescript@5.3.2)
-      '@whatwg-node/fetch':
-        specifier: 0.9.13
-        version: 0.9.13
       colors:
         specifier: 1.4.0
         version: 1.4.0
@@ -377,6 +374,9 @@ importers:
       mkdirp:
         specifier: 2.1.6
         version: 2.1.6
+      node-fetch:
+        specifier: 3.3.2
+        version: 3.3.2
       tslib:
         specifier: 2.6.2
         version: 2.6.2
@@ -17813,6 +17813,11 @@ packages:
       assert-plus: 1.0.0
     dev: true
 
+  /data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+    dev: false
+
   /dataloader@1.4.0:
     resolution: {integrity: sha512-68s5jYdlvasItOJnCuI2Q9s4q98g0pCyL3HrcKJu8KNugUl8ahgmZYg38ysLTgQjjXX3H8CJLkAvWrclWfcalw==}
     dev: true
@@ -19725,6 +19730,14 @@ packages:
       tmp: 0.0.33
     dev: true
 
+  /fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.2.1
+    dev: false
+
   /fetch-retry@5.0.4:
     resolution: {integrity: sha512-LXcdgpdcVedccGg0AZqg+S8lX/FCdwXD92WNZ5k5qsb0irRhSFsBOpcJt7oevyqT2/C2nEE0zSFNdBEpj3YOSw==}
     dev: true
@@ -20063,6 +20076,13 @@ packages:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
     dev: true
+
+  /formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+    dependencies:
+      fetch-blob: 3.2.0
+    dev: false
 
   /formik@2.4.5(react@18.2.0):
     resolution: {integrity: sha512-Gxlht0TD3vVdzMDHwkiNZqJ7Mvg77xQNfmBRrNtvzcHZs72TJppSTDKHpImCMJZwcWPBJ8jSQQ95GJzXFf1nAQ==}
@@ -25515,6 +25535,11 @@ packages:
       minimatch: 3.1.2
     dev: true
 
+  /node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    dev: false
+
   /node-fetch-native@1.0.2:
     resolution: {integrity: sha512-KIkvH1jl6b3O7es/0ShyCgWLcfXxlBrLBbP3rOr23WArC66IMcU4DeZEeYEOwnopYhawLTn7/y+YtmASe8DFVQ==}
     dev: true
@@ -25529,6 +25554,15 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
+
+  /node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
+    dev: false
 
   /node-gyp-build-optional-packages@5.0.3:
     resolution: {integrity: sha512-k75jcVzk5wnnc/FMxsf4udAoTEUv2jY3ycfdSd3yWu6Cnd1oee6/CfZJApyscA4FJOmdoixWwiwOyf16RzD5JA==}

--- a/scripts/seed-local-env.ts
+++ b/scripts/seed-local-env.ts
@@ -1,6 +1,5 @@
 import { buildSchema, parse } from 'graphql';
 import { createHive } from '@graphql-hive/client';
-import { fetch } from '@whatwg-node/fetch';
 
 const isFederation = process.env.FEDERATION === '1';
 const isSchemaReportingEnabled = process.env.SCHEMA_REPORTING !== '0';


### PR DESCRIPTION
Seems like it should solve an issue with constantly growing active handlers/requests.

Use `whatwg-node/fetch` only in CLI (as we don't know the node version it will run on).