### PR TITLE
Fix legacy SDL, introspection and metadata (+ publishing metadata) endpoints

### DIFF
--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -1539,7 +1539,7 @@ export class SchemaPublisher {
       if (metadata.length > 0) {
         await this.artifactStorageWriter.writeArtifact({
           targetId: target.id,
-          artifact: metadata,
+          artifact: metadata.length === 1 ? metadata[0] : metadata,
           artifactType: 'metadata',
         });
       }

--- a/packages/services/cdn-worker/src/handler.ts
+++ b/packages/services/cdn-worker/src/handler.ts
@@ -4,7 +4,6 @@ import { GetArtifactActionFn } from './artifact-handler';
 import { ArtifactsType as ModernArtifactsType } from './artifact-storage-reader';
 import {
   CDNArtifactNotFound,
-  InvalidArtifactMatch,
   InvalidArtifactTypeResponse,
   InvalidAuthKeyResponse,
   MissingAuthKeyResponse,
@@ -20,13 +19,6 @@ async function createETag(value: string) {
 
   return `"${hashArray.map(b => b.toString(16).padStart(2, '0')).join('')}"`;
 }
-
-type SchemaArtifact = {
-  sdl: string;
-  url?: string;
-  name?: string;
-  date?: string;
-};
 
 type ArtifactType = 'schema' | 'supergraph' | 'sdl' | 'metadata' | 'introspection';
 const artifactTypes = ['schema', 'supergraph', 'sdl', 'metadata', 'introspection'] as const;
@@ -224,7 +216,7 @@ export const createRequestHandler = (deps: RequestHandlerDependencies) => {
         .fetchText(rawValueAction.location)
         .catch(() => deps.fetchText(rawValueAction.location));
 
-      const etag = await createETag(`${kvStorageKey}|${rawValueAction}`);
+      const etag = await createETag(`${kvStorageKey}|${rawValue}`);
       const ifNoneMatch = request.headers.get('if-none-match');
 
       if (ifNoneMatch && ifNoneMatch === etag) {

--- a/packages/services/cdn-worker/src/handler.ts
+++ b/packages/services/cdn-worker/src/handler.ts
@@ -69,15 +69,9 @@ const createArtifactTypesHandlers = (
       targetId,
     ),
   sdl: (targetId: string, artifactType: string, rawValue: string, etag: string) => {
-    if (rawValue.startsWith('[')) {
-      return new InvalidArtifactMatch(artifactType, targetId, analytics);
-    }
-
-    const parsed = JSON.parse(rawValue) as SchemaArtifact;
-
     return createResponse(
       analytics,
-      parsed.sdl,
+      rawValue,
       {
         status: 200,
         headers: {
@@ -104,13 +98,7 @@ const createArtifactTypesHandlers = (
       targetId,
     ),
   introspection: (targetId: string, artifactType: string, rawValue: string, etag: string) => {
-    if (rawValue.startsWith('[')) {
-      return new InvalidArtifactMatch(artifactType, targetId, analytics);
-    }
-
-    const parsed = JSON.parse(rawValue) as SchemaArtifact;
-    const rawSdl = parsed.sdl;
-    const schema = buildSchema(rawSdl);
+    const schema = buildSchema(rawValue);
     const introspection = introspectionFromSchema(schema);
 
     return createResponse(

--- a/packages/services/cdn-worker/tests/cdn.spec.ts
+++ b/packages/services/cdn-worker/tests/cdn.spec.ts
@@ -27,7 +27,7 @@ describe('CDN Worker', () => {
     const SECRET = '123456';
     const targetId = 'fake-target-id';
     const map = new Map();
-    map.set(`target:${targetId}:sdl`, JSON.stringify({ sdl: `type Query { dummy: String }` }));
+    map.set(`target:${targetId}:sdl`, `type Query { dummy: String }`);
     const token = createToken(SECRET, targetId);
 
     const handleRequest = createRequestHandler({
@@ -86,7 +86,7 @@ describe('CDN Worker', () => {
     const SECRET = '123456';
     const targetId = 'fake-target-id';
     const map = new Map();
-    map.set(`target:${targetId}:sdl`, JSON.stringify({ sdl: `type Query { dummy: String }` }));
+    map.set(`target:${targetId}:sdl`, `type Query { dummy: String }`);
 
     const handleRequest = createRequestHandler({
       isKeyValid: createIsKeyValid({
@@ -161,10 +161,7 @@ describe('CDN Worker', () => {
     const SECRET = '123456';
     const targetId = 'fake-target-id';
     const map = new Map();
-    map.set(
-      `target:${targetId}:supergraph`,
-      JSON.stringify({ sdl: `type Query { dummy: String }` }),
-    );
+    map.set(`target:${targetId}:supergraph`, `type Query { dummy: String }`);
 
     const token = createToken(SECRET, targetId);
 
@@ -314,7 +311,7 @@ describe('CDN Worker', () => {
     const SECRET = '123456';
     const targetId = 'fake-target-id';
     const map = new Map();
-    map.set(`target:${targetId}:sdl`, JSON.stringify({ sdl: `type Query { dummy: String }` }));
+    map.set(`target:${targetId}:sdl`, `type Query { dummy: String }`);
 
     const handleRequest = createRequestHandler({
       isKeyValid: createIsKeyValid({
@@ -389,12 +386,7 @@ describe('CDN Worker', () => {
     const SECRET = '123456';
     const targetId = 'fake-target-id';
     const map = new Map();
-    map.set(
-      `target:${targetId}:sdl`,
-      JSON.stringify({
-        sdl: `type Query { dummy: String }`,
-      }),
-    );
+    map.set(`target:${targetId}:sdl`, `type Query { dummy: String }`);
 
     const handleRequest = createRequestHandler({
       isKeyValid: createIsKeyValid({
@@ -556,7 +548,7 @@ describe('CDN Worker', () => {
       const SECRET = '123456';
       const targetId = 'fake-target-id';
       const map = new Map();
-      map.set(`target:${targetId}:sdl`, JSON.stringify({ sdl: `type Query { dummy: String }` }));
+      map.set(`target:${targetId}:sdl`, `type Query { dummy: String }`);
 
       const handleRequest = createRequestHandler({
         isKeyValid: createIsKeyValid({


### PR DESCRIPTION
`/sdl` and `/introspection` - both expected an object with `"sdl"` property in it, but we passed SDL to them directly.

`/metadata` - the endpoint was fine but apparently the schema publisher uploaded an array of metadata instead of a single object. In order to not break existing Mesh projects, I had to detect if a value returned from R2 was a stringified array of objects and if that object was in fact a Mesh artifact. If so, I had to turn it into an object.