### PR TITLE
Ensure valid supergraph in Router

### DIFF
--- a/packages/libraries/router/router.yaml
+++ b/packages/libraries/router/router.yaml
@@ -1,4 +1,9 @@
 supergraph:
   listen: 0.0.0.0:4000
+  introspection: true
+sandbox:
+  enabled: true
+homepage:
+  enabled: false
 plugins:
   hive.usage: {}

--- a/packages/libraries/router/src/registry.rs
+++ b/packages/libraries/router/src/registry.rs
@@ -182,7 +182,21 @@ impl HiveRegistry {
             return Ok(None);
         }
 
-        Ok(Some(resp.text().map_err(|e| e.to_string())?))
+        if resp.status().is_success() {
+            let supergraph = resp.text().map_err(|e| e.to_string())?;
+
+            if supergraph.contains("join__graph") {
+                return Ok(Some(supergraph));
+            }
+
+            return Err("Fetched invalid supergraph".to_string());
+        }
+
+        Err(format!(
+            "Failed to fetch supergraph (status={}, reason={})",
+            resp.status().as_u16(),
+            resp.text().map_err(|e| e.to_string())?
+        ))
     }
 
     fn initial_supergraph(&mut self) -> Result<(), String> {


### PR DESCRIPTION
Closes #3052

Pass supergraph SDL to Router only if the response status is 2XX and the response body contains a valid supergraph.