### PR TITLE
fix: always use GITHUB_REPOSITORY in schema:check command. Print warn…

### DIFF
--- a/.changeset/yellow-lobsters-pull.md
+++ b/.changeset/yellow-lobsters-pull.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': minor
+---
+
+Print warning when pull request number can not be resolved.

--- a/packages/libraries/cli/src/commands/schema/check.ts
+++ b/packages/libraries/cli/src/commands/schema/check.ts
@@ -190,8 +190,9 @@ export default class SchemaCheck extends Command {
           );
         }
         if (!git.pullRequestNumber) {
-          throw new Errors.CLIError(
-            `Couldn't resolve pull request number required for GitHub Application`,
+          this.warn(
+            "Could not resolve pull request number. Are you running this command on a 'pull_request' event?\n" +
+              'See https://the-guild.dev/graphql/hive/docs/integrations/ci-cd#github-workflow-for-ci',
           );
         }
 

--- a/packages/libraries/cli/src/helpers/git.ts
+++ b/packages/libraries/cli/src/helpers/git.ts
@@ -54,6 +54,11 @@ function useGitHubAction(): CIRunner {
       return !!process.env.GITHUB_ACTIONS;
     },
     env() {
+      // eslint-disable-next-line no-process-env
+      const repository = process.env['GITHUB_REPOSITORY'] ?? null;
+      let pullRequestNumber: string | null = null;
+      let commit: string | null = null;
+
       const isPr =
         // eslint-disable-next-line no-process-env
         process.env.GITHUB_EVENT_NAME === 'pull_request' ||
@@ -69,19 +74,15 @@ function useGitHubAction(): CIRunner {
             : undefined;
 
           if (event?.pull_request) {
-            return {
-              commit: event.pull_request.head.sha as string,
-              pullRequestNumber: String(event.pull_request.number),
-              // eslint-disable-next-line no-process-env
-              repository: process.env['GITHUB_REPOSITORY']!,
-            };
+            commit = event.pull_request.head.sha as string;
+            pullRequestNumber = String(event.pull_request.number);
           }
         } catch {
           // Noop
         }
       }
 
-      return { commit: undefined, pullRequestNumber: undefined, repository: undefined };
+      return { commit, pullRequestNumber, repository };
     },
   };
 }


### PR DESCRIPTION
…ing instead of failing if the pull requets number can not be resolved.

### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
