### PR TITLE
refactor: inflate schema changes as early as reading from the database

### DIFF
--- a/integration-tests/tests/api/schema/delete.spec.ts
+++ b/integration-tests/tests/api/schema/delete.spec.ts
@@ -221,12 +221,18 @@ test.concurrent(
 
       expect(changes[0]).toMatchInlineSnapshot(`
         {
+          criticality: {
+            level: BREAKING,
+            reason: Removing a field is a breaking change. It is preferable to deprecate the field before removing it.,
+          },
+          message: Field 'bruv' was removed from object type 'Query',
           meta: {
             isRemovedFieldDeprecated: false,
             removedFieldName: bruv,
             typeName: Query,
             typeType: object type,
           },
+          path: Query.bruv,
           type: FIELD_REMOVED,
         }
       `);

--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -628,7 +628,10 @@ describe('schema publishing changes are persisted', () => {
     name: string;
     schemaBefore: string;
     schemaAfter: string;
-    equalsObject: object;
+    equalsObject: {
+      meta: unknown;
+      type: unknown;
+    };
     /** Only provide if you want to test a service url change */
     serviceUrlAfter?: string;
   }) {
@@ -685,7 +688,8 @@ describe('schema publishing changes are persisted', () => {
         versionId: latestVersion.id,
       });
 
-      expect(changes[0]).toEqual(args.equalsObject);
+      expect(changes[0]['meta']).toEqual(args.equalsObject['meta']);
+      expect(changes[0]['type']).toEqual(args.equalsObject['type']);
     });
   }
 

--- a/packages/libraries/cli/tsconfig.json
+++ b/packages/libraries/cli/tsconfig.json
@@ -10,7 +10,9 @@
     "rootDir": "src",
 
     "esModuleInterop": true,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "declarationMap": true
   },
   "include": ["src"]
 }

--- a/packages/libraries/client/tsconfig.json
+++ b/packages/libraries/client/tsconfig.json
@@ -7,6 +7,8 @@
     "rootDir": "src",
     "target": "es2017",
     "module": "esnext",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true
   }
 }

--- a/packages/libraries/core/tsconfig.json
+++ b/packages/libraries/core/tsconfig.json
@@ -7,6 +7,8 @@
     "rootDir": "src",
     "target": "es2017",
     "module": "esnext",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true
   }
 }

--- a/packages/libraries/external-composition/tsconfig.json
+++ b/packages/libraries/external-composition/tsconfig.json
@@ -7,6 +7,8 @@
     "rootDir": "src",
     "target": "es2017",
     "module": "esnext",
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true
   }
 }

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -55,7 +55,7 @@ import {
 import { SingleModel } from './models/single';
 import { SingleLegacyModel } from './models/single-legacy';
 import { ensureCompositeSchemas, ensureSingleSchema, SchemaHelper } from './schema-helper';
-import { inflateSchemaCheck, SchemaManager } from './schema-manager';
+import { SchemaManager } from './schema-manager';
 
 const schemaCheckCount = new promClient.Counter({
   name: 'registry_check_count',
@@ -591,7 +591,7 @@ export class SchemaPublisher {
         changes: checkResult.state?.schemaChanges ?? [],
         warnings: checkResult.state?.schemaPolicyWarnings ?? [],
         initial: latestVersion == null,
-        schemaCheck: toGraphQLSchemaCheck(schemaCheckSelector, inflateSchemaCheck(schemaCheck)),
+        schemaCheck: toGraphQLSchemaCheck(schemaCheckSelector, schemaCheck),
       } as const;
     }
 
@@ -610,7 +610,7 @@ export class SchemaPublisher {
         ...(checkResult.state.schemaPolicy?.errors?.map(formatPolicyError) ?? []),
         ...(checkResult.state.composition.errors ?? []),
       ],
-      schemaCheck: toGraphQLSchemaCheck(schemaCheckSelector, inflateSchemaCheck(schemaCheck)),
+      schemaCheck: toGraphQLSchemaCheck(schemaCheckSelector, schemaCheck),
     } as const;
   }
 

--- a/packages/services/api/src/modules/schema/to-graphql-schema-check.ts
+++ b/packages/services/api/src/modules/schema/to-graphql-schema-check.ts
@@ -1,6 +1,6 @@
 import lodash from 'lodash';
