### PR TITLE
Fix GraphiQL's hints transparent background

### DIFF
--- a/packages/web/app/pages/[organizationId]/[projectId]/[targetId]/laboratory.tsx
+++ b/packages/web/app/pages/[organizationId]/[projectId]/[targetId]/laboratory.tsx
@@ -857,6 +857,10 @@ function LaboratoryPageContent() {
         .graphiql-container .cm-punctuation:hover {
           color: #ffffff;
         }
+
+        .graphiql-container .CodeMirror-hints {
+          background-color: #070d17;
+        }
       `}</style>
       {query.fetching ? null : (
         <GraphiQL


### PR DESCRIPTION
### Background

As we reset the colours, the background became transparent. There are possibly other ways to fix it by rethinking the CSS we apply, but this works, and the bg colour I applied aligns with the other colours. 

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
