### PR TITLE
Update theguild/federation-composition to 0.1.4

### DIFF
--- a/packages/services/schema/package.json
+++ b/packages/services/schema/package.json
@@ -16,7 +16,7 @@
     "@graphql-tools/stitching-directives": "3.0.0",
     "@hive/service-common": "workspace:*",
     "@sentry/node": "7.80.1",
-    "@theguild/federation-composition": "0.1.3",
+    "@theguild/federation-composition": "0.1.4",
     "@trpc/server": "10.44.0",
     "@types/async-retry": "1.4.8",
     "@types/ioredis-mock": "8.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -950,8 +950,8 @@ importers:
         specifier: 7.80.1
         version: 7.80.1
       '@theguild/federation-composition':
-        specifier: 0.1.3
-        version: 0.1.3(graphql@16.8.1)
+        specifier: 0.1.4
+        version: 0.1.4(graphql@16.8.1)
       '@trpc/server':
         specifier: 10.44.0
         version: 10.44.0
@@ -12848,8 +12848,8 @@ packages:
       - typescript
     dev: true
 
-  /@theguild/federation-composition@0.1.3(graphql@16.8.1):
-    resolution: {integrity: sha512-H3mtVhpI0CeX1Yyv2HfUM7qc3bxCS8oPxPzJXaDckt4nWUecKIZXCI5FaiUV3feu2UN4j6iMVCQOWPok8jwX7Q==}
+  /@theguild/federation-composition@0.1.4(graphql@16.8.1):
+    resolution: {integrity: sha512-w1jCP98ZLuipZ8siXgFXsVWKscecXs8IM5x0VwDmWKBP1TR9zg5OGfrUh3GPgHMrlsB8yOh+oex/pEHyljLL4Q==}
     engines: {node: '>=18'}
     peerDependencies:
       graphql: ^16.0.0


### PR DESCRIPTION
Makes stripFederationFromSupergraph less strict and remove only Federation directives