### PR TITLE
Dynamic sampling in GraphQL Hive client

### DIFF
--- a/.changeset/old-pigs-dress.md
+++ b/.changeset/old-pigs-dress.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/client': minor
+---
+
+Add atLeastOnceSampler

--- a/.changeset/twenty-adults-cough.md
+++ b/.changeset/twenty-adults-cough.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/client': minor
+---
+
+Introduce sampler for dynamic sampling

--- a/packages/libraries/client/src/index.ts
+++ b/packages/libraries/client/src/index.ts
@@ -4,3 +4,4 @@ export { useHive as useYogaHive } from './yoga.js';
 export { hiveApollo, createSupergraphSDLFetcher, createSupergraphManager } from './apollo.js';
 export { createSchemaFetcher, createServicesFetcher } from './gateways.js';
 export { createHive } from './client.js';
+export { atLeastOnceSampler } from './samplers.js';

--- a/packages/libraries/client/src/internal/sampling.ts
+++ b/packages/libraries/client/src/internal/sampling.ts
@@ -1,9 +1,29 @@
+import type { SamplingContext } from './types.js';
+
 export function randomSampling(sampleRate: number) {
   if (sampleRate > 1 || sampleRate < 0) {
     throw new Error(`Expected usage.sampleRate to be 0 <= x <= 1, received ${sampleRate}`);
   }
 
   return function shouldInclude(): boolean {
+    return Math.random() <= sampleRate;
+  };
+}
+
+export function dynamicSampling(sampler: (context: SamplingContext) => number | boolean) {
+  return function shouldInclude(context: SamplingContext): boolean {
+    let sampleRate = sampler(context);
+
+    if (sampleRate === true) {
+      sampleRate = 1;
+    } else if (sampleRate === false) {
+      sampleRate = 0;
+    }
+
+    if (sampleRate > 1 || sampleRate < 0) {
+      throw new Error(`Expected usage.sampleRate to be 0 <= x <= 1, received ${sampleRate}`);
+    }
+
     return Math.random() <= sampleRate;
   };
 }

