### PR TITLE
add option to pass validateOptions

### DIFF
--- a/packages/libraries/cli/README.md
+++ b/packages/libraries/cli/README.md
@@ -222,6 +222,9 @@ FLAGS
   --require=<value>...
       [default: ] Loads specific require.extensions before running the command
 
+  --validateOptions=<value>...
+      [default: '{}'] validations options to be passed to graphql inspector validate library, as JSON
+
   --token=<value>
       api token
 

--- a/packages/libraries/cli/src/commands/operations/check.ts
+++ b/packages/libraries/cli/src/commands/operations/check.ts
@@ -44,9 +44,9 @@ export default class OperationsCheck extends Command {
       default: [],
       multiple: true,
     }),
-    'validateOptions': Flags.string({
-      description: 'options for validations from graphql inspector core validate library',
-      default: {}
+    validateOptions: Flags.string({
+      description: 'validations options to be passed to graphql inspector validate library, as JSON',
+      default: '{}'
     }),
     graphqlTag: Flags.string({
       description: [
@@ -132,7 +132,7 @@ export default class OperationsCheck extends Command {
         assumeValid: true,
       });
 
-      const validateOptions = flags.validateOptions;
+      const validateOptions = JSON.parse(flags.validateOptions);
       const invalidOperations = validate(
         schema,
         operations.map(s => new Source(s.content, s.location)),

--- a/packages/libraries/cli/src/commands/operations/check.ts
+++ b/packages/libraries/cli/src/commands/operations/check.ts
@@ -44,6 +44,10 @@ export default class OperationsCheck extends Command {
       default: [],
       multiple: true,
     }),
+    'validateOptions': Flags.string({
+      description: 'options for validations from graphql inspector core validate library',
+      default: {}
+    }),
     graphqlTag: Flags.string({
       description: [
         'Identify template literals containing GraphQL queries in JavaScript/TypeScript code. Supports multiple values.',
@@ -128,9 +132,11 @@ export default class OperationsCheck extends Command {
         assumeValid: true,
       });
 
+      const validateOptions = flags.validateOptions;
       const invalidOperations = validate(
         schema,
         operations.map(s => new Source(s.content, s.location)),
+        validateOptions
       );
 
       const operationsWithErrors = invalidOperations.filter(o => o.errors.length > 0);

--- a/packages/libraries/client/src/version.ts
+++ b/packages/libraries/client/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.25.0';
+export const version = '0.26.0';


### PR DESCRIPTION
Closes https://github.com/kamilkisiela/graphql-hive/issues/3379 

### Background

By default apollo is false, so we are proposing to enable to pass some options for graphql inspector validate.
This will be used if the operation that is being check has `@client` directive
https://github.com/kamilkisiela/graphql-inspector/blob/master/packages/core/src/validate/index.ts#L47
