### PR TITLE
chore: upgrade supertokens core to 7

### DIFF
--- a/deployment/services/supertokens.ts
+++ b/deployment/services/supertokens.ts
@@ -19,7 +19,7 @@ export function deploySuperTokens(
     restartPolicy: 'Always',
     containers: [
       {
-        image: 'registry.supertokens.io/supertokens/supertokens-postgresql:6.0',
+        image: 'registry.supertokens.io/supertokens/supertokens-postgresql:7.0',
         name: 'supertokens',
         ports: {
           http: port,

--- a/docker/docker-compose.community.yml
+++ b/docker/docker-compose.community.yml
@@ -113,7 +113,7 @@ services:
       - './.hive/redis/db:/bitnami/redis/data'
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql:6.0
+    image: registry.supertokens.io/supertokens/supertokens-postgresql:7.0
     depends_on:
       db:
         condition: service_healthy

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -121,7 +121,7 @@ services:
       - ./.hive-dev/broker/db:/var/lib/kafka/data
 
   supertokens:
-    image: registry.supertokens.io/supertokens/supertokens-postgresql:6.0
+    image: registry.supertokens.io/supertokens/supertokens-postgresql:7.0
     depends_on:
       db:
         condition: service_healthy

--- a/integration-tests/testkit/auth.ts
+++ b/integration-tests/testkit/auth.ts
@@ -9,10 +9,24 @@ const { fetch } = createFetch({
   useNodeFetch: true,
 });
 
-const SignUpSignInUserResponseModel = z.object({
-  status: z.literal('OK'),
-  user: z.object({ email: z.string(), id: z.string(), timeJoined: z.number() }),
-});
+const SignUpSignInUserResponseModel = z
+  .object({
+    status: z.literal('OK'),
+    user: z.object({
+      emails: z.array(z.string()),
+      id: z.string(),
+      timeJoined: z.number(),
+    }),
+  })
+  .refine(response => response.user.emails.length === 1)
+  .transform(response => ({
+    ...response,
+    user: {
+      id: response.user.id,
+      email: response.user.emails[0],
+      timeJoined: response.user.timeJoined,
+    },
+  }));
 
 const signUpUserViaEmail = async (
   email: string,
@@ -26,7 +40,7 @@ const signUpUserViaEmail = async (
         headers: {
           'content-type': 'application/json; charset=UTF-8',
           'api-key': ensureEnv('SUPERTOKENS_API_KEY'),
-          'cdi-version': '3.0',
+          'cdi-version': '4.0',
         },
         body: JSON.stringify({
           email,
@@ -103,7 +117,7 @@ const createSession = async (
           'content-type': 'application/json; charset=UTF-8',
           'api-key': ensureEnv('SUPERTOKENS_API_KEY'),
           rid: 'session',
-          'cdi-version': '3.0',
+          'cdi-version': '4.0',
         },
         body: JSON.stringify(payload),
       },

--- a/packages/services/server/src/graphql-handler.ts
+++ b/packages/services/server/src/graphql-handler.ts
@@ -379,7 +379,7 @@ async function verifySuperTokensSession(
       'content-type': 'application/json',
       'api-key': apiKey,
       rid: 'session',
-      'cdi-version': '3.0',
+      'cdi-version': '4.0',
     },
     body: JSON.stringify({
       accessToken,


### PR DESCRIPTION
### Background

See https://github.com/kamilkisiela/graphql-hive/issues/3332

### Description

Bumps supertoken core to v7 and cdi API usages to 4.0 (see https://app.swaggerhub.com/apis/supertokens/CDI).

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
