### PR TITLE
fix: require project read access for creating new projects within an organization

### DIFF
--- a/packages/services/api/src/modules/project/providers/project-manager.ts
+++ b/packages/services/api/src/modules/project/providers/project-manager.ts
@@ -41,6 +41,11 @@ export class ProjectManager {
     this.logger.info('Creating a project (input=%o)', input);
     let cleanId = paramCase(name);
 
+    await this.authManager.ensureOrganizationAccess({
+      organization: input.organization,
+      scope: OrganizationAccessScope.READ,
+    });
+
     if (
       // packages/web/app uses the "view" prefix, let's avoid the collision
       name.toLowerCase() === 'view' ||


### PR DESCRIPTION
### Background

Right now, anyone can create projects for an organization.

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
