### PR TITLE
feat: run migrations outside transaction

### DIFF
--- a/packages/migrations/src/actions/2023.10.26T12.44.36.schema-checks-filters-index.ts
+++ b/packages/migrations/src/actions/2023.10.26T12.44.36.schema-checks-filters-index.ts
@@ -3,37 +3,50 @@ import { type MigrationExecutor } from '../pg-migrator';
 export default {
   name: '2023.10.26T12.44.36.schema-checks-filters-index.ts',
   noTransaction: true,
-  run: ({ sql }) => sql`
-    CREATE INDEX CONCURRENTLY "schema_checks_connection_pagination_with_changes" ON "schema_checks" (
-      "target_id" ASC
-      , "created_at" DESC
-      , "id" DESC
-    )
-    WHERE
-      jsonb_typeof("safe_schema_changes") = 'array'
-      OR jsonb_typeof("breaking_schema_changes") = 'array'
-    ;
-
-    CREATE INDEX CONCURRENTLY "schema_checks_connection_pagination_with_no_success" ON "schema_checks" (
-      "target_id" ASC
-      , "created_at" DESC
-      , "id" DESC
-    )
-    WHERE
-      "is_success" = false
-    ;
-
-    CREATE INDEX CONCURRENTLY "schema_checks_connection_pagination_with_no_success_and_changes" ON "schema_checks" (
-      "target_id" ASC
-      , "created_at" DESC
-      , "id" DESC
-    )
-    WHERE
-      "is_success" = false
-      AND  (
-        jsonb_typeof("safe_schema_changes") = 'array'
-        OR jsonb_typeof("breaking_schema_changes") = 'array'
-      )
-    ;
-  `,
+  run: ({ sql }) => [
+    {
+      name: 'schema_checks_connection_pagination_with_changes',
+      query: sql`
+        CREATE INDEX CONCURRENTLY "schema_checks_connection_pagination_with_changes" ON "schema_checks" (
+          "target_id" ASC
+          , "created_at" DESC
+          , "id" DESC
+        )
+        WHERE
+          jsonb_typeof("safe_schema_changes") = 'array'
+          OR jsonb_typeof("breaking_schema_changes") = 'array'
+        ;
+    `,
+    },
+    {
+      name: 'schema_checks_connection_pagination_with_no_success',
+      query: sql`
+        CREATE INDEX CONCURRENTLY "schema_checks_connection_pagination_with_no_success" ON "schema_checks" (
+          "target_id" ASC
+          , "created_at" DESC
+          , "id" DESC
+        )
+         WHERE
+           "is_success" = false
+         ;
+    `,
+    },
+    {
+      name: 'schema_checks_connection_pagination_with_no_success_and_changes',
+      query: sql`
+        CREATE INDEX CONCURRENTLY "schema_checks_connection_pagination_with_no_success_and_changes" ON "schema_checks" (
+          "target_id" ASC
+          , "created_at" DESC
+          , "id" DESC
+        )
+        WHERE
+          "is_success" = false
+          AND  (
+            jsonb_typeof("safe_schema_changes") = 'array'
+            OR jsonb_typeof("breaking_schema_changes") = 'array'
+          )
+        ;
+      `,
+    },
+  ],
 } satisfies MigrationExecutor;

