### PR TITLE
Update "Trigger staging deployment" step

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,8 +27,9 @@ jobs:
         run: |
           curl --request POST \
             --url 'https://api.github.com/repos/${{ secrets.PRIVATE_REPO_OWNER }}/${{ secrets.PRIVATE_REPO_NAME }}/dispatches' \
-            --header 'Accept: application/vnd.github.everest-preview+json' \
+            --header 'Accept: application/vnd.github+json' \
             --header 'Authorization: token ${{ secrets.GH_PAT }}' \
+            --header 'X-GitHub-Api-Version: 2022-11-28' \
             --header 'Content-Type: application/json' \
             --data '{
             "event_type": "deploy-staging",


### PR DESCRIPTION
Update `Accept` and `X-GitHub-Api-Version` headers according to https://docs.github.com/en/free-pro-team@latest/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event

Looks like the api is stable now.