### PR TITLE
Very small typo fixes

### DIFF
--- a/packages/web/docs/src/pages/docs/management/projects.mdx
+++ b/packages/web/docs/src/pages/docs/management/projects.mdx
@@ -141,7 +141,7 @@ URL, with a JSON payload as body (with `Content-Type: application/json` header s
 a notification is triggered.
 
 <Callout type="warning">
-  Note that using this form of alert is intended to imlement custom flows. You cannot use an
+  Note that using this form of alert is intended to implement custom flows. You cannot use an
   Incoming Webhook feature of products like MSTeams or Slack, because the expected payload is
   different.
 </Callout>
@@ -158,7 +158,7 @@ a notification is triggered.
 />
 
 <Callout type="info">
-  Every type of event/notification have a different JSON payload, please refer to the information
+  Every type of event/notification has a different JSON payload, please refer to the information
   below, for a specific payload structure for every kind of alert.
 </Callout>
 


### PR DESCRIPTION
### Background

I'm just diving into the docs for GraphQL hive and noticed a couple small typos that I thought I'd fix.

### Description

A couple of small typo fixes in the documentation.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

n/a