### PR TITLE
feat: revise breaking change presentation in web app

### DIFF
--- a/integration-tests/tests/api/schema/delete.spec.ts
+++ b/integration-tests/tests/api/schema/delete.spec.ts
@@ -222,11 +222,9 @@ test.concurrent(
       expect(changes[0]).toMatchInlineSnapshot(`
         {
           approvalMetadata: null,
-          criticality: {
-            level: BREAKING,
-            reason: Removing a field is a breaking change. It is preferable to deprecate the field before removing it.,
-          },
+          criticality: BREAKING,
           id: b3cb5845edf64492571c7b5c5857b7f9,
+          isSafeBasedOnUsage: false,
           message: Field 'bruv' was removed from object type 'Query',
           meta: {
             isRemovedFieldDeprecated: false,
@@ -235,6 +233,7 @@ test.concurrent(
             typeType: object type,
           },
           path: Query.bruv,
+          reason: Removing a field is a breaking change. It is preferable to deprecate the field before removing it.,
           type: FIELD_REMOVED,
         }
       `);

--- a/packages/libraries/cli/src/commands/schema/check.ts
+++ b/packages/libraries/cli/src/commands/schema/check.ts
@@ -29,8 +29,9 @@ const schemaCheckMutation = graphql(/* GraphQL */ `
         }
         changes {
           nodes {
-            message
+            message(withSafeBasedOnUsageNote: false)
             criticality
+            isSafeBasedOnUsage
           }
           total
         }
@@ -42,8 +43,9 @@ const schemaCheckMutation = graphql(/* GraphQL */ `
         valid
         changes {
           nodes {
-            message
+            message(withSafeBasedOnUsageNote: false)
             criticality
+            isSafeBasedOnUsage
           }
           total
         }

--- a/packages/libraries/cli/src/commands/schema/publish.ts
+++ b/packages/libraries/cli/src/commands/schema/publish.ts
@@ -20,8 +20,9 @@ const schemaPublishMutation = graphql(/* GraphQL */ `
         linkToWebsite
         changes {
           nodes {
-            message
+            message(withSafeBasedOnUsageNote: false)
             criticality
+            isSafeBasedOnUsage
           }
           total
         }
@@ -31,8 +32,9 @@ const schemaPublishMutation = graphql(/* GraphQL */ `
         linkToWebsite
         changes {
           nodes {
-            message
+            message(withSafeBasedOnUsageNote: false)
             criticality
+            isSafeBasedOnUsage
           }
           total
         }

--- a/packages/services/api/src/modules/alerts/providers/adapters/common.ts
+++ b/packages/services/api/src/modules/alerts/providers/adapters/common.ts
@@ -1,6 +1,13 @@
-import { Change, CriticalityLevel } from '@graphql-inspector/core';
+import { CriticalityLevel } from '@graphql-inspector/core';
+import type { SchemaChangeType } from '@hive/storage';
 import type * as Types from '../../../../__generated__/types';
-import { Alert, AlertChannel, Organization, Project, Target } from '../../../../shared/entities';
+import type {
+  Alert,
+  AlertChannel,
+  Organization,
+  Project,
+  Target,
+} from '../../../../shared/entities';
 
 export interface SchemaChangeNotificationInput {
   event: {
@@ -12,7 +19,7 @@ export interface SchemaChangeNotificationInput {
       commit: string;
       valid: boolean;
     };
-    changes: Array<Change>;
+    changes: Array<SchemaChangeType>;
     messages: string[];
     errors: Types.SchemaError[];
     initial: boolean;
@@ -61,5 +68,5 @@ export function quotesTransformer(msg: string, symbols = '**') {
 }
 
 export function filterChangesByLevel(level: CriticalityLevel) {
-  return (change: Change) => change.criticality.level === level;
+  return (change: SchemaChangeType) => change.criticality === level;
 }

--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -296,13 +296,22 @@ export default gql`
   type SchemaChange {
     criticality: CriticalityLevel!
     criticalityReason: String
-    message: String!
+    message(
+      """
+      Whether to include a note about the safety of the change based on usage data within the message.
+      """
+      withSafeBasedOnUsageNote: Boolean = true
+    ): String!
     path: [String!]
     """
     Approval metadata for this schema change.
     This field is populated in case the breaking change was manually approved.
     """
     approval: SchemaChangeApproval
+    """
+    Whether the breaking change is safe based on usage data.
+    """
+    isSafeBasedOnUsage: Boolean!
   }
 
   type SchemaChangeApproval {

--- a/packages/services/api/src/modules/schema/providers/inspector.ts
+++ b/packages/services/api/src/modules/schema/providers/inspector.ts
@@ -97,7 +97,7 @@ export class Inspector {
           isSafeBasedOnUsage: change.criticality.isSafeBasedOnUsage,
         }),
       )
-      .sort((a, b) => a.criticality.level.localeCompare(b.criticality.level));
+      .sort((a, b) => a.criticality.localeCompare(b.criticality));
   }
 
   private async getSettings({ selector }: { selector: Types.TargetSelector }) {

--- a/packages/services/api/src/modules/schema/providers/models/composite-legacy.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite-legacy.ts
@@ -127,7 +127,7 @@ export class CompositeLegacyModel {
     return {
       conclusion: SchemaCheckConclusion.Success,
       state: {
-        schemaChanges: diffCheck.result?.changes ?? null,
+        schemaChanges: diffCheck.result ?? null,
         schemaPolicyWarnings: null,
         composition: {
           compositeSchemaSDL: compositionCheck.result.fullSchemaSdl,
@@ -266,10 +266,8 @@ export class CompositeLegacyModel {
     const compositionErrors =
       compositionCheck.status === 'failed' ? compositionCheck.reason.errors : null;
     const breakingChanges =
-      diffCheck.status === 'failed' && !acceptBreakingChanges
-        ? diffCheck.reason.breakingChanges
-        : null;
-    const changes = diffCheck.result?.changes || diffCheck.reason?.changes || null;
+      diffCheck.status === 'failed' && !acceptBreakingChanges ? diffCheck.reason.breaking : null;
+    const changes = diffCheck.result?.all || diffCheck.reason?.all || null;
 
     const hasNewUrl =
       serviceUrlCheck.status === 'completed' && serviceUrlCheck.result.status === 'modified';
@@ -331,8 +329,8 @@ export class CompositeLegacyModel {
     if (diffCheck.status === 'failed' && !acceptBreakingChanges) {
       reasons.push({
         code: PublishFailureReasonCode.BreakingChanges,
-        changes: diffCheck.reason.changes ?? [],
-        breakingChanges: diffCheck.reason.breakingChanges ?? [],
+        changes: diffCheck.reason.all ?? [],
+        breakingChanges: diffCheck.reason.breaking ?? [],
       });
     }
 

--- a/packages/services/api/src/modules/schema/providers/models/composite.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite.ts
@@ -156,7 +156,7 @@ export class CompositeModel {
       conclusion: SchemaCheckConclusion.Success,
       state: {
         schemaPolicyWarnings: policyCheck.result?.warnings ?? null,
-        schemaChanges: diffCheck.result?.changes ?? null,
+        schemaChanges: diffCheck.result ?? null,
         composition: {
           compositeSchemaSDL: compositionCheck.result.fullSchemaSdl,
           supergraphSDL: compositionCheck.result.supergraph,
@@ -337,7 +337,7 @@ export class CompositeModel {
       state: {
         composable: compositionCheck.status === 'completed',
         initial: latestVersion === null,
-        changes: diffCheck.result?.changes ?? diffCheck.reason?.changes ?? null,
+        changes: diffCheck.result?.all ?? diffCheck.reason?.all ?? null,
         messages,
         breakingChanges: null,
         compositionErrors: compositionCheck.reason?.errors ?? null,
@@ -451,11 +451,11 @@ export class CompositeModel {
     const { changes, breakingChanges } =
       diffCheck.status === 'failed'
         ? {
-            changes: diffCheck.reason.changes ?? [],
-            breakingChanges: diffCheck.reason.breakingChanges ?? [],
+            changes: diffCheck.reason.all ?? [],
+            breakingChanges: diffCheck.reason.breaking ?? [],
           }
         : {
-            changes: diffCheck.result?.changes ?? [],
+            changes: diffCheck.result?.all ?? [],
             breakingChanges: [],
           };
 

--- a/packages/services/api/src/modules/schema/providers/models/single-legacy.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single-legacy.ts
@@ -112,7 +112,7 @@ export class SingleLegacyModel {
     return {
       conclusion: SchemaCheckConclusion.Success,
       state: {
-        schemaChanges: diffCheck.result?.changes ?? null,
+        schemaChanges: diffCheck.result ?? null,
         schemaPolicyWarnings: null,
         composition: {
           compositeSchemaSDL: compositionCheck.result.fullSchemaSdl,
@@ -205,10 +205,8 @@ export class SingleLegacyModel {
     const compositionErrors =
       compositionCheck.status === 'failed' ? compositionCheck.reason.errors : null;
     const breakingChanges =
-      diffCheck.status === 'failed' && !acceptBreakingChanges
-        ? diffCheck.reason.breakingChanges
-        : null;
-    const changes = diffCheck.result?.changes || diffCheck.reason?.changes || null;
+      diffCheck.status === 'failed' && !acceptBreakingChanges ? diffCheck.reason.breaking : null;
+    const changes = diffCheck.result?.all || diffCheck.reason?.all || null;
 
     const hasNewMetadata =
       metadataCheck.status === 'completed' && metadataCheck.result.status === 'modified';
@@ -269,8 +267,8 @@ export class SingleLegacyModel {
     if (diffCheck.status === 'failed' && !acceptBreakingChanges) {
       reasons.push({
         code: PublishFailureReasonCode.BreakingChanges,
-        changes: diffCheck.reason.changes ?? [],
-        breakingChanges: diffCheck.reason.breakingChanges ?? [],
+        changes: diffCheck.reason.all ?? [],
+        breakingChanges: diffCheck.reason.breaking ?? [],
       });
     }
 

--- a/packages/services/api/src/modules/schema/providers/models/single.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single.ts
@@ -133,7 +133,7 @@ export class SingleModel {
     return {
       conclusion: SchemaCheckConclusion.Success,
       state: {
-        schemaChanges: diffCheck.result?.changes ?? null,
+        schemaChanges: diffCheck.result ?? null,
         schemaPolicyWarnings: policyCheck.result?.warnings ?? null,
         composition: {
           compositeSchemaSDL: compositionCheck.result.fullSchemaSdl,
@@ -268,7 +268,7 @@ export class SingleModel {
       state: {
         composable: compositionCheck.status === 'completed',
         initial: latestVersion === null,
-        changes: diffCheck.result?.changes ?? diffCheck.reason?.changes ?? null,
+        changes: diffCheck.result?.all ?? diffCheck.reason?.all ?? null,
         messages,
         breakingChanges: null,
         compositionErrors: compositionCheck.reason?.errors ?? null,

--- a/packages/services/api/src/modules/schema/providers/schema-manager.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-manager.ts
@@ -2,8 +2,7 @@ import { parse } from 'graphql';
 import { Inject, Injectable, Scope } from 'graphql-modules';
 import lodash from 'lodash';
 import { z } from 'zod';
-import { Change } from '@graphql-inspector/core';
-import type { SchemaCheck, SchemaCompositionError } from '@hive/storage';
+import type { SchemaChangeType, SchemaCheck, SchemaCompositionError } from '@hive/storage';
 import { RegistryModel, SchemaChecksFilter } from '../../../__generated__/types';
 import {
   DateRange,
@@ -327,7 +326,7 @@ export class SchemaManager {
       metadata: string | null;
       projectType: ProjectType;
       actionFn(): Promise<void>;
-      changes: Array<Change>;
+      changes: Array<SchemaChangeType>;
       previousSchemaVersion: string | null;
       github: null | {
         repository: string;

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -1,5 +1,4 @@
 import { Injectable } from 'graphql-modules';
-import { Change } from '@graphql-inspector/core';
 import type { PolicyConfigurationObject } from '@hive/policy';
 import type {
   SchemaChangeType,
@@ -368,7 +367,7 @@ export interface Storage {
       serviceName: string;
       composable: boolean;
       actionFn(): Promise<void>;
-      changes: Array<Change> | null;
+      changes: Array<SchemaChangeType> | null;
     } & TargetSelector &
       (
         | {
@@ -396,7 +395,7 @@ export interface Storage {
       logIds: string[];
       base_schema: string | null;
       actionFn(): Promise<void>;
-      changes: Array<Change>;
+      changes: Array<SchemaChangeType>;
       previousSchemaVersion: null | string;
       github: null | {
         repository: string;

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -8,7 +8,6 @@ import {
 } from 'slonik';
 import { update } from 'slonik-utilities';
 import zod from 'zod';
-import type { Change } from '@graphql-inspector/core';
 import type {
   ActivityObject,
   Alert,
@@ -4052,7 +4051,7 @@ const DocumentCollectionDocumentModel = zod.object({
 async function insertSchemaVersionChanges(
   trx: DatabaseTransactionConnection,
   args: {
-    changes: Array<Change>;
+    changes: Array<SchemaChangeType>;
     versionId: string;
   },
 ) {
@@ -4074,9 +4073,9 @@ async function insertSchemaVersionChanges(
           sql`(
             ${args.versionId},
             ${change.type},
-            ${change.criticality.level},
+            ${change.criticality},
             ${JSON.stringify(change.meta)}::jsonb,
-            ${change.criticality.isSafeBasedOnUsage ?? false}
+            ${change.isSafeBasedOnUsage ?? false}
           )`,
       ),
       sql`\n,`,
@@ -4170,7 +4169,7 @@ function toSerializableSchemaChange(change: SchemaChangeType): {
     id: change.id,
     type: change.type,
     meta: change.meta,
-    isSafeBasedOnUsage: change.criticality?.isSafeBasedOnUsage ?? false,
+    isSafeBasedOnUsage: change.isSafeBasedOnUsage,
     approvalMetadata: change.approvalMetadata,
   };
 }

--- a/packages/web/app/pages/[organizationId]/[projectId]/[targetId]/checks.tsx
+++ b/packages/web/app/pages/[organizationId]/[projectId]/[targetId]/checks.tsx
@@ -192,7 +192,7 @@ const ActiveSchemaCheck_SchemaCheckFragment = graphql(`
     }
     breakingSchemaChanges {
       nodes {
-        message
+        message(withSafeBasedOnUsageNote: false)
         criticality
         criticalityReason
         path
@@ -204,11 +204,12 @@ const ActiveSchemaCheck_SchemaCheckFragment = graphql(`
           approvedAt
           schemaCheckId
         }
+        isSafeBasedOnUsage
       }
     }
     safeSchemaChanges {
       nodes {
-        message
+        message(withSafeBasedOnUsageNote: false)
         criticality
         criticalityReason
         path
@@ -220,6 +221,7 @@ const ActiveSchemaCheck_SchemaCheckFragment = graphql(`
           approvedAt
           schemaCheckId
         }
+        isSafeBasedOnUsage
       }
     }
     schemaPolicyWarnings {

--- a/packages/web/app/src/components/target/history/errors-and-changes.tsx
+++ b/packages/web/app/src/components/target/history/errors-and-changes.tsx
@@ -46,6 +46,12 @@ export function ChangesBlock(props: {
             <MaybeWrapTooltip tooltip={change.criticalityReason ?? null}>
               <span className="text-gray-600 dark:text-white">{labelize(change.message)}</span>
             </MaybeWrapTooltip>
+            {change.isSafeBasedOnUsage ? (
+              <span className="cursor-pointer text-yellow-500">
+                {' '}
+                <CheckIcon className="inline h-3 w-3" /> Safe based on usage data
+              </span>
+            ) : null}
             {change.approval ? <SchemaChangeApproval approval={change.approval} /> : null}
           </li>
         ))}
@@ -96,7 +102,7 @@ const SchemaChangeApproval = (props: {
           </>
         }
       >
-        <span className="cursor-pointer">
+        <span className="cursor-pointer text-green-500">
           {' '}
           <CheckIcon className="inline h-3 w-3" /> Approved by {approvalName}
         </span>

--- a/packages/web/app/src/graphql/fragments.graphql
+++ b/packages/web/app/src/graphql/fragments.graphql
@@ -90,7 +90,7 @@ fragment SchemaVersionFields on SchemaVersion {
 
 fragment SchemaChangeFields on SchemaChange {
   path
-  message
+  message(withSafeBasedOnUsageNote: false)
   criticality
   criticalityReason
   approval {
@@ -101,6 +101,7 @@ fragment SchemaChangeFields on SchemaChange {
     approvedAt
     schemaCheckId
   }
+  isSafeBasedOnUsage
 }
 
 fragment SchemaCompareResultFields on SchemaCompareResult {

--- a/packages/web/app/src/stories/history-page.stories.tsx
+++ b/packages/web/app/src/stories/history-page.stories.tsx
@@ -6,18 +6,22 @@ const changes = [
   {
     message: 'Type "Foo" was removed',
     criticality: CriticalityLevel.Breaking,
+    isSafeBasedOnUsage: false,
   },
   {
     message: 'Input field "limit" was added to input object type "Filter"',
     criticality: CriticalityLevel.Breaking,
+    isSafeBasedOnUsage: false,
   },
   {
     message: 'Field "User.nickname" is no longer deprecated',
     criticality: CriticalityLevel.Dangerous,
+    isSafeBasedOnUsage: false,
   },
   {
     message: 'Field "type" was added to object type "User"',
     criticality: CriticalityLevel.Safe,
+    isSafeBasedOnUsage: false,
   },
 ];
 


### PR DESCRIPTION
### Background

>We show “breaking changes” that are safe based on usage on the “Safe Changes” section.
I feel like it makes more sense to show them on the “Breaking Changes” section with an annotation instead (similar to screenshot attached). We actually already have the annotation “(safe based on usage)“, but having the change within Safe Changes still feels a bit misleading.

[Internal discussion](https://guild-oss.slack.com/archives/C01E8ATBQGN/p1699872922797379)

### Description



### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
