### PR TITLE
fix: use same pathname parameter name as route filename

### DIFF
--- a/packages/web/app/pages/[organizationId]/[projectId]/[targetId]/checks.tsx
+++ b/packages/web/app/pages/[organizationId]/[projectId]/[targetId]/checks.tsx
@@ -111,12 +111,12 @@ const Navigation = (props: {
               <NextLink
                 key={edge.node.id}
                 href={{
-                  pathname: '/[organizationId]/[projectId]/[targetId]/checks/[checkId]',
+                  pathname: '/[organizationId]/[projectId]/[targetId]/checks/[schemaCheckId]',
                   query: {
                     organizationId: router.organizationId,
                     projectId: router.projectId,
                     targetId: router.targetId,
-                    checkId: edge.node.id,
+                    schemaCheckId: edge.node.id,
                   },
                 }}
                 scroll={false} // disable the scroll to top on page


### PR DESCRIPTION
### Background

Closes https://github.com/kamilkisiela/graphql-hive/issues/3180

### Description

[This issue](https://github.com/kamilkisiela/graphql-hive/issues/3180) and the "Invariant: attempted to hard navigate to the same URL" issue that popped up on Sentry is solved with this PR.

This issue was that we used `checkId` instead of `schemaCheckId` in the pathname. The pathname variables must mirror the filesystem routing files...

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