--- a/packages/migrations/src/actions/2023.10.26T12.44.36.schema-checks-filters-index.ts
+++ b/packages/migrations/src/actions/2023.10.26T12.44.36.schema-checks-filters-index.ts
@@ -2,37 +2,38 @@ import { type MigrationExecutor } from '../pg-migrator';
 
 export default {
   name: '2023.10.26T12.44.36.schema-checks-filters-index.ts',
+  noTransaction: true,
   run: ({ sql }) => sql`
-CREATE INDEX "schema_checks_connection_pagination_with_changes" ON "schema_checks" (
-  "target_id" ASC
-  , "created_at" DESC
-  , "id" DESC
-)
-WHERE
-  jsonb_typeof("safe_schema_changes") = 'array'
-  OR jsonb_typeof("breaking_schema_changes") = 'array'
-;
+    CREATE INDEX CONCURRENTLY "schema_checks_connection_pagination_with_changes" ON "schema_checks" (
+      "target_id" ASC
+      , "created_at" DESC
+      , "id" DESC
+    )
+    WHERE
+      jsonb_typeof("safe_schema_changes") = 'array'
+      OR jsonb_typeof("breaking_schema_changes") = 'array'
+    ;
 
-CREATE INDEX "schema_checks_connection_pagination_with_no_success" ON "schema_checks" (
-  "target_id" ASC
-  , "created_at" DESC
-  , "id" DESC
-)
-WHERE
-  "is_success" = false
-  ;
+    CREATE INDEX CONCURRENTLY "schema_checks_connection_pagination_with_no_success" ON "schema_checks" (
+      "target_id" ASC
+      , "created_at" DESC
+      , "id" DESC
+    )
+    WHERE
+      "is_success" = false
+    ;
 
-CREATE INDEX "schema_checks_connection_pagination_with_no_success_and_changes" ON "schema_checks" (
-  "target_id" ASC
-  , "created_at" DESC
-  , "id" DESC
-)
-WHERE
-  "is_success" = false
-  AND  (
-    jsonb_typeof("safe_schema_changes") = 'array'
-    OR jsonb_typeof("breaking_schema_changes") = 'array'
-  )
-;
+    CREATE INDEX CONCURRENTLY "schema_checks_connection_pagination_with_no_success_and_changes" ON "schema_checks" (
+      "target_id" ASC
+      , "created_at" DESC
+      , "id" DESC
+    )
+    WHERE
+      "is_success" = false
+      AND  (
+        jsonb_typeof("safe_schema_changes") = 'array'
+        OR jsonb_typeof("breaking_schema_changes") = 'array'
+      )
+    ;
   `,
 } satisfies MigrationExecutor;

--- a/packages/migrations/src/index.ts
+++ b/packages/migrations/src/index.ts
@@ -7,7 +7,10 @@ import { createConnectionString } from './connection-string';
 import { env } from './environment';
 import { runPGMigrations } from './run-pg-migrations';
 
-const slonik = await createPool(createConnectionString(env.postgres));
+const slonik = await createPool(createConnectionString(env.postgres), {
+  // 10 minute timeout per statement
+  statementTimeout: 10 * 60 * 1000,
+});
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const actionsDirectory = __dirname + path.sep + 'actions';

--- a/packages/migrations/src/index.ts
+++ b/packages/migrations/src/index.ts
@@ -1,6 +1,4 @@
 #!/usr/bin/env node
-import path from 'node:path';
-import url from 'node:url';
 import { createPool } from 'slonik';
 import { migrateClickHouse } from './clickhouse';
 import { createConnectionString } from './connection-string';
@@ -11,10 +9,6 @@ const slonik = await createPool(createConnectionString(env.postgres), {
   // 10 minute timeout per statement
   statementTimeout: 10 * 60 * 1000,
 });
-
-const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
-const actionsDirectory = __dirname + path.sep + 'actions';
-console.log('Actions in:', actionsDirectory);
 
 // This is used by production build of this package.
 // We are building a "cli" out of the package, so we need a workaround to pass the command to run.

