### PR TITLE
feat: no longer publish to the legacy CDN

### DIFF
--- a/deployment/services/graphql.ts
+++ b/deployment/services/graphql.ts
@@ -145,10 +145,6 @@ export function deployGraphQL({
         WEB_APP_URL: `https://${deploymentEnv.DEPLOYED_DNS}/`,
         // CDN
         CDN_CF: '1',
-        CDN_CF_BASE_PATH: 'https://api.cloudflare.com/client/v4/accounts',
-        CDN_CF_ACCOUNT_ID: cloudflareConfig.require('accountId'),
-        CDN_CF_AUTH_TOKEN: cloudflareConfig.requireSecret('apiToken'),
-        CDN_CF_NAMESPACE_ID: cdn.cfStorageNamespaceId,
         CDN_CF_BASE_URL: cdn.workerBaseUrl,
         CDN_AUTH_PRIVATE_KEY: cdnAuthPrivateKey,
         // Hive

--- a/packages/services/api/src/modules/cdn/providers/tokens.ts
+++ b/packages/services/api/src/modules/cdn/providers/tokens.ts
@@ -4,11 +4,7 @@ export interface CDNConfig {
   /** Available providers for serving the CDN. */
   providers: {
     cloudflare: {
-      basePath: string;
       baseUrl: string;
-      accountId: string;
-      authToken: string;
-      namespaceId: string;
     } | null;
     api: {
       baseUrl: string;

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -5,7 +5,6 @@ import promClient from 'prom-client';
 import { Change, CriticalityLevel } from '@graphql-inspector/core';
 import { SchemaCheck } from '@hive/storage';
 import * as Sentry from '@sentry/node';
-import type { Span } from '@sentry/types';
 import * as Types from '../../../__generated__/types';
 import {
   hashSDL,
@@ -1517,22 +1516,19 @@ export class SchemaPublisher {
     });
   }
 
-  private async updateCDN(
-    {
-      target,
-      project,
-      supergraph,
-      schemas,
-      fullSchemaSdl,
-    }: {
-      target: Target;
-      project: Project;
-      schemas: readonly Schema[];
-      supergraph?: string | null;
-      fullSchemaSdl: string;
-    },
-    span?: Span,
-  ) {
+  private async updateCDN({
+    target,
+    project,
+    supergraph,
+    schemas,
+    fullSchemaSdl,
+  }: {
+    target: Target;
+    project: Project;
+    schemas: readonly Schema[];
+    supergraph?: string | null;
+    fullSchemaSdl: string;
+  }) {
     const publishMetadata = async () => {
       const metadata: Array<Record<string, any>> = [];
       for (const schema of schemas) {
@@ -1541,21 +1537,11 @@ export class SchemaPublisher {
         }
       }
       if (metadata.length > 0) {
-        await Promise.all([
-          this.artifactStorageWriter.writeArtifact({
-            targetId: target.id,
-            artifact: metadata,
-            artifactType: 'metadata',
-          }),
-          this.cdn.publish(
-            {
-              targetId: target.id,
-              resourceType: 'metadata',
-              value: JSON.stringify(metadata.length === 1 ? metadata[0] : metadata),
-            },
-            span,
-          ),
-        ]);
+        await this.artifactStorageWriter.writeArtifact({
+          targetId: target.id,
+          artifact: metadata,
+          artifactType: 'metadata',
+        });
       }
     };
 
@@ -1563,7 +1549,7 @@ export class SchemaPublisher {
       const compositeSchema = ensureCompositeSchemas(schemas);
 
       await Promise.all([
-        this.artifactStorageWriter.writeArtifact({
+        await this.artifactStorageWriter.writeArtifact({
           targetId: target.id,
           artifactType: 'services',
           artifact: compositeSchema.map(s => ({
@@ -1577,50 +1563,15 @@ export class SchemaPublisher {
           artifactType: 'sdl',
           artifact: fullSchemaSdl,
         }),
-        this.cdn.publish(
-          {
-            targetId: target.id,
-            resourceType: 'schema',
-            value: JSON.stringify(
-              schemas.length > 1
-                ? compositeSchema.map(s => ({
-                    sdl: s.sdl,
-                    url: s.service_url,
-                    name: s.service_name,
-                    date: s.date,
-                  }))
-                : {
-                    sdl: compositeSchema[0].sdl,
-                    url: compositeSchema[0].service_url,
-                    name: compositeSchema[0].service_name,
-                    date: compositeSchema[0].date,
-                  },
-            ),
-          },
-          span,
-        ),
       ]);
     };
 
     const publishSingleSchema = async () => {
-      await Promise.all([
-        this.artifactStorageWriter.writeArtifact({
-          targetId: target.id,
-          artifactType: 'sdl',
-          artifact: fullSchemaSdl,
-        }),
-        this.cdn.publish(
-          {
-            targetId: target.id,
-            resourceType: 'schema',
-            value: JSON.stringify({
-              sdl: schemas[0].sdl,
-              date: schemas[0].date,
-            }),
-          },
-          span,
-        ),
-      ]);
+      await this.artifactStorageWriter.writeArtifact({
+        targetId: target.id,
+        artifactType: 'sdl',
+        artifact: fullSchemaSdl,
+      });
     };
 
     const actions = [
@@ -1633,14 +1584,6 @@ export class SchemaPublisher {
         this.logger.debug('Publishing supergraph to CDN');
 
         actions.push(
-          this.cdn.publish(
-            {
-              targetId: target.id,
-              resourceType: 'supergraph',
-              value: supergraph,
-            },
-            span,
-          ),
           this.artifactStorageWriter.writeArtifact({
             targetId: target.id,
             artifactType: 'supergraph',

--- a/packages/services/cdn-worker/src/dev-polyfill.ts
+++ b/packages/services/cdn-worker/src/dev-polyfill.ts
@@ -1,5 +1,5 @@
 import 'dotenv/config';
-import { crypto, Headers, ReadableStream, Request, Response } from '@whatwg-node/fetch';
+import { crypto, fetch, Headers, ReadableStream, Request, Response } from '@whatwg-node/fetch';
 import type { Env } from './env';
 
 if (!globalThis.Response) {
@@ -18,10 +18,9 @@ if (!globalThis.crypto) {
   globalThis.crypto = crypto;
 }
 
-export const devStorage = new Map<string, string>();
+export { fetch };
 
 export const env: Env = {
-  HIVE_DATA: devStorage,
   // eslint-disable-next-line no-process-env
   S3_ENDPOINT: process.env.S3_ENDPOINT || '',
   // eslint-disable-next-line no-process-env

--- a/packages/services/cdn-worker/src/dev.ts
+++ b/packages/services/cdn-worker/src/dev.ts
@@ -1,12 +1,11 @@
 import { createServer } from 'http';
 import * as itty from 'itty-router';
-import { json, withParams } from 'itty-router-extras';
 import { createServerAdapter } from '@whatwg-node/server';
 import { createArtifactRequestHandler } from './artifact-handler';
 import { ArtifactStorageReader } from './artifact-storage-reader';
 import { AwsClient } from './aws';
 import './dev-polyfill';
-import { devStorage, env } from './dev-polyfill';
+import { env, fetch } from './dev-polyfill';
 import { createRequestHandler } from './handler';
 import { createIsKeyValid } from './key-validation';
 
@@ -23,12 +22,23 @@ const s3 = {
 // eslint-disable-next-line no-process-env
 const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 4010;
 
-const handleRequest = createRequestHandler({
-  getRawStoreValue: value => env.HIVE_DATA.get(value),
-  isKeyValid: createIsKeyValid({ s3, getCache: null, waitUntil: null, analytics: null }),
-});
-
 const artifactStorageReader = new ArtifactStorageReader(s3, env.S3_PUBLIC_URL, null);
+
+const handleRequest = createRequestHandler({
+  isKeyValid: createIsKeyValid({ s3, getCache: null, waitUntil: null, analytics: null }),
+  async getArtifactAction(targetId, artifactType, eTag) {
+    return artifactStorageReader.generateArtifactReadUrl(targetId, artifactType, eTag);
+  },
+  async fetchText(url) {
+    const r = await fetch(url);
+
+    if (r.ok) {
+      return r.text();
+    }
+
+    throw new Error(`Failed to fetch ${url}, status: ${r.status}`);
+  },
+});
 
 const handleArtifactRequest = createArtifactRequestHandler({
   isKeyValid: createIsKeyValid({ s3, getCache: null, waitUntil: null, analytics: null }),
@@ -39,40 +49,6 @@ const handleArtifactRequest = createArtifactRequestHandler({
 
 function main() {
   const app = createServerAdapter(itty.Router());
-
-  app.put(
-    '/:accountId/storage/kv/namespaces/:namespaceId/values/:key',
-    withParams,
-    async (
-      request: Request & {
-        params: {
-          accountId: string;
-          namespaceId: string;
-          key: string;
-        };
-      },
-    ) => {
-      if (!request.params.key) {
-        throw new Error(`Missing key`);
-      }
-
-      const textBody = await request.text();
-
-      if (!textBody) {
-        throw new Error(`Missing body value`);
-      }
-
-      console.log(`Writing to ephermal storage: ${request.params.key}, value: ${request.body}`);
-
-      devStorage.set(request.params.key, textBody);
-
-      return json({
-        success: true,
-      });
-    },
-  );
-
-  app.get('/dump', () => json(Object.fromEntries(devStorage.entries())));
 
   app.get(
     '/_readiness',

--- a/packages/services/cdn-worker/src/env.ts
+++ b/packages/services/cdn-worker/src/env.ts
@@ -10,7 +10,6 @@ export type Env = {
   /**
    * KV Storage for the CDN
    */
-  HIVE_DATA: KVNamespace;
   SENTRY_DSN: string;
   /**
    * Name of the environment, e.g. staging, production

--- a/packages/services/cdn-worker/src/handler.ts
+++ b/packages/services/cdn-worker/src/handler.ts
@@ -110,6 +110,9 @@ function createArtifactTypesHandlers(analytics: Analytics) {
       rawValue: string,
       etag: string,
     ) {
+      if (rawValue.startsWith('[')) {
+        rawValue = rawValue.slice(1, -1);
+      }
       return createResponse(
         analytics,
         rawValue,

--- a/packages/services/cdn-worker/tests/cdn.spec.ts
+++ b/packages/services/cdn-worker/tests/cdn.spec.ts
@@ -1,6 +1,7 @@
 import { createHmac } from 'crypto';
 import * as bcrypt from 'bcryptjs';
 import '../src/dev-polyfill';
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { describe, expect, test } from 'vitest';
 import {
   InvalidArtifactTypeResponse,

--- a/packages/services/cdn-worker/tests/cdn.spec.ts
+++ b/packages/services/cdn-worker/tests/cdn.spec.ts
@@ -27,7 +27,7 @@ describe('CDN Worker', () => {
     const SECRET = '123456';
     const targetId = 'fake-target-id';
     const map = new Map();
-    map.set(`target:${targetId}:schema`, JSON.stringify({ sdl: `type Query { dummy: String }` }));
+    map.set(`target:${targetId}:sdl`, JSON.stringify({ sdl: `type Query { dummy: String }` }));
     const token = createToken(SECRET, targetId);
 
     const handleRequest = createRequestHandler({
@@ -46,7 +46,19 @@ describe('CDN Worker', () => {
           },
         },
       }),
-      getRawStoreValue: async (key: string) => map.get(key),
+      async getArtifactAction(targetId, artifactType) {
+        return map.has(`target:${targetId}:${artifactType}`)
+          ? {
+              type: 'redirect',
+              location: `target:${targetId}:${artifactType}`,
+            }
+          : {
+              type: 'notFound',
+            };
+      },
+      async fetchText(url) {
+        return map.get(url);
+      },
     });
 
     const schemaRequest = new Request(`https://fake-worker.com/${targetId}/schema`, {
@@ -74,7 +86,7 @@ describe('CDN Worker', () => {
     const SECRET = '123456';
     const targetId = 'fake-target-id';
     const map = new Map();
-    map.set(`target:${targetId}:schema`, JSON.stringify({ sdl: `type Query { dummy: String }` }));
+    map.set(`target:${targetId}:sdl`, JSON.stringify({ sdl: `type Query { dummy: String }` }));
 
     const handleRequest = createRequestHandler({
       isKeyValid: createIsKeyValid({
@@ -92,7 +104,19 @@ describe('CDN Worker', () => {
           },
         },
       }),
-      getRawStoreValue: async (key: string) => map.get(key),
+      async getArtifactAction(targetId, artifactType) {
+        return map.has(`target:${targetId}:${artifactType}`)
+          ? {
+              type: 'redirect',
+              location: `target:${targetId}:${artifactType}`,
+            }
+          : {
+              type: 'notFound',
+            };
+      },
+      async fetchText(url) {
+        return map.get(url);
+      },
     });
 
     const token = createToken(SECRET, targetId);
@@ -160,7 +184,19 @@ describe('CDN Worker', () => {
           },
         },
       }),
-      getRawStoreValue: async (key: string) => map.get(key),
+      async getArtifactAction(targetId, artifactType) {
+        return map.has(`target:${targetId}:${artifactType}`)
+          ? {
+              type: 'redirect',
+              location: `target:${targetId}:${artifactType}`,
+            }
+          : {
+              type: 'notFound',
+            };
+      },
+      async fetchText(url) {
+        return map.get(url);
+      },
     });
 
     const firstRequest = new Request(`https://fake-worker.com/${targetId}/supergraph`, {
@@ -221,7 +257,19 @@ describe('CDN Worker', () => {
           },
         },
       }),
-      getRawStoreValue: async (key: string) => map.get(key),
+      async getArtifactAction(targetId, artifactType) {
+        return map.has(`target:${targetId}:${artifactType}`)
+          ? {
+              type: 'redirect',
+              location: `target:${targetId}:${artifactType}`,
+            }
+          : {
+              type: 'notFound',
+            };
+      },
+      async fetchText(url) {
+        return map.get(url);
+      },
     });
 
     const token = createToken(SECRET, targetId);
@@ -266,7 +314,7 @@ describe('CDN Worker', () => {
     const SECRET = '123456';
     const targetId = 'fake-target-id';
     const map = new Map();
-    map.set(`target:${targetId}:schema`, JSON.stringify({ sdl: `type Query { dummy: String }` }));
+    map.set(`target:${targetId}:sdl`, JSON.stringify({ sdl: `type Query { dummy: String }` }));
 
     const handleRequest = createRequestHandler({
       isKeyValid: createIsKeyValid({
@@ -284,7 +332,19 @@ describe('CDN Worker', () => {
           },
         },
       }),
-      getRawStoreValue: async (key: string) => map.get(key),
+      async getArtifactAction(targetId, artifactType) {
+        return map.has(`target:${targetId}:${artifactType}`)
+          ? {
+              type: 'redirect',
+              location: `target:${targetId}:${artifactType}`,
+            }
+          : {
+              type: 'notFound',
+            };
+      },
+      async fetchText(url) {
+        return map.get(url);
+      },
     });
 
     const token = createToken(SECRET, targetId);
@@ -330,7 +390,7 @@ describe('CDN Worker', () => {
     const targetId = 'fake-target-id';
     const map = new Map();
     map.set(
-      `target:${targetId}:schema`,
+      `target:${targetId}:sdl`,
       JSON.stringify({
         sdl: `type Query { dummy: String }`,
       }),
@@ -352,7 +412,19 @@ describe('CDN Worker', () => {
           },
         },
       }),
-      getRawStoreValue: async (key: string) => map.get(key),
+      async getArtifactAction(targetId, artifactType) {
+        return map.has(`target:${targetId}:${artifactType}`)
+          ? {
+              type: 'redirect',
+              location: `target:${targetId}:${artifactType}`,
+            }
+          : {
+              type: 'notFound',
+            };
+      },
+      async fetchText(url) {
+        return map.get(url);
+      },
     });
 
     const token = createToken(SECRET, targetId);
@@ -397,7 +469,14 @@ describe('CDN Worker', () => {
     it('Should throw when target id is missing', async () => {
       const handleRequest = createRequestHandler({
         isKeyValid: KeyValidators.AlwaysTrue,
-        getRawStoreValue: async (_key: string) => Promise.resolve(null),
+        async getArtifactAction() {
+          return {
+            type: 'notFound',
+          };
+        },
+        async fetchText() {
+          throw new Error('Should not be called');
+        },
       });
 
       const request = new Request('https://fake-worker.com/', {});
@@ -410,7 +489,14 @@ describe('CDN Worker', () => {
     it('Should throw when requested resource is not valid', async () => {
       const handleRequest = createRequestHandler({
         isKeyValid: KeyValidators.AlwaysTrue,
-        getRawStoreValue: async (_key: string) => Promise.resolve(null),
+        async getArtifactAction() {
+          return {
+            type: 'notFound',
+          };
+        },
+        async fetchText() {
+          throw new Error('Should not be called');
+        },
       });
 
       const request = new Request('https://fake-worker.com/fake-target-id/error', {});
@@ -423,7 +509,14 @@ describe('CDN Worker', () => {
     it('Should throw when auth key is missing', async () => {
       const handleRequest = createRequestHandler({
         isKeyValid: KeyValidators.AlwaysTrue,
-        getRawStoreValue: async (_key: string) => Promise.resolve(null),
+        async getArtifactAction() {
+          return {
+            type: 'notFound',
+          };
+        },
+        async fetchText() {
+          throw new Error('Should not be called');
+        },
       });
 
       const request = new Request('https://fake-worker.com/fake-target-id/sdl', {});
@@ -436,7 +529,14 @@ describe('CDN Worker', () => {
     it('Should throw when key validation function fails', async () => {
       const handleRequest = createRequestHandler({
         isKeyValid: KeyValidators.AlwaysFalse,
-        getRawStoreValue: async (_key: string) => Promise.resolve(null),
+        async getArtifactAction() {
+          return {
+            type: 'notFound',
+          };
+        },
+        async fetchText() {
+          throw new Error('Should not be called');
+        },
       });
 
       const request = new Request('https://fake-worker.com/fake-target-id/sdl', {
@@ -456,7 +556,7 @@ describe('CDN Worker', () => {
       const SECRET = '123456';
       const targetId = 'fake-target-id';
       const map = new Map();
-      map.set(`target:${targetId}:schema`, JSON.stringify({ sdl: `type Query { dummy: String }` }));
+      map.set(`target:${targetId}:sdl`, JSON.stringify({ sdl: `type Query { dummy: String }` }));
 
       const handleRequest = createRequestHandler({
         isKeyValid: createIsKeyValid({
@@ -474,7 +574,19 @@ describe('CDN Worker', () => {
             },
           },
         }),
-        getRawStoreValue: async (key: string) => map.get(key),
+        async getArtifactAction(targetId, artifactType) {
+          return map.has(`target:${targetId}:${artifactType}`)
+            ? {
+                type: 'redirect',
+                location: `target:${targetId}:${artifactType}`,
+              }
+            : {
+                type: 'notFound',
+              };
+        },
+        async fetchText(url) {
+          return map.get(url);
+        },
       });
 
       const token = createToken(SECRET, targetId);
@@ -509,7 +621,19 @@ describe('CDN Worker', () => {
             },
           },
         }),
-        getRawStoreValue: async (key: string) => map.get(key),
+        async getArtifactAction(targetId, artifactType) {
+          return map.has(`target:${targetId}:${artifactType}`)
+            ? {
+                type: 'redirect',
+                location: `target:${targetId}:${artifactType}`,
+              }
+            : {
+                type: 'notFound',
+              };
+        },
+        async fetchText(url) {
+          return map.get(url);
+        },
       });
 
       const token = createToken(SECRET, 'fake-target-id');
@@ -542,7 +666,14 @@ describe('CDN Worker', () => {
             },
           },
         }),
-        getRawStoreValue: async (key: string) => new Map().get(key),
+        async getArtifactAction() {
+          return {
+            type: 'notFound',
+          };
+        },
+        async fetchText() {
+          throw new Error('Should not be called');
+        },
       });
 
       const request = new Request(`https://fake-worker.com/some-target/sdl`, {

--- a/packages/services/server/README.md
+++ b/packages/services/server/README.md
@@ -56,21 +56,17 @@ The GraphQL API for GraphQL Hive.
 If you are self-hosting GraphQL Hive, you can ignore this section. It is only required for the Cloud
 version.
 
-| Name                                 | Required                                   | Description                                  | Example Value                      |
-| ------------------------------------ | ------------------------------------------ | -------------------------------------------- | ---------------------------------- |
-| `BILLING_ENDPOINT`                   | **Yes**                                    | The endpoint of the Hive Billing service.    | `http://127.0.0.1:4013`            |
-| `USAGE_ESTIMATOR_ENDPOINT`           | No                                         | The endpoint of the usage estimator service. | `4011`                             |
-| `CDN_CF`                             | No                                         | Whether the CDN is enabled.                  | `1` (enabled) or `0` (disabled)    |
-| `CDN_CF_BASE_URL`                    | No (**Yes** if `CDN` is `1`)               | The base URL of the cdn.                     | `https://cdn.graphql-hive.com`     |
-| `CDN_CF_BASE_PATH`                   | No (**Yes** if `CDN` is `1`)               | The base path of the cdn.                    | `https://cdn.graphql-hive.com`     |
-| `CDN_CF_ACCOUNT_ID`                  | No (**Yes** if `CDN` is `1`)               | The cloudflare account ID.                   | `103df45224310d669213971ce28b5b70` |
-| `CDN_CF_AUTH_TOKEN`                  | No (**Yes** if `CDN` is `1`)               | The cloudflare authentication token.         | `85e20c26c03759603c0f45884824a1c3` |
-| `CDN_CF_NAMESPACE_ID`                | No (**Yes** if `CDN` is `1`)               | The cloudflare namespace name.               | `33b1e3bbb4a4707d05ea0307cbb55c79` |
-| `AUTH_LEGACY_AUTH0`                  | No                                         | Whether the legacy Auth0 import is enabled.  | `1` (enabled) or `0` (disabled)    |
-| `AUTH_LEGACY_AUTH0_INTERNAL_API_KEY` | No (**Yes** if `AUTH_LEGACY_AUTH0` is set) | The internal endpoint key.                   | `iliketurtles`                     |
-| `HIVE`                               | No                                         | The internal endpoint key.                   | `iliketurtles`                     |
-| `HIVE_API_TOKEN`                     | No (**Yes** if `HIVE` is set)              | The internal endpoint key.                   | `iliketurtles`                     |
-| `HIVE_USAGE`                         | No                                         | The internal endpoint key.                   | `1` (enabled) or `0` (disabled)    |
-| `HIVE_USAGE_ENDPOINT`                | No                                         | The endpoint used for usage reporting.       | `http://127.0.0.1:4001`            |
-| `HIVE_REPORTING`                     | No                                         | The internal endpoint key.                   | `iliketurtles`                     |
-| `HIVE_REPORTING_ENDPOINT`            | No                                         | The internal endpoint key.                   | `http://127.0.0.1:4000/graphql`    |
+| Name                                 | Required                                   | Description                                  | Example Value                   |
+| ------------------------------------ | ------------------------------------------ | -------------------------------------------- | ------------------------------- |
+| `BILLING_ENDPOINT`                   | **Yes**                                    | The endpoint of the Hive Billing service.    | `http://127.0.0.1:4013`         |
+| `USAGE_ESTIMATOR_ENDPOINT`           | No                                         | The endpoint of the usage estimator service. | `4011`                          |
+| `CDN_CF`                             | No                                         | Whether the CDN is enabled.                  | `1` (enabled) or `0` (disabled) |
+| `CDN_CF_BASE_URL`                    | No (**Yes** if `CDN` is `1`)               | The base URL of the cdn.                     | `https://cdn.graphql-hive.com`  |
+| `AUTH_LEGACY_AUTH0`                  | No                                         | Whether the legacy Auth0 import is enabled.  | `1` (enabled) or `0` (disabled) |
+| `AUTH_LEGACY_AUTH0_INTERNAL_API_KEY` | No (**Yes** if `AUTH_LEGACY_AUTH0` is set) | The internal endpoint key.                   | `iliketurtles`                  |
+| `HIVE`                               | No                                         | The internal endpoint key.                   | `iliketurtles`                  |
+| `HIVE_API_TOKEN`                     | No (**Yes** if `HIVE` is set)              | The internal endpoint key.                   | `iliketurtles`                  |
+| `HIVE_USAGE`                         | No                                         | The internal endpoint key.                   | `1` (enabled) or `0` (disabled) |
+| `HIVE_USAGE_ENDPOINT`                | No                                         | The endpoint used for usage reporting.       | `http://127.0.0.1:4001`         |
+| `HIVE_REPORTING`                     | No                                         | The internal endpoint key.                   | `iliketurtles`                  |
+| `HIVE_REPORTING_ENDPOINT`            | No                                         | The internal endpoint key.                   | `http://127.0.0.1:4000/graphql` |

--- a/packages/services/server/src/environment.ts
+++ b/packages/services/server/src/environment.ts
@@ -104,10 +104,6 @@ const CdnCFModel = zod.union([
   zod.object({
     CDN_CF: zod.literal('1'),
     CDN_CF_BASE_URL: zod.string(),
-    CDN_CF_BASE_PATH: zod.string(),
-    CDN_CF_ACCOUNT_ID: zod.string(),
-    CDN_CF_AUTH_TOKEN: zod.string(),
-    CDN_CF_NAMESPACE_ID: zod.string(),
   }),
 ]);
 
@@ -337,10 +333,6 @@ export const env = {
       cloudflare:
         cdnCf.CDN_CF === '1'
           ? {
-              basePath: cdnCf.CDN_CF_BASE_PATH,
-              accountId: cdnCf.CDN_CF_ACCOUNT_ID,
-              authToken: cdnCf.CDN_CF_AUTH_TOKEN,
-              namespaceId: cdnCf.CDN_CF_NAMESPACE_ID,
               baseUrl: cdnCf.CDN_CF_BASE_URL,
             }
           : null,


### PR DESCRIPTION
- [x] /schema should return [{sdl: string}]
- [x] /supergraph should return a string
- [x] /sdl should return a string
- [x] /metadata should return what's in the R2 but {object} instead of [{object}] when it's Mesh artifact
- [x] /introspection should return introspection result