--- a/packages/libraries/client/src/internal/types.ts
+++ b/packages/libraries/client/src/internal/types.ts
@@ -79,11 +79,28 @@ export interface HiveUsagePluginOptions {
    */
   sampleRate?: number;
   /**
+   * Compute sample rate dynamically.
+   *
+   * If `sampler` is defined, `sampleRate` is ignored.
+   *
+   * @returns A sample rate between 0 and 1.
+   * 0.0 = 0% chance of being sent
+   * 1.0 = 100% chance of being sent.
+   * true = 100%
+   * false = 0%
+   */
+  sampler?: (context: SamplingContext) => number | boolean;
+  /**
    * (Experimental) Enables collecting Input fields usage based on the variables passed to the operation.
    *
    * Default: false
    */
   processVariables?: boolean;
+}
+
+export interface SamplingContext
+  extends Pick<ExecutionArgs, 'document' | 'contextValue' | 'variableValues'> {
+  operationName: string;
 }
 
 export interface HiveReportingPluginOptions {

--- a/packages/libraries/client/src/samplers.ts
+++ b/packages/libraries/client/src/samplers.ts
@@ -1,0 +1,28 @@
+import { dynamicSampling } from './internal/sampling.js';
+import type { SamplingContext } from './internal/types.js';
+
+/**
+ * Every operation is reported at least once, but every next occurrence is decided by the sampler.
+ */
+export function atLeastOnceSampler(config: {
+  /**
+   * Produces a unique key for a given GraphQL request.
+   * This key is used to determine the uniqueness of a GraphQL operation.
+   */
+  keyFn(context: SamplingContext): string;
+  sampler(context: SamplingContext): number | boolean;
+}) {
+  const sampler = dynamicSampling(config.sampler);
+  const reportedKeys = new Set<string>();
+
+  return function shouldInclude(context: SamplingContext): boolean {
+    const key = config.keyFn(context);
+
+    if (!reportedKeys.has(key)) {
+      reportedKeys.add(key);
+      return true;
+    }
+
+    return sampler(context);
+  };
+}

--- a/packages/web/docs/src/pages/docs/api-reference/client.mdx
+++ b/packages/web/docs/src/pages/docs/api-reference/client.mdx
@@ -67,15 +67,85 @@ const config: HivePluginOptions = {
 
 #### Sampling
 
-You can pass a custom `sampleRate` array to the `HivePluginOptions` to sample a percentage of the
-total operations reported. By default, Hive agent reports 100% of the operations (`1.0`).
+##### Basic sampling
 
-```ts
-const config: HivePluginOptions = {
+With `sampleRate` option, you're able to control the sampling rate of the usage reporting. Setting
+it to `0.5` will result in 50% of the operations being sent to Hive. There is no guarantee that
+every operation will be reported at least once (see `atLeastOnceSampler`).
+
+Default: `1` (100%)
+
+```typescript
+useHive({
+  /* ... other options ... */,
   usage: {
-    sampleRate: 0.1
+    sampleRate: 0.6 // 60% of the operations will be sent to Hive
   }
-}
+})
+```
+
+##### Dynamic sampling
+
+GraphQL Hive client accepts a function that returns a number between 0 and 1. This allows you to
+implement dynamic sampling based on the operation's context.
+
+If `sampler` is defined, `sampleRate` is ignored.
+
+A sample rate between 0 and 1.
+
+- `0.0` = 0% chance of being sent
+- `1.0` = 100% chance of being sent.
+- `true` = 100%
+- `false` = 0%
+
+```typescript
+useHive({
+  /* ... other options ... */,
+  usage: {
+  sampler(samplingContext) {
+      if (samplingContext.operationName === 'GetUser') {
+        return 0.5 // 50% of GetUser operations will be sent to Hive
+      }
+
+      return 0.7; // 70% of the other operations will be sent to Hive
+    }
+  }
+})
+```
+
+##### At-least-once sampling
+
+If you want to make sure that every operation is reported at least once, you can use the
+`atLeastOnceSampler`. Every operation is reported at least once, but every next occurrence is
+decided by the sampler.
+
+```typescript
+import { useHive, atLeastOnceSampler} from '@graphql-hive/client';
+
+useHive({
+  /* ... other options ... */,
+  usage: {
+    sampler: atLeastOnceSampler({
+      // Produces a unique key for a given GraphQL request.
+      // This key is used to determine the uniqueness of a GraphQL operation.
+      keyFn(samplingContext) {
+        // Operation name is a good candidate for a key, but not perfect,
+        // as not all operations have names
+        // and some operations may have the same name but different body.
+        return samplingContext.operationName;
+      },
+      sampler(_samplingContext) {
+        const hour = new Date().getHours();
+
+        if (hour >= 9 && hour <= 17) {
+          return 0.3;
+        }
+
+        return 0.8;
+      }
+    })
+  }
+})
 ```
 
 #### Custom Integration


### PR DESCRIPTION
Compute sample rate dynamically.

If `sampler` is defined, `sampleRate` is ignored.

The `sampler` function returns a sample rate between 0 and 1.
- 0 = 0% chance of being sent
- 1 = 100% chance of being sent.
- 0.5 = 50%
- true = 100%
- false = 0%


This allows to provide a set of samplers (like "report at least once, then use sampleRate") that we can expose in graphql-hive/client

---

Adds `atLeastOnceSampler` where every operation is reported at least once, but every next occurrence is decided by the sampler.

```typescript
import { atLeastOnceSampler } from '@graphql-hive/client';

useHive({
  usage: {
    sampler: atLeastOnceSampler({
      keyFn(ctx) {
        return ctx.operationName;
      },
      sampler(ctx) {
        return shouldOperationBeReported(ctx);
      },
    }),
  },
});
```

---

Closes #3330