### PR TITLE
fix: omit federation related changes from diff output

### DIFF
--- a/packages/services/api/src/modules/schema/providers/registry-checks.ts
+++ b/packages/services/api/src/modules/schema/providers/registry-checks.ts
@@ -301,10 +301,15 @@ export class RegistryChecks {
       } satisfies CheckResult;
     }
 
-    const inspectorChanges = await this.inspector.diff(existingSchema, incomingSchema, selector);
+    let inspectorChanges = await this.inspector.diff(existingSchema, incomingSchema, selector);
 
     if (includeUrlChanges) {
       inspectorChanges.push(...detectUrlChanges(version.schemas, schemas));
+    }
+
+    // Filter out federation specific changes as they are not relevant for the schema diff and were in previous schema versions by accident.
+    if ('type' in orchestrator && orchestrator.type === ProjectType.FEDERATION) {
+      inspectorChanges = inspectorChanges.filter(change => !isFederationRelatedChange(change));
     }
 
     let isFailure = false;
@@ -587,3 +592,22 @@ const toSchemaCheckWarning = (record: CheckPolicyResponse[number]): SchemaCheckW
   endColumn: record.endColumn ?? null,
   endLine: record.endLine ?? null,
 });
+
+const federationTypes = new Set(['join__FieldSet', 'join__Graph', 'link__Import', 'link__Purpose']);
+const federationDirectives = new Set([
+  '@join__enumValue',
+  '@join__field',
+  '@join__graph',
+  '@join__implements',
+  '@join__type',
+  '@join__unionMember',
+  '@link',
+  '@federation__inaccessible',
+  '@inaccessible',
+  '@tag',
+  '@federation__tag',
+]);
+
+function isFederationRelatedChange(change: SchemaChangeType) {
+  return change.path && (federationTypes.has(change.path) || federationDirectives.has(change.path));
+}


### PR DESCRIPTION
### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

In https://github.com/kamilkisiela/graphql-hive/pull/3439 we fixed an issue where the supergraph instead of the public API schema was stored for the SDL. However, this now started failing schema publishes and checks. By filtering out federation directive related changes within the diff command, we avoid these failures.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
