### PR TITLE
Fix usage-based exclusion of clients

### DIFF
--- a/packages/services/api/src/modules/operations/providers/operations-reader.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-reader.ts
@@ -251,9 +251,10 @@ export class OperationsReader {
         hash NOT IN (
           SELECT hash FROM clients_daily ${this.createFilter({
             target,
-            period,
-            extra: [sql`client_name IN (${sql.array(excludedClients, 'String')})`],
-          })} GROUP BY hash
+            period
+          })}
+          GROUP BY hash
+          HAVING COUNT(CASE WHEN `client` NOT IN (${sql.array(excludedClients, 'String')}) THEN 1 END) > 0
         )
       `);
     }


### PR DESCRIPTION
### Background

We have a query like the following done from multiple clients:
query getVisitorPropertiesQuery($marketId: String!, $userId: ID!) {
  clinicPodForUser(userId: $userId) {
    name
  }
  clinicsForMarket(marketId: $marketId) {
    id
    name
  }
  currentUser {
    createdAt
    permissions
  }
}

In a PR, I removed the `clinicPodForUser` field from top-level Query. However, the Hive check is flagging this as safe based on usage. We only exclude one client, and this query is made on multiple, so this should be flagged as broken

![image](https://github.com/kamilkisiela/graphql-hive/assets/542149/6deb800e-97d1-4189-b7ef-09fa3ee44b27)

### Description

Instead of filtering hashes where the client names are present, we actually want to select hashes where a non-excluded client is present

### Checklist

TBD: Trying to discover tests run via CI

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
