### PR TITLE
fix: return api schema for sdl instead of supergraph schema

### DIFF
--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -3056,41 +3056,7 @@ test('Composition Network Failure (Federation 2)', async () => {
             total: 1,
           },
           diff: {
-            after: directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-
-      directive @join__graph(name: String!, url: String!) on ENUM_VALUE
-
-      directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
-
-      directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
-
-      directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
-
-      directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
-
-      directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
-
-      enum link__Purpose {
-        """
-        \`SECURITY\` features provide metadata necessary to securely resolve fields.
-        """
-        SECURITY
-
-        """
-        \`EXECUTION\` features provide metadata necessary for operation execution.
-        """
-        EXECUTION
-      }
-
-      scalar link__Import
-
-      enum join__Graph {
-        TEST
-      }
-
-      scalar join__FieldSet
-
-      type Product {
+            after: type Product {
         id: ID!
         title: String
       }
@@ -3098,41 +3064,7 @@ test('Composition Network Failure (Federation 2)', async () => {
       type Query {
         product(id: ID!): Product
       },
-            before: directive @link(url: String, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
-
-      directive @join__graph(name: String!, url: String!) on ENUM_VALUE
-
-      directive @join__type(graph: join__Graph!, key: join__FieldSet, extension: Boolean! = false, resolvable: Boolean! = true, isInterfaceObject: Boolean! = false) repeatable on OBJECT | INTERFACE | UNION | ENUM | INPUT_OBJECT | SCALAR
-
-      directive @join__field(graph: join__Graph, requires: join__FieldSet, provides: join__FieldSet, type: String, external: Boolean, override: String, usedOverridden: Boolean) repeatable on FIELD_DEFINITION | INPUT_FIELD_DEFINITION
-
-      directive @join__implements(graph: join__Graph!, interface: String!) repeatable on OBJECT | INTERFACE
-
-      directive @join__unionMember(graph: join__Graph!, member: String!) repeatable on UNION
-
-      directive @join__enumValue(graph: join__Graph!) repeatable on ENUM_VALUE
-
-      enum link__Purpose {
-        """
-        \`SECURITY\` features provide metadata necessary to securely resolve fields.
-        """
-        SECURITY
-
-        """
-        \`EXECUTION\` features provide metadata necessary for operation execution.
-        """
-        EXECUTION
-      }
-
-      scalar link__Import
-
-      enum join__Graph {
-        TEST
-      }
-
-      scalar join__FieldSet
-
-      type Product {
+            before: type Product {
         id: ID!
       }
 

--- a/packages/services/external-composition/federation-2/package.json
+++ b/packages/services/external-composition/federation-2/package.json
@@ -9,6 +9,7 @@
   },
   "devDependencies": {
     "@apollo/composition": "2.5.7",
+    "@apollo/federation-internals": "2.5.7",
     "@graphql-hive/external-composition": "workspace:*",
     "@whatwg-node/fetch": "0.9.13",
     "@whatwg-node/server": "0.9.10",

--- a/packages/services/external-composition/federation-2/src/server.ts
+++ b/packages/services/external-composition/federation-2/src/server.ts
@@ -1,6 +1,7 @@
 import { parse, printSchema } from 'graphql';
 import LRU from 'lru-cache';
 import { composeServices } from '@apollo/composition';
+import { Supergraph } from '@apollo/federation-internals';
 import { compose, signatureHeaderName, verifyRequest } from '@graphql-hive/external-composition';
 import { Response } from '@whatwg-node/fetch';
 import { createServerAdapter } from '@whatwg-node/server';
@@ -54,11 +55,13 @@ const composeFederation = compose(services => {
       };
     }
 
+    const apiSchema = Supergraph.build(result.supergraphSdl).apiSchema().toGraphQLJSSchema();
+
     return {
       type: 'success',
       result: {
         supergraph: result.supergraphSdl,
-        sdl: printSchema(result.schema.toGraphQLJSSchema()),
+        sdl: printSchema(apiSchema),
       },
     };
   } catch (e) {

--- a/packages/services/schema/package.json
+++ b/packages/services/schema/package.json
@@ -16,7 +16,7 @@
     "@graphql-tools/stitching-directives": "3.0.0",
     "@hive/service-common": "workspace:*",
     "@sentry/node": "7.81.1",
-    "@theguild/federation-composition": "0.1.4",
+    "@theguild/federation-composition": "0.2.0",
     "@trpc/server": "10.44.0",
     "@types/async-retry": "1.4.8",
     "@types/ioredis-mock": "8.2.5",

--- a/packages/services/schema/src/orchestrators.ts
+++ b/packages/services/schema/src/orchestrators.ts
@@ -23,7 +23,7 @@ import type { FastifyLoggerInstance } from '@hive/service-common';
 import {
   composeServices as nativeComposeServices,
   compositionHasErrors as nativeCompositionHasErrors,
-  stripFederationFromSupergraph,
+  transformSupergraphToPublicSchema,
 } from '@theguild/federation-composition';
 import type { Cache } from './cache';
 import type {
@@ -361,7 +361,7 @@ function composeFederationV2(
     type: 'success',
     result: {
       supergraph: result.supergraphSdl,
-      sdl: print(stripFederationFromSupergraph(parse(result.supergraphSdl))),
+      sdl: print(transformSupergraphToPublicSchema(parse(result.supergraphSdl))),
     },
     includesNetworkError: false,
   };
@@ -458,7 +458,9 @@ const createFederation: (
             type: 'success',
             result: {
               supergraph: parseResult.data.result.supergraph,
-              sdl: parseResult.data.result.sdl,
+              sdl: print(
+                transformSupergraphToPublicSchema(parse(parseResult.data.result.supergraph)),
+              ),
             },
             includesNetworkError: false,
           };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -820,6 +820,9 @@ importers:
       '@apollo/composition':
         specifier: 2.5.7
         version: 2.5.7(graphql@16.8.1)
+      '@apollo/federation-internals':
+        specifier: 2.5.7
+        version: 2.5.7(graphql@16.8.1)
       '@graphql-hive/external-composition':
         specifier: workspace:*
         version: link:../../../libraries/external-composition/dist

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -953,8 +953,8 @@ importers:
         specifier: 7.81.1
         version: 7.81.1
       '@theguild/federation-composition':
-        specifier: 0.1.4
-        version: 0.1.4(graphql@16.8.1)
+        specifier: 0.2.0
+        version: 0.2.0(graphql@16.8.1)
       '@trpc/server':
         specifier: 10.44.0
         version: 10.44.0
@@ -12927,8 +12927,8 @@ packages:
       - typescript
     dev: true
 
-  /@theguild/federation-composition@0.1.4(graphql@16.8.1):
-    resolution: {integrity: sha512-w1jCP98ZLuipZ8siXgFXsVWKscecXs8IM5x0VwDmWKBP1TR9zg5OGfrUh3GPgHMrlsB8yOh+oex/pEHyljLL4Q==}
+  /@theguild/federation-composition@0.2.0(graphql@16.8.1):
+    resolution: {integrity: sha512-xqTj1kV7CdmMFw3xaEoupuUYrwPeYsPG0PWMwXvh9eLwF+gr7UhMs4XurYPE/RgvYNMq4Hr6GkZSEFcn74HGtQ==}
     engines: {node: '>=18'}
     peerDependencies:
       graphql: ^16.0.0


### PR DESCRIPTION
### Background

We are currently returning the supergraph instead of the schema SDL (which is what should be used by tools like graphql code generator).

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
