### PR TITLE
Check graphql server response for validity before updating supergraph file on regular poll.

### DIFF
--- a/packages/libraries/router/src/registry.rs
+++ b/packages/libraries/router/src/registry.rs
@@ -210,6 +210,11 @@ impl HiveRegistry {
         match self.fetch_supergraph(self.etag.clone()) {
             Ok(new_supergraph) => {
                 if let Some(new_supergraph) = new_supergraph {
+                    let parse_result = graphql_parser::parse_schema::<&str>(&new_supergraph);
+                    if let Err(parse_err) = parse_result {
+                        self.logger.error(&format!("Unable to update supergraph schema: {}", parse_err));
+                        return;
+                    }
                     let current_file = std::fs::read_to_string(self.file_name.clone())
                         .expect("Could not read file");
                     let current_supergraph_hash = hash(current_file.as_bytes());


### PR DESCRIPTION
### Background

If hive registry is reverse-proxied and becomes unreachable, there can be non-graphql response returned with different statuscode (e.g. 404 due to gateway misconfiguration, 503/502 if upstream is unreachable).

In this case plain text response is returned and supergraph file is updated with this plain text response, which cause apollo router to crash.

### Description

Regardless of response code returned, check response for validity. log error and do not update the supergraph file.

### Checklist

- [x] Error handling and logging
- [x] Testing
