### PR TITLE
Fix "requested date range is too old for the selected query type" error

### DIFF
--- a/packages/web/app/pages/[organizationId]/[projectId]/[targetId]/settings.tsx
+++ b/packages/web/app/pages/[organizationId]/[projectId]/[targetId]/settings.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, useCallback, useState } from 'react';
 import NextLink from 'next/link';
 import clsx from 'clsx';
-import { formatISO, subDays } from 'date-fns';
+import { formatISO } from 'date-fns';
 import { useFormik } from 'formik';
 import { useMutation, useQuery } from 'urql';
 import * as Yup from 'yup';
@@ -38,6 +38,7 @@ import { Combobox } from '@/components/v2/combobox';
 import { CreateAccessTokenModal, DeleteTargetModal } from '@/components/v2/modals';
 import { FragmentType, graphql, useFragment } from '@/gql';
 import { canAccessTarget, TargetAccessScope } from '@/lib/access/target';
+import { subDays } from '@/lib/date-time';
 import { useRouteSelector, useToggle } from '@/lib/hooks';
 import { withSessionProtection } from '@/lib/supertokens/guard';
 

--- a/packages/web/app/pages/[organizationId]/[projectId]/index.tsx
+++ b/packages/web/app/pages/[organizationId]/[projectId]/index.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, useMemo, useRef } from 'react';
 import NextLink from 'next/link';
-import { formatISO, subDays } from 'date-fns';
+import { formatISO } from 'date-fns';
 import * as echarts from 'echarts';
 import ReactECharts from 'echarts-for-react';
 import { Globe, History } from 'lucide-react';
@@ -18,6 +18,7 @@ import { QueryError } from '@/components/ui/query-error';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 import { Activities, Card, EmptyList, MetaTitle } from '@/components/v2';
 import { FragmentType, graphql, useFragment } from '@/gql';
+import { subDays } from '@/lib/date-time';
 import { useFormattedNumber } from '@/lib/hooks';
 import { useRouteSelector } from '@/lib/hooks/use-route-selector';
 import { withSessionProtection } from '@/lib/supertokens/guard';

--- a/packages/web/app/pages/[organizationId]/index.tsx
+++ b/packages/web/app/pages/[organizationId]/index.tsx
@@ -1,6 +1,6 @@
 import { ReactElement, useMemo, useRef } from 'react';
 import NextLink from 'next/link';
-import { formatISO, subDays } from 'date-fns';
+import { formatISO } from 'date-fns';
 import * as echarts from 'echarts';
 import ReactECharts from 'echarts-for-react';
 import { Globe, History } from 'lucide-react';
@@ -20,6 +20,7 @@ import { Activities, Card, EmptyList, MetaTitle } from '@/components/v2';
 import { FragmentType, graphql, useFragment } from '@/gql';
 import { ProjectType } from '@/gql/graphql';
 import { writeLastVisitedOrganization } from '@/lib/cookies';
+import { subDays } from '@/lib/date-time';
 import { useFormattedNumber } from '@/lib/hooks';
 import { useRouteSelector } from '@/lib/hooks/use-route-selector';
 import { withSessionProtection } from '@/lib/supertokens/guard';

--- a/packages/web/app/pages/manage/index.tsx
+++ b/packages/web/app/pages/manage/index.tsx
@@ -1,10 +1,11 @@
 import { useCallback, useMemo, useState } from 'react';
-import { startOfMonth, subDays, subHours } from 'date-fns';
+import { startOfMonth, subHours } from 'date-fns';
 import { AdminStats, Filters } from '@/components/admin/AdminStats';
 import { authenticated } from '@/components/authenticated-container';
 import { Page } from '@/components/common';
 import { DATE_RANGE_OPTIONS, floorToMinute } from '@/components/common/TimeFilter';
 import { Checkbox as RadixCheckbox, RadixSelect, Tooltip } from '@/components/v2';
+import { subDays } from '@/lib/date-time';
 import { withSessionProtection } from '@/lib/supertokens/guard';
 
 type DateRangeOptions = Exclude<(typeof DATE_RANGE_OPTIONS)[number], { key: 'all' }>;

--- a/packages/web/app/src/components/common/TimeFilter.ts
+++ b/packages/web/app/src/components/common/TimeFilter.ts
@@ -1,4 +1,5 @@
-import { formatISO, startOfMonth, subDays, subHours, subMinutes } from 'date-fns';
+import { formatISO, startOfMonth, subHours, subMinutes } from 'date-fns';
+import { subDays } from '@/lib/date-time';
 
 export function floorToMinute(date: Date) {
   const time = 1000 * 60 * 1;

--- a/packages/web/app/src/components/target/explorer/provider.tsx
+++ b/packages/web/app/src/components/target/explorer/provider.tsx
@@ -8,7 +8,8 @@ import {
   useMemo,
   useState,
 } from 'react';
-import { formatISO, subDays } from 'date-fns';
+import { formatISO } from 'date-fns';
+import { subDays } from '@/lib/date-time';
 import { useLocalStorage } from '@/lib/hooks';
 
 type PeriodOption = '365d' | '180d' | '90d' | '30d' | '14d' | '7d';

--- a/packages/web/app/src/lib/date-time.ts
+++ b/packages/web/app/src/lib/date-time.ts
@@ -1,5 +1,7 @@
 import { subHours } from 'date-fns';
 
+// subDays from date-fns adjusts the hour based on daylight savings time.
+// We want to keep the hour the same, so we use subHours instead.
 export function subDays(date: Date | number, days: number) {
   return subHours(date, days * 24);
 }

--- a/packages/web/app/src/lib/date-time.ts
+++ b/packages/web/app/src/lib/date-time.ts
@@ -1,0 +1,5 @@
+import { subHours } from 'date-fns';
+
+export function subDays(date: Date | number, days: number) {
+  return subHours(date, days * 24);
+}

--- a/packages/web/app/src/lib/hooks/use-date-range-controller.ts
+++ b/packages/web/app/src/lib/hooks/use-date-range-controller.ts
@@ -1,6 +1,7 @@
 import { useCallback, useMemo } from 'react';
 import { useRouter } from 'next/router';
-import { formatISO, subDays, subHours, subMinutes } from 'date-fns';
+import { formatISO, subHours, subMinutes } from 'date-fns';
+import { subDays } from '@/lib/date-time';
 
 function floorDate(date: Date): Date {
   const time = 1000 * 60;


### PR DESCRIPTION
The `subDays` function from `date-fns` adjusts the hour based on daylight savings.
We want to keep the hour the same as TTL in ClickHouse is set to 30 * 24 hours and it conflicts with date-fns logic.