### PR TITLE
fix: unused schema on field-definition

### DIFF
--- a/packages/services/api/src/modules/schema/lib/unused-graphql.ts
+++ b/packages/services/api/src/modules/schema/lib/unused-graphql.ts
@@ -28,6 +28,11 @@ export function stripUsedSchemaCoordinatesFromDocumentNode(
             throw new Error('Expected type name');
           }
 
+          const coordinate = `${typeName}.${fieldName}`;
+          if (usedCoordinates.has(coordinate)) {
+            return null;
+          }
+
           // if a field is used but some of it's arguments is not used, we cannot remove the field
           // we can simply check if some of the arguments are used, if not we can remove the field
           if (!node.arguments?.length && usedCoordinates.has(`${typeName}.${fieldName}`)) {


### PR DESCRIPTION
### Background

It seem like some of the "Unused schema" is a big misleading and shows FieldDefinitions that are actually used. It shows up when at least one of the arguments are _unused_ in the field query.

This is misleading because it looks like the entire field is unused, when in fact is used. It's just used with a different argument. 

### Description

NOTE: This is still very much in progress and a proof of concept for the issue here above.

Issue on Hive: https://github.com/kamilkisiela/graphql-hive/issues/3049

Goals:
- Make sure that Fields that are used do not show up on "Unused schema"

Open questions:
- Do we have arguments that are unused show up anywhere else?
  - Is this required?

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