+import { SchemaCheck } from '@hive/storage';
 import type { FailedSchemaCheckMapper, SuccessfulSchemaCheckMapper } from '../../shared/mappers';
-import type { InflatedSchemaCheck } from './providers/schema-manager';
 
 const { curry } = lodash;
 /**
@@ -8,7 +8,7 @@ const { curry } = lodash;
  */
 export function toGraphQLSchemaCheck(
   selector: { organizationId: string; projectId: string },
-  schemaCheck: InflatedSchemaCheck,
+  schemaCheck: SchemaCheck,
 ): SuccessfulSchemaCheckMapper | FailedSchemaCheckMapper {
   if (schemaCheck.isSuccess) {
     return {

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -2,6 +2,7 @@ import { Injectable } from 'graphql-modules';
 import { Change } from '@graphql-inspector/core';
 import type { PolicyConfigurationObject } from '@hive/policy';
 import type {
+  SchemaChangeType,
   SchemaCheck,
   SchemaCheckInput,
   SchemaCompositionError,
@@ -40,7 +41,6 @@ import type {
 import type { OrganizationAccessScope } from '../../auth/providers/organization-access';
 import type { ProjectAccessScope } from '../../auth/providers/project-access';
 import type { TargetAccessScope } from '../../auth/providers/target-access';
-import { SerializableChange } from '../../schema/schema-change-from-meta';
 
 type Paginated<T> = T & {
   after?: string | null;
@@ -422,7 +422,7 @@ export interface Storage {
    * If it return `null` the schema version does not have any changes persisted.
    * This can happen if the schema version was created before we introduced persisting changes.
    */
-  getSchemaChangesForVersion(_: { versionId: string }): Promise<null | Array<SerializableChange>>;
+  getSchemaChangesForVersion(_: { versionId: string }): Promise<null | Array<SchemaChangeType>>;
 
   updateVersionStatus(
     _: {

--- a/packages/services/api/src/shared/mappers.ts
+++ b/packages/services/api/src/shared/mappers.ts
@@ -1,4 +1,5 @@
 import type { DocumentNode, GraphQLSchema } from 'graphql';
+import { SchemaChangeType, SchemaCheck } from '@hive/storage';
 import type {
   ClientStatsValues,
   OperationStatsValues,
@@ -8,8 +9,6 @@ import type {
 import { type SuperGraphInformation } from '../modules/schema/lib/federation-super-graph';
 import { SchemaCheckWarning } from '../modules/schema/providers/models/shared';
 import { SchemaBuildError } from '../modules/schema/providers/orchestrators/errors';
-import { InflatedSchemaCheck } from '../modules/schema/providers/schema-manager';
-import { SerializableChange } from '../modules/schema/schema-change-from-meta';
 import type {
   ActivityObject,
   DateRange,
@@ -268,7 +267,7 @@ export type SchemaCompareResult = {
       before: string | null;
       current: string;
     };
-    changes: Array<SerializableChange>;
+    changes: Array<SchemaChangeType>;
     versionIds: {
       before: string | null;
       current: string;
@@ -355,13 +354,14 @@ export type FailedSchemaCheckMapper = {
     organizationId: string;
     projectId: string;
   };
-} & Extract<InflatedSchemaCheck, { isSuccess: false }>;
+} & Extract<SchemaCheck, { isSuccess: false }>;
+
 export type SuccessfulSchemaCheckMapper = {
   __typename: 'SuccessfulSchemaCheck';
   selector: {
     organizationId: string;
     projectId: string;
   };
-} & Extract<InflatedSchemaCheck, { isSuccess: true }>;
+} & Extract<SchemaCheck, { isSuccess: true }>;
 
 export type SchemaPolicyWarningConnectionMapper = ReadonlyArray<SchemaCheckWarning>;

--- a/packages/services/storage/package.json
+++ b/packages/services/storage/package.json
@@ -16,6 +16,7 @@
     "db:generate": "schemats generate --config schemats.cjs -o src/db/types.ts && prettier --write src/db/types.ts"
   },
   "devDependencies": {
+    "@graphql-inspector/core": "5.0.1",
     "@sentry/node": "7.79.0",
     "@sentry/types": "7.79.0",
     "@tgriesser/schemats": "9.0.1",

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -1,4 +1,3 @@
-import type { SerializableChange } from 'packages/services/api/src/modules/schema/schema-change-from-meta';
 import {
   DatabasePool,
   DatabaseTransactionConnection,
@@ -57,7 +56,7 @@ import {
 } from './db';
 import {
   createSchemaChangeId,
-  SchemaChangeModel,
+  SchemaChangeModelWithIsSafeBreakingChange,
   SchemaCheckModel,
   SchemaCompositionError,
   SchemaCompositionErrorModel,
@@ -2103,8 +2102,7 @@ export async function createStorage(connection: string, maximumPoolSize: number)
         return null;
       }
 
-      // TODO: I don't like the cast...
-      return changes.rows.map(row => SchemaChangeModel.parse(row) as SerializableChange);
+      return changes.rows.map(row => SchemaChangeModelWithIsSafeBreakingChange.parse(row));
     },
 
     async updateVersionStatus({ version, valid }) {
@@ -4166,3 +4164,7 @@ const PurgeExpiredSchemaChecksIDModel = zod
   });
 
 export * from './schema-change-model';
+export {
+  buildRegistryServiceURLFromMeta,
+  type RegistryServiceUrlChangeSerializableChange,
+} from './schema-change-meta';

--- a/packages/services/storage/src/schema-change-meta.ts
+++ b/packages/services/storage/src/schema-change-meta.ts
@@ -93,7 +93,9 @@ export type RegistryServiceUrlChangeChange = RegistryServiceUrlChangeSerializabl
 /**
  * Create the schema change from the persisted meta data.
  */
-function schemaChangeFromSerializableChange(change: SerializableChange): Change {
+export function schemaChangeFromSerializableChange(
+  change: SerializableChange,
+): Change | RegistryServiceUrlChangeChange {
   switch (change.type) {
     case ChangeType.FieldArgumentDescriptionChanged:
       return fieldArgumentDescriptionChangedFromMeta(change);
@@ -204,7 +206,7 @@ function schemaChangeFromSerializableChange(change: SerializableChange): Change 
   }
 }
 
-function buildRegistryServiceURLFromMeta(
+export function buildRegistryServiceURLFromMeta(
   change: RegistryServiceUrlChangeSerializableChange,
 ): RegistryServiceUrlChangeChange {
   return {
@@ -224,21 +226,4 @@ function buildRegistryServiceURLFromMeta(
   } as const;
 }
 
-export function schemaChangeFromMeta(serializableChange: SerializableChange): Change {
-  const change = schemaChangeFromSerializableChange(serializableChange);
-
-  // see https://github.com/kamilkisiela/graphql-inspector/blob/3f5d7291d730119c926a05d165aa2f4a309e4fbd/packages/core/src/diff/rules/consider-usage.ts#L71-L78
-  if (serializableChange.isSafeBasedOnUsage) {
-    return {
-      ...change,
-      criticality: {
-        ...change.criticality,
-        level: CriticalityLevel.Dangerous,
-        isSafeBasedOnUsage: true,
-      },
-      message: `${change.message} (non-breaking based on usage)`,
-    };
-  }
-
-  return change;
-}
+export type InternalSchemaChange = Change | RegistryServiceUrlChangeChange;

--- a/packages/services/storage/src/schema-change-model.ts
+++ b/packages/services/storage/src/schema-change-model.ts
@@ -1,7 +1,6 @@
 /** These mirror DB models from  */
 import crypto from 'node:crypto';
 import stableJSONStringify from 'fast-json-stable-stringify';
-import type { RegistryServiceUrlChangeSerializableChange } from 'packages/services/api/src/modules/schema/schema-change-from-meta';
 import { z } from 'zod';
 import { CriticalityLevel } from '@graphql-inspector/core';
 import type {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1139,6 +1139,9 @@ importers:
 
   packages/services/storage:
     devDependencies:
+      '@graphql-inspector/core':
+        specifier: 5.0.1
+        version: 5.0.1(graphql@16.8.1)
       '@sentry/node':
         specifier: 7.79.0
         version: 7.79.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,8 +18,9 @@
     "emitDecoratorMetadata": true,
 
     "sourceMap": true,
-    "declaration": true,
-    "resolveJsonModule": true,
+    "declaration": false,
+    "declarationMap": false,
+    "resolveJsonModule": false,
 
     "moduleResolution": "node",
     "strict": true,


### PR DESCRIPTION
### Background

There is not really a reason to do that later on aside from unnecessarily increasing complexity and small performance wins when not using the schema changes...

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
