### PR TITLE
Improve performance of OperationsReader.getTopOperationsForTypes

### DIFF
--- a/packages/services/api/src/modules/operations/providers/operations-reader.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-reader.ts
@@ -1198,15 +1198,14 @@ export class OperationsReader {
           FROM (
             SELECT
               sum(cdi.total) as total, cdi.hash as hash, cdi.coordinate as coordinate
-            FROM coordinates_daily as cd
+            FROM coordinates_daily as cdi
               ${this.createFilter({
                 target: args.targetId,
                 period: args.period,
-                // extra: [sql`(${sql.join(ORs, ' OR ')})`],
                 extra: [sql`cdi.coordinate NOT LIKE '%.%.%'`],
                 namespace: 'cdi',
               })}
-            GROUP BY cdi.hash, cdi.coordinate ORDER by total DESC, cdi.hash ASC DESC LIMIT ${sql.raw(
+            GROUP BY cdi.hash, cdi.coordinate ORDER by total DESC, cdi.hash ASC LIMIT ${sql.raw(
               String(args.limit),
             )} by cdi.coordinate
           ) as cd


### PR DESCRIPTION
A query I used for benchmarking shows 2.5x improvement: 3.5s -> 1s.

The "before" query had a long list of WHERE conditions. The new query fetches all rows, aggregates them to sum(total) and only then applies a long list of WHERE conditions. I would expect it to be less performant but it actually do less computation this way. 