--- a/packages/migrations/src/pg-migrator.ts
+++ b/packages/migrations/src/pg-migrator.ts
@@ -1,4 +1,5 @@
 import {
+  CommonQueryMethods,
   sql,
   type DatabasePool,
   type DatabaseTransactionConnection,
@@ -8,8 +9,16 @@ import {
 
 export type MigrationExecutor = {
   name: string;
+  /**
+   * Run the database migration outside a transaction.
+   * E.g. if you want to set a costly index or need to run any other costly SQL that would block the database users too long.
+   **/
+  noTransaction?: true;
+  /**
+   * You can either return a SQL query to run or instead use the connection within the function to run custom logic.
+   */
   run: (args: {
-    connection: DatabaseTransactionConnection;
+    connection: CommonQueryMethods;
     sql: SqlTaggedTemplate;
   }) => Promise<void> | TaggedTemplateLiteralInvocation;
 };
@@ -25,6 +34,38 @@ const seedMigrationsIfNotExists = async (args: { connection: DatabaseTransaction
   `);
 };
 
+async function runMigration(connection: CommonQueryMethods, migration: MigrationExecutor) {
+  const exists = await connection.maybeOneFirst(sql`
+    SELECT true
+    FROM
+      "public"."migration"
+    WHERE
+      "name" = ${migration.name}
+  `);
+
+  if (exists === true) {
+    return;
+  }
+
+  const startTime = Date.now();
+  console.log(`Running migration: ${migration.name}`);
+
+  const result = await migration.run({ connection, sql });
+  if (result) {
+    await connection.query(result);
+  }
+
+  // TODO: hash verification (but tbh nobody cares about that)
+  await connection.query(sql`
+    INSERT INTO "public"."migration" ("name", "hash")
+    VALUES (${migration.name}, ${migration.name});
+  `);
+  const finishTime = Date.now();
+  const delta = finishTime - startTime;
+
+  console.log(`Finished in ${convertMsToTime(delta)}`);
+}
+
 export async function runMigrations(args: {
   slonik: DatabasePool;
   migrations: Array<MigrationExecutor>;
@@ -32,42 +73,46 @@ export async function runMigrations(args: {
 }) {
   console.log('Running PG migrations.');
 
-  await args.slonik.transaction(async connection => {
-    await seedMigrationsIfNotExists({ connection });
-    for (const migration of args.migrations) {
-      const { name } = migration;
+  await seedMigrationsIfNotExists({ connection: args.slonik });
 
-      const exists = await connection.maybeOneFirst(sql`
-        SELECT true
-        FROM
-          "public"."migration"
-        WHERE
-          "name" = ${name}
-      `);
-
-      if (exists === true) {
-        continue;
-      }
-
-      console.log(`Running migration: ${name}`);
-
-      const result = await migration.run({ connection, sql });
-      if (result) {
-        await connection.query(result);
-      }
-
-      // TODO: hash verification (but tbh nobody cares about that)
-      await connection.query(sql`
-        INSERT INTO "public"."migration" ("name", "hash")
-        VALUES (${name}, ${name});
-      `);
-
-      if (args.runTo && args.runTo === name) {
-        console.log(`reached migration '${name}'. Stopping.`);
-        break;
-      }
+  for (const migration of args.migrations) {
+    if (migration.noTransaction === true) {
+      await runMigration(args.slonik, migration);
+    } else {
+      await args.slonik.transaction(connection => runMigration(connection, migration));
     }
-  });
+
+    if (args.runTo && args.runTo === migration.name) {
+      console.log(`reached migration '${migration.name}'. Stopping.`);
+      break;
+    }
+  }
 
   console.log('Done.');
+}
+
+function padTo2Digits(num: number) {
+  return num.toString().padStart(2, '0');
+}
+
+function convertMsToTime(milliseconds: number) {
+  if (milliseconds < 1000) {
+    return `${milliseconds}ms`;
+  }
+  let seconds = Math.floor(milliseconds / 1000);
+  let minutes = Math.floor(seconds / 60);
+  let hours = Math.floor(minutes / 60);
+
+  seconds = seconds % 60;
+  minutes = minutes % 60;
+
+  if (hours === 0) {
+    if (minutes === 0) {
+      return `${padTo2Digits(seconds)}s`;
+    }
+
+    return `${padTo2Digits(minutes)}:${padTo2Digits(seconds)}min`;
+  }
+
+  return `${padTo2Digits(hours)}:${padTo2Digits(minutes)}:${padTo2Digits(seconds)}h`;
 }

--- a/packages/migrations/src/pg-migrator.ts
+++ b/packages/migrations/src/pg-migrator.ts
@@ -112,12 +112,9 @@ function convertMsToTime(milliseconds: number) {
   if (milliseconds < 1000) {
     return `${milliseconds}ms`;
   }
-  let seconds = Math.floor(milliseconds / 1000);
-  let minutes = Math.floor(seconds / 60);
-  let hours = Math.floor(minutes / 60);
-
-  seconds = seconds % 60;
-  minutes = minutes % 60;
+  const seconds = Math.floor(milliseconds / 1000) % 60;
+  const minutes = Math.floor(seconds / 60) % 60;
+  const hours = Math.floor(minutes / 60);
 
   if (hours === 0) {
     if (minutes === 0) {


### PR DESCRIPTION
### Background

Adding indices to the `schema_checks` table is slow and would block pending operations on the table (writes, updates) for at least 30 seconds, according to @kamilkisiela estimations), which would block our customers from using any features related to schema_checks for that timeframe...

Instead, we can create indices concurrently using the [`CONCURRENTLY` keyword](https://www.postgresql.org/docs/current/sql-createindex.html).
However, this requires us to run database migrations outside a transaction, which is fine but requires adjustments to our migrations-runner, which is running everything inside a single transaction. 
I also added some time logging, which makes it easier for us to see the actual runtimes of the single migrations.

Example output:

<img width="672" alt="image" src="https://github.com/kamilkisiela/graphql-hive/assets/14338007/c28a6e2d-66c5-4118-bfd8-9f5b6d1cf8f1">



### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
