### PR TITLE
SQL statements should not have PostgreSQL schema names hardcoded

### DIFF
--- a/packages/migrations/src/actions/2021-03-05T19-06-23.initial.ts
+++ b/packages/migrations/src/actions/2021-03-05T19-06-23.initial.ts
@@ -28,7 +28,7 @@ COMMENT
 
 --- Tables
 CREATE TABLE
-  public.users (
+  users (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4 (),
     email VARCHAR(320) NOT NULL UNIQUE,
     external_auth_user_id VARCHAR(50) NOT NULL UNIQUE,
@@ -36,19 +36,19 @@ CREATE TABLE
   );
 
 CREATE TABLE
-  public.organizations (
+  organizations (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4 (),
     clean_id slug NOT NULL,
     NAME TEXT NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     invite_code VARCHAR(10) NOT NULL UNIQUE DEFAULT SUBSTR(MD5(RANDOM()::TEXT), 0, 10),
-    user_id UUID NOT NULL REFERENCES public.users (id),
+    user_id UUID NOT NULL REFERENCES users (id),
     TYPE
       organization_type NOT NULL
   );
 
 CREATE TABLE
-  public.projects (
+  projects (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4 (),
     clean_id slug NOT NULL,
     NAME VARCHAR(200) NOT NULL,
@@ -57,20 +57,20 @@ CREATE TABLE
       created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
       build_url url,
       validation_url url,
-      org_id UUID NOT NULL REFERENCES public.organizations (id) ON DELETE CASCADE
+      org_id UUID NOT NULL REFERENCES organizations (id) ON DELETE CASCADE
   );
 
 CREATE TABLE
-  public.targets (
+  targets (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4 (),
     clean_id slug NOT NULL,
     NAME TEXT NOT NULL,
-    project_id UUID NOT NULL REFERENCES public.projects (id) ON DELETE CASCADE,
+    project_id UUID NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
   );
 
 CREATE TABLE
-  public.commits (
+  commits (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4 (),
     author TEXT NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
@@ -81,44 +81,44 @@ CREATE TABLE
   );
 
 CREATE TABLE
-  public.versions (
+  versions (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4 (),
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     VALID BOOLEAN NOT NULL,
-    target_id UUID NOT NULL REFERENCES public.targets (id) ON DELETE CASCADE,
-    commit_id UUID NOT NULL REFERENCES public.commits (id) ON DELETE CASCADE
+    target_id UUID NOT NULL REFERENCES targets (id) ON DELETE CASCADE,
+    commit_id UUID NOT NULL REFERENCES commits (id) ON DELETE CASCADE
   );
 
 CREATE TABLE
-  public.version_commit (
-    version_id UUID NOT NULL REFERENCES public.versions (id) ON DELETE CASCADE,
-    commit_id UUID NOT NULL REFERENCES public.commits (id) ON DELETE CASCADE,
+  version_commit (
+    version_id UUID NOT NULL REFERENCES versions (id) ON DELETE CASCADE,
+    commit_id UUID NOT NULL REFERENCES commits (id) ON DELETE CASCADE,
     url url,
     PRIMARY KEY (version_id, commit_id)
   );
 
 CREATE TABLE
-  public.tokens (
+  tokens (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4 (),
     token VARCHAR(32) NOT NULL DEFAULT MD5(RANDOM()::TEXT),
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-    project_id UUID NOT NULL REFERENCES public.projects (id) ON DELETE CASCADE,
+    project_id UUID NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
     NAME TEXT NOT NULL,
     last_used_at TIMESTAMP WITH TIME ZONE
   );
 
 CREATE TABLE
-  public.organization_member (
-    organization_id UUID NOT NULL REFERENCES public.organizations (id) ON DELETE CASCADE,
-    user_id UUID NOT NULL REFERENCES public.users (id) ON DELETE CASCADE,
+  organization_member (
+    organization_id UUID NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users (id) ON DELETE CASCADE,
     PRIMARY KEY (organization_id, user_id)
   );
 
 --- Indices
 CREATE INDEX
-  email_idx ON public.users USING btree (email);
+  email_idx ON users USING btree (email);
 
 CREATE INDEX
-  external_auth_user_id_idx ON public.users USING btree (external_auth_user_id);
+  external_auth_user_id_idx ON users USING btree (external_auth_user_id);
 `,
 } satisfies MigrationExecutor;

--- a/packages/migrations/src/actions/2021-03-08T11-02-26.urls.ts
+++ b/packages/migrations/src/actions/2021-03-08T11-02-26.urls.ts
@@ -5,7 +5,7 @@ export default {
   run: ({ sql }) => sql`
 --urls (up)
 ALTER TABLE
-  public.projects
+  projects
 ALTER COLUMN
   build_url
 TYPE

--- a/packages/migrations/src/actions/2021-03-09T10-30-35.roles.ts
+++ b/packages/migrations/src/actions/2021-03-09T10-30-35.roles.ts
@@ -8,12 +8,12 @@ CREATE TYPE
   user_role AS ENUM('ADMIN', 'MEMBER');
 
 ALTER TABLE
-  public.organization_member
+  organization_member
 ADD COLUMN
   ROLE user_role NOT NULL DEFAULT 'MEMBER';
 
 UPDATE
-  public.organization_member AS om
+  organization_member AS om
 SET ROLE
   = 'ADMIN'
 WHERE
@@ -21,7 +21,7 @@ WHERE
     SELECT
       o.user_id
     FROM
-      public.organizations AS o
+      organizations AS o
     WHERE
       o.id = om.organization_id
       AND o.user_id = om.user_id

--- a/packages/migrations/src/actions/2021-03-09T14-02-34.activities.ts
+++ b/packages/migrations/src/actions/2021-03-09T14-02-34.activities.ts
@@ -5,12 +5,12 @@ export default {
   run: ({ sql }) => sql`
 --activities (up)
 CREATE TABLE
-  public.activities (
+  activities (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4 (),
-    user_id UUID NOT NULL REFERENCES public.users (id) ON DELETE CASCADE,
-    organization_id UUID NOT NULL REFERENCES public.organizations (id) ON DELETE CASCADE,
-    project_id UUID REFERENCES public.projects (id) ON DELETE CASCADE,
-    target_id UUID REFERENCES public.targets (id) ON DELETE CASCADE,
+    user_id UUID NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    organization_id UUID NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
+    project_id UUID REFERENCES projects (id) ON DELETE CASCADE,
+    target_id UUID REFERENCES targets (id) ON DELETE CASCADE,
     activity_type VARCHAR(30) NOT NULL,
     activity_metadata JSONB NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()

--- a/packages/migrations/src/actions/2021-03-15T19-32-01.commit-project-id.ts
+++ b/packages/migrations/src/actions/2021-03-15T19-32-01.commit-project-id.ts
@@ -5,23 +5,23 @@ export default {
   run: ({ sql }) => sql`
 --commit-project-id (up)
 ALTER TABLE
-  public.commits
+  commits
 ADD COLUMN
-  project_id UUID REFERENCES public.projects (id) ON DELETE CASCADE;
+  project_id UUID REFERENCES projects (id) ON DELETE CASCADE;
 
 UPDATE
-  public.commits AS c
+  commits AS c
 SET
   project_id = t.project_id
 FROM
-  public.versions AS v,
-  public.targets AS t
+  versions AS v,
+  targets AS t
 WHERE
   v.commit_id = c.id
   AND t.id = v.target_id;
 
 ALTER TABLE
-  public.commits
+  commits
 ALTER COLUMN
   project_id
 SET NOT NULL;

--- a/packages/migrations/src/actions/2021-04-20T11-30-30.tokens.ts
+++ b/packages/migrations/src/actions/2021-04-20T11-30-30.tokens.ts
@@ -5,7 +5,7 @@ export default {
   run: ({ sql }) => sql`
 --tokens (up)
 ALTER TABLE
-  public.tokens
+  tokens
 DROP COLUMN
   last_used_at;
 `,

--- a/packages/migrations/src/actions/2021-04-30T07-01-57.token-per-target.ts
+++ b/packages/migrations/src/actions/2021-04-30T07-01-57.token-per-target.ts
@@ -5,13 +5,13 @@ export default {
   run: ({ sql }) => sql`
 --token-per-target (up)
 ALTER TABLE
-  public.tokens
+  tokens
 ADD COLUMN
-  target_id UUID NOT NULL REFERENCES public.targets (id) ON DELETE CASCADE;
+  target_id UUID NOT NULL REFERENCES targets (id) ON DELETE CASCADE;
 
 ALTER TABLE
-  public.tokens
+  tokens
 ADD COLUMN
-  organization_id UUID NOT NULL REFERENCES public.organizations (id) ON DELETE CASCADE;
+  organization_id UUID NOT NULL REFERENCES organizations (id) ON DELETE CASCADE;
 `,
 } satisfies MigrationExecutor;

--- a/packages/migrations/src/actions/2021-04-30T11-47-26.validation.ts
+++ b/packages/migrations/src/actions/2021-04-30T11-47-26.validation.ts
@@ -5,17 +5,17 @@ export default {
   run: ({ sql }) => sql`
 --validation (up)
 ALTER TABLE
-  public.targets
+  targets
 ADD COLUMN
   validation_enabled BOOLEAN NOT NULL DEFAULT FALSE;
 
 ALTER TABLE
-  public.targets
+  targets
 ADD COLUMN
   validation_period SMALLINT NOT NULL DEFAULT 30;
 
 ALTER TABLE
-  public.targets
+  targets
 ADD COLUMN
   validation_percentage FLOAT NOT NULL DEFAULT 0.00;
 `,

--- a/packages/migrations/src/actions/2021-04-30T18-30-00.persisted-operations.ts
+++ b/packages/migrations/src/actions/2021-04-30T18-30-00.persisted-operations.ts
@@ -8,14 +8,14 @@ CREATE TYPE
   operation_kind AS ENUM('query', 'mutation', 'subscription');
 
 CREATE TABLE
-  public.persisted_operations (
+  persisted_operations (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4 (),
     operation_hash VARCHAR(600) NOT NULL,
     operation_name TEXT NOT NULL,
     operation_kind operation_kind NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
     CONTENT TEXT NOT NULL,
-    project_id UUID NOT NULL REFERENCES public.projects (id) ON DELETE CASCADE,
+    project_id UUID NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
     UNIQUE (operation_hash, project_id)
   );
 `,

--- a/packages/migrations/src/actions/2021-05-07T07-28-07.token-last-used-at.ts
+++ b/packages/migrations/src/actions/2021-05-07T07-28-07.token-last-used-at.ts
@@ -5,7 +5,7 @@ export default {
   run: ({ sql }) => sql`
 --token-last-used-at (up)
 ALTER TABLE
-  public.tokens
+  tokens
 ADD COLUMN
   last_used_at TIMESTAMP WITH TIME ZONE;
 `,

--- a/packages/migrations/src/actions/2021-06-11T10-46-24.slack-integration.ts
+++ b/packages/migrations/src/actions/2021-06-11T10-46-24.slack-integration.ts
@@ -5,7 +5,7 @@ export default {
   run: ({ sql }) => sql`
 --slack-integration (up)
 ALTER TABLE
-  public.organizations
+  organizations
 ADD COLUMN
   slack_token TEXT;
 `,

--- a/packages/migrations/src/actions/2021-06-11T15-38-28.alerts.ts
+++ b/packages/migrations/src/actions/2021-06-11T15-38-28.alerts.ts
@@ -11,7 +11,7 @@ CREATE TYPE
   alert_type AS ENUM('SCHEMA_CHANGE_NOTIFICATIONS');
 
 CREATE TABLE
-  public.alert_channels (
+  alert_channels (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4 (),
     TYPE
       alert_channel_type NOT NULL,
@@ -19,18 +19,18 @@ CREATE TABLE
       NAME TEXT NOT NULL,
       slack_channel TEXT,
       webhook_endpoint TEXT,
-      project_id UUID NOT NULL REFERENCES public.projects (id) ON DELETE CASCADE
+      project_id UUID NOT NULL REFERENCES projects (id) ON DELETE CASCADE
   );
 
 CREATE TABLE
-  public.alerts (
+  alerts (
     id UUID PRIMARY KEY DEFAULT uuid_generate_v4 (),
     TYPE
       alert_type NOT NULL,
       created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
-      alert_channel_id UUID NOT NULL REFERENCES public.alert_channels (id) ON DELETE CASCADE,
-      project_id UUID NOT NULL REFERENCES public.projects (id) ON DELETE CASCADE,
-      target_id UUID NOT NULL REFERENCES public.targets (id) ON DELETE CASCADE
+      alert_channel_id UUID NOT NULL REFERENCES alert_channels (id) ON DELETE CASCADE,
+      project_id UUID NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
+      target_id UUID NOT NULL REFERENCES targets (id) ON DELETE CASCADE
   );
 `,
 } satisfies MigrationExecutor;

--- a/packages/migrations/src/actions/2021-08-18T13-20-45.urls.ts
+++ b/packages/migrations/src/actions/2021-08-18T13-20-45.urls.ts
@@ -5,21 +5,21 @@ export default {
   run: ({ sql }) => sql`
 --urls (up)
 ALTER TABLE
-  public.version_commit
+  version_commit
 ALTER COLUMN
   url
 TYPE
   TEXT;
 
 ALTER TABLE
-  public.projects
+  projects
 ALTER COLUMN
   build_url
 TYPE
   TEXT;
 
 ALTER TABLE
-  public.projects
+  projects
 ALTER COLUMN
   validation_url
 TYPE

--- a/packages/migrations/src/actions/2021-08-27T14-19-48.non-unique-emails.ts
+++ b/packages/migrations/src/actions/2021-08-27T14-19-48.non-unique-emails.ts
@@ -8,39 +8,39 @@ DROP INDEX
   email_idx;
 
 ALTER TABLE
-  public.users
+  users
 DROP
   CONSTRAINT users_email_key;
 
 ALTER TABLE
-  public.users
+  users
 ADD
   CONSTRAINT users_external_email_key UNIQUE (email, external_auth_user_id);
 
 ALTER TABLE
-  public.users
+  users
 ADD
   display_name VARCHAR(300);
 
 ALTER TABLE
-  public.users
+  users
 ADD
   full_name VARCHAR(300);
 
 UPDATE
-  public.users
+  users
 SET
   display_name = SPLIT_PART(email, '@', 1),
   full_name = SPLIT_PART(email, '@', 1);
 
 ALTER TABLE
-  public.users
+  users
 ALTER COLUMN
   display_name
 SET NOT NULL;
 
 ALTER TABLE
-  public.users
+  users
 ALTER COLUMN
   full_name
 SET NOT NULL;

--- a/packages/migrations/src/actions/2021.09.17T14.45.36.token-deleted.ts
+++ b/packages/migrations/src/actions/2021.09.17T14.45.36.token-deleted.ts
@@ -4,7 +4,7 @@ export default {
   name: '2021.09.17T14.45.36.token-deleted.sql',
   run: ({ sql }) => sql`
 ALTER TABLE
-  public.tokens
+  tokens
 ADD COLUMN
   deleted_at TIMESTAMP WITH TIME ZONE DEFAULT NULL;
 `,

--- a/packages/migrations/src/actions/2021.10.07T12.11.13.access-scopes.ts
+++ b/packages/migrations/src/actions/2021.10.07T12.11.13.access-scopes.ts
@@ -5,19 +5,19 @@ export default {
   run: ({ sql }) => sql`
 -- Adds scopes to tokens
 ALTER TABLE
-  public.tokens
+  tokens
 ADD COLUMN
   scopes TEXT[] DEFAULT NULL;
 
 -- Adds scopes to organization_member
 ALTER TABLE
-  public.organization_member
+  organization_member
 ADD COLUMN
   scopes TEXT[] DEFAULT NULL;
 
 -- Adds scopes to existing regular members
 UPDATE
-  public.organization_member
+  organization_member
 SET
   scopes = ARRAY[
     'organization:read',
@@ -31,7 +31,7 @@ WHERE
 
 -- Adds scopes to existing admin members
 UPDATE
-  public.organization_member
+  organization_member
 SET
   scopes = ARRAY[
     'organization:read',
@@ -58,7 +58,7 @@ WHERE
 
 -- Adds scopes to existing tokens
 UPDATE
-  public.tokens
+  tokens
 SET
   scopes = ARRAY[
     'organization:read',

--- a/packages/migrations/src/actions/2021.11.22T11.23.44.base-schema.ts
+++ b/packages/migrations/src/actions/2021.11.22T11.23.44.base-schema.ts
@@ -5,12 +5,12 @@ export default {
   run: ({ sql }) => sql`
 -- Adds a base schema column in target table and versions table
 ALTER TABLE
-  public.targets
+  targets
 ADD
   base_schema TEXT;
 
 ALTER TABLE
-  public.versions
+  versions
 ADD
   base_schema TEXT;
 `,

--- a/packages/migrations/src/actions/2021.12.20T14.05.30.commits-with-targets.ts
+++ b/packages/migrations/src/actions/2021.12.20T14.05.30.commits-with-targets.ts
@@ -3,23 +3,23 @@ import { type MigrationExecutor } from '../pg-migrator';
 export default {
   name: '2021.12.20T14.05.30.commits-with-targets.sql',
   run: ({ sql }) => sql`
---creates and fills a target_id column on public.commits
+--creates and fills a target_id column on commits
 ALTER TABLE
-  public.commits
+  commits
 ADD COLUMN
-  target_id UUID REFERENCES public.targets (id) ON DELETE CASCADE;
+  target_id UUID REFERENCES targets (id) ON DELETE CASCADE;
 
 UPDATE
-  public.commits AS c
+  commits AS c
 SET
   target_id = v.target_id
 FROM
-  public.versions AS v
+  versions AS v
 WHERE
   v.commit_id = c.id;
 
 ALTER TABLE
-  public.commits
+  commits
 ALTER COLUMN
   target_id
 SET NOT NULL;

--- a/packages/migrations/src/actions/2022.01.21T12.34.46.validation-targets.ts
+++ b/packages/migrations/src/actions/2022.01.21T12.34.46.validation-targets.ts
@@ -4,19 +4,19 @@ export default {
   name: '2022.01.21T12.34.46.validation-targets.sql',
   run: ({ sql }) => sql`
 CREATE TABLE
-  public.target_validation (
-    target_id UUID NOT NULL REFERENCES public.targets (id) ON DELETE CASCADE,
-    destination_target_id UUID NOT NULL REFERENCES public.targets (id) ON DELETE CASCADE,
+  target_validation (
+    target_id UUID NOT NULL REFERENCES targets (id) ON DELETE CASCADE,
+    destination_target_id UUID NOT NULL REFERENCES targets (id) ON DELETE CASCADE,
     PRIMARY KEY (target_id, destination_target_id)
   );
 
 INSERT INTO
-  public.target_validation (target_id, destination_target_id) (
+  target_validation (target_id, destination_target_id) (
     SELECT
       id AS target_id,
       id AS destination_target_id
     FROM
-      public.targets
+      targets
     WHERE
       validation_enabled IS TRUE
   );

--- a/packages/migrations/src/actions/2022.03.28T10.31.26.github-integration.ts
+++ b/packages/migrations/src/actions/2022.03.28T10.31.26.github-integration.ts
@@ -5,12 +5,12 @@ export default {
   run: ({ sql }) => sql`
 --slack-integration (up)
 ALTER TABLE
-  public.organizations
+  organizations
 ADD COLUMN
   github_app_installation_id TEXT;
 
 ALTER TABLE
-  public.projects
+  projects
 ADD COLUMN
   git_repository TEXT;
 `,

--- a/packages/migrations/src/actions/2022.04.15T14.24.17.hash-tokens.ts
+++ b/packages/migrations/src/actions/2022.04.15T14.24.17.hash-tokens.ts
@@ -4,19 +4,19 @@ export default {
   name: '2022.04.15T14.24.17.hash-tokens.sql',
   run: ({ sql }) => sql`
 ALTER TABLE
-  public.tokens
+  tokens
 ADD COLUMN
   token_alias VARCHAR(64) NOT NULL DEFAULT REPEAT('*', 64);
 
 ALTER TABLE
-  public.tokens
+  tokens
 ALTER COLUMN
   token
 TYPE
   VARCHAR(64);
 
 UPDATE
-  public.tokens
+  tokens
 SET
   token_alias = CONCAT(
     SUBSTRING(

--- a/packages/migrations/src/actions/2022.05.03T15.58.13.org_rate_limits.ts
+++ b/packages/migrations/src/actions/2022.05.03T15.58.13.org_rate_limits.ts
@@ -4,19 +4,19 @@ export default {
   name: '2022.05.03T15.58.13.org_rate_limits.sql',
   run: ({ sql }) => sql`
 ALTER TABLE
-  public.organizations
+  organizations
 ADD COLUMN
   limit_operations_monthly BIGINT NOT NULL DEFAULT 1000000;
 
 -- HOBBY plan is default
 ALTER TABLE
-  public.organizations
+  organizations
 ADD COLUMN
   limit_schema_push_monthly BIGINT NOT NULL DEFAULT 50;
 
 -- HOBBY plan is default
 ALTER TABLE
-  public.organizations
+  organizations
 ADD COLUMN
   limit_retention_days BIGINT NOT NULL DEFAULT 3;
 

--- a/packages/migrations/src/actions/2022.05.04T11.01.22.billing_plans.ts
+++ b/packages/migrations/src/actions/2022.05.04T11.01.22.billing_plans.ts
@@ -4,15 +4,15 @@ export default {
   name: '2022.05.04T11.01.22.billing_plans.sql',
   run: ({ sql }) => sql`
 CREATE TABLE
-  public.organizations_billing (
-    organization_id UUID NOT NULL REFERENCES public.organizations (id) ON DELETE CASCADE, -- org id 
+  organizations_billing (
+    organization_id UUID NOT NULL REFERENCES organizations (id) ON DELETE CASCADE, -- org id 
     external_billing_reference_id VARCHAR(255) NOT NULL, -- stripe customer id
     billing_email_address VARCHAR(255),
     PRIMARY KEY (organization_id)
   );
 
 ALTER TABLE
-  public.organizations
+  organizations
 ADD COLUMN
   plan_name VARCHAR(50) NOT NULL DEFAULT 'HOBBY';
 `,

--- a/packages/migrations/src/actions/2022.05.05T08.05.35.commits-metadata.ts
+++ b/packages/migrations/src/actions/2022.05.05T08.05.35.commits-metadata.ts
@@ -4,7 +4,7 @@ export default {
   name: '2022.05.05T08.05.35.commits-metadata.sql',
   run: ({ sql }) => sql`
 ALTER TABLE
-  public.commits
+  commits
 ADD COLUMN
   "metadata" TEXT;
 `,

--- a/packages/migrations/src/actions/2022.07.07T12.15.10.no-schema-pushes-limit.ts
+++ b/packages/migrations/src/actions/2022.07.07T12.15.10.no-schema-pushes-limit.ts
@@ -4,7 +4,7 @@ export default {
   name: '2022.07.07T12.15.10.no-schema-pushes-limit.sql',
   run: ({ sql }) => sql`
 ALTER TABLE
-  public.organizations
+  organizations
 DROP COLUMN
   limit_schema_push_monthly;
 `,

--- a/packages/migrations/src/actions/2022.07.11T10.09.41.get-started-wizard.ts
+++ b/packages/migrations/src/actions/2022.07.11T10.09.41.get-started-wizard.ts
@@ -5,7 +5,7 @@ export default {
   run: ({ sql }) => sql`
 -- Tracks feature discovery progress
 ALTER TABLE
-  public.organizations
+  organizations
 ADD COLUMN
   get_started_creating_project BOOLEAN NOT NULL DEFAULT FALSE,
 ADD COLUMN
@@ -20,7 +20,7 @@ ADD COLUMN
   get_started_usage_breaking BOOLEAN NOT NULL DEFAULT FALSE;
 
 UPDATE
-  public.organizations
+  organizations
 SET
   get_started_creating_project = TRUE
 WHERE
@@ -28,13 +28,13 @@ WHERE
     SELECT
       org_id
     FROM
-      public.projects
+      projects
     GROUP BY
       org_id
   );
 
 UPDATE
-  public.organizations
+  organizations
 SET
   get_started_publishing_schema = TRUE
 WHERE
@@ -42,14 +42,14 @@ WHERE
     SELECT
       p.org_id
     FROM
-      public.commits AS c
-      INNER JOIN public.projects AS p ON p.id = c.project_id
+      commits AS c
+      INNER JOIN projects AS p ON p.id = c.project_id
     GROUP BY
       p.org_id
   );
 
 UPDATE
-  public.organizations
+  organizations
 SET
   get_started_inviting_members = TRUE
 WHERE
@@ -57,7 +57,7 @@ WHERE
     SELECT
       organization_id
     FROM
-      public.organization_member
+      organization_member
     GROUP BY
       organization_id
     HAVING
@@ -65,7 +65,7 @@ WHERE
   );
 
 UPDATE
-  public.organizations
+  organizations
 SET
   get_started_usage_breaking = TRUE
 WHERE
@@ -73,8 +73,8 @@ WHERE
     SELECT
       p.org_id
     FROM
-      public.targets AS t
-      INNER JOIN public.projects AS p ON p.id = t.project_id
+      targets AS t
+      INNER JOIN projects AS p ON p.id = t.project_id
     WHERE
       t.validation_enabled IS TRUE
   );

--- a/packages/migrations/src/actions/2022.07.11T20.09.37.migrate-pro-hobby-retention.ts
+++ b/packages/migrations/src/actions/2022.07.11T20.09.37.migrate-pro-hobby-retention.ts
@@ -5,7 +5,7 @@ export default {
   run: ({ sql }) => sql`
 -- Update Hobby with 3d to 7d
 UPDATE
-  public.organizations
+  organizations
 SET
   limit_retention_days = 7
 WHERE
@@ -14,7 +14,7 @@ WHERE
 
 -- Update Pro with 180d to 90d
 UPDATE
-  public.organizations
+  organizations
 SET
   limit_retention_days = 90
 WHERE

--- a/packages/migrations/src/actions/2022.07.18T10.10.44.target-validation-client-exclusion.ts
+++ b/packages/migrations/src/actions/2022.07.18T10.10.44.target-validation-client-exclusion.ts
@@ -4,7 +4,7 @@ export default {
   name: '2022.07.18T10.10.44.target-validation-client-exclusion.sql',
   run: ({ sql }) => sql`
 ALTER TABLE
-  public.targets
+  targets
 ADD COLUMN
   validation_excluded_clients TEXT[];
 `,

--- a/packages/migrations/src/actions/2022.08.25T09.59.16.multiple-invitation-codes.ts
+++ b/packages/migrations/src/actions/2022.08.25T09.59.16.multiple-invitation-codes.ts
@@ -4,13 +4,13 @@ export default {
   name: '2022.08.25T09.59.16.multiple-invitation-codes.sql',
   run: ({ sql }) => sql`
 ALTER TABLE
-  public.organizations
+  organizations
 DROP COLUMN
   invite_code;
 
 CREATE TABLE
-  public.organization_invitations (
-    organization_id UUID NOT NULL REFERENCES public.organizations (id) ON DELETE CASCADE,
+  organization_invitations (
+    organization_id UUID NOT NULL REFERENCES organizations (id) ON DELETE CASCADE,
     code VARCHAR(10) NOT NULL UNIQUE DEFAULT SUBSTR(MD5(RANDOM()::TEXT), 0, 10),
     email VARCHAR(320) NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),

--- a/packages/migrations/src/actions/2022.08.26T06.23.24.add-supertokens-id.ts
+++ b/packages/migrations/src/actions/2022.08.26T06.23.24.add-supertokens-id.ts
@@ -4,7 +4,7 @@ export default {
   name: '2022.08.26T06.23.24.add-supertokens-id.sql',
   run: ({ sql }) => sql`
 ALTER TABLE
-  public.users
+  users
 ADD COLUMN
   supertoken_user_id VARCHAR(50),
 ADD

--- a/packages/migrations/src/actions/2022.09.14T16.09.43.external-projects.ts
+++ b/packages/migrations/src/actions/2022.09.14T16.09.43.external-projects.ts
@@ -4,7 +4,7 @@ export default {
   name: '2022.09.14T16.09.43.external-projects.sql',
   run: ({ sql }) => sql`
 ALTER TABLE
-  public.projects
+  projects
 ADD COLUMN
   external_composition_enabled BOOLEAN NOT NULL DEFAULT FALSE,
 ADD COLUMN

--- a/packages/migrations/src/actions/2022.12.03T09.12.28.organization-transfer.ts
+++ b/packages/migrations/src/actions/2022.12.03T09.12.28.organization-transfer.ts
@@ -4,9 +4,9 @@ export default {
   name: '2022.12.03T09.12.28.organization-transfer.sql',
   run: ({ sql }) => sql`
 ALTER TABLE
-  public.organizations
+  organizations
 ADD COLUMN
-  ownership_transfer_user_id UUID REFERENCES public.users (id),
+  ownership_transfer_user_id UUID REFERENCES users (id),
 ADD COLUMN
   ownership_transfer_code VARCHAR(10),
 ADD COLUMN

--- a/packages/migrations/src/actions/2023.01.04T17.00.23.hobby-7-by-default.ts
+++ b/packages/migrations/src/actions/2023.01.04T17.00.23.hobby-7-by-default.ts
@@ -5,7 +5,7 @@ export default {
   run: ({ sql }) => sql`
 -- Update Hobby with 3d to 7d - personal orgs were created with the default value of 3d
 UPDATE
-  public.organizations
+  organizations
 SET
   limit_retention_days = 7
 WHERE
@@ -14,7 +14,7 @@ WHERE
 
 -- Update limit_retention_days default value to 7
 ALTER TABLE
-  public.organizations
+  organizations
 ALTER COLUMN
   limit_retention_days
 SET DEFAULT

--- a/packages/migrations/src/actions/2023.02.22T09.27.02.delete-personal-org.ts
+++ b/packages/migrations/src/actions/2023.02.22T09.27.02.delete-personal-org.ts
@@ -5,14 +5,14 @@ export default {
   run: ({ sql }) => sql`
 -- Find and delete all organizations of type PERSONAL that have no projects
 DELETE FROM
-  public.organizations AS o
+  organizations AS o
 WHERE
   o.type = 'PERSONAL'
   AND NOT EXISTS (
     SELECT
       id
     FROM
-      public.projects AS p
+      projects AS p
     WHERE
       p.org_id = o.id
     LIMIT
@@ -21,7 +21,7 @@ WHERE
 
 -- Delete the "type" column from organizations
 ALTER TABLE
-  public.organizations
+  organizations
 DROP COLUMN
 TYPE;
 

--- a/packages/migrations/src/actions/2023.03.14T12.14.23.schema-policy.ts
+++ b/packages/migrations/src/actions/2023.03.14T12.14.23.schema-policy.ts
@@ -7,7 +7,7 @@ CREATE TYPE
   schema_policy_resource AS ENUM('ORGANIZATION', 'PROJECT');
 
 CREATE TABLE
-  public.schema_policy_config (
+  schema_policy_config (
     resource_type schema_policy_resource NOT NULL,
     resource_id UUID NOT NULL,
     created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),

--- a/packages/migrations/src/actions/2023.03.29T11.42.44.feature-flags.ts
+++ b/packages/migrations/src/actions/2023.03.29T11.42.44.feature-flags.ts
@@ -4,7 +4,7 @@ export default {
   name: '2023.03.29T11.42.44.feature-flags.sql',
   run: ({ sql }) => sql`
 ALTER TABLE
-  public.organizations
+  organizations
 ADD COLUMN
   feature_flags JSONB
   `,

--- a/packages/migrations/src/actions/2023.06.01T09.07.53.create_collections.ts
+++ b/packages/migrations/src/actions/2023.06.01T09.07.53.create_collections.ts
@@ -3,12 +3,12 @@ import { type MigrationExecutor } from '../pg-migrator';
 export default {
   name: '2023.06.01T09.07.53.create_collections.sql',
   run: ({ sql }) => sql`
-CREATE TABLE public."document_collections" (
+CREATE TABLE "document_collections" (
   "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
   "title" text NOT NULL,
   "description" text,
-  "target_id" uuid NOT NULL REFERENCES public."targets"("id") ON DELETE CASCADE,
-  "created_by_user_id" uuid REFERENCES public."users"("id") ON DELETE SET NULL,
+  "target_id" uuid NOT NULL REFERENCES "targets"("id") ON DELETE CASCADE,
+  "created_by_user_id" uuid REFERENCES "users"("id") ON DELETE SET NULL,
   "created_at" timestamptz NOT NULL DEFAULT now(),
   "updated_at" timestamptz NOT NULL DEFAULT now(),
   PRIMARY KEY ("id")
@@ -20,14 +20,14 @@ CREATE INDEX "document_collections_connection_pagination" ON "document_collectio
   "id" DESC
 );
 
-CREATE TABLE public."document_collection_documents" (
+CREATE TABLE "document_collection_documents" (
   "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
   "title" text NOT NULL,
   "contents" text NOT NULL,
   "variables" text,
   "headers" text,
-  "created_by_user_id" uuid REFERENCES public."users"("id") ON DELETE SET NULL,
-  "document_collection_id" uuid NOT NULL REFERENCES public."document_collections"("id") ON DELETE CASCADE,
+  "created_by_user_id" uuid REFERENCES "users"("id") ON DELETE SET NULL,
+  "document_collection_id" uuid NOT NULL REFERENCES "document_collections"("id") ON DELETE CASCADE,
   "created_at" timestamptz NOT NULL DEFAULT now(),
   "updated_at" timestamptz NOT NULL DEFAULT now(),
   PRIMARY KEY ("id")

--- a/packages/migrations/test/2023.02.22T09.27.02.delete-personal-org.test.ts
+++ b/packages/migrations/test/2023.02.22T09.27.02.delete-personal-org.test.ts
@@ -15,18 +15,18 @@ await describe('drop-personal-org', async () => {
       const user = await seed.user();
       const emptyOrgs = await Promise.all([
         db.one(
-          sql`INSERT INTO public.organizations (clean_id, name, user_id, type) VALUES ('personal-empty', 'personal-empty', ${user.id}, 'PERSONAL') RETURNING *;`,
+          sql`INSERT INTO organizations (clean_id, name, user_id, type) VALUES ('personal-empty', 'personal-empty', ${user.id}, 'PERSONAL') RETURNING *;`,
         ),
         db.one(
-          sql`INSERT INTO public.organizations (clean_id, name, user_id, type) VALUES ('regular-empty', 'regular-empty', ${user.id}, 'REGULAR') RETURNING *;`,
+          sql`INSERT INTO organizations (clean_id, name, user_id, type) VALUES ('regular-empty', 'regular-empty', ${user.id}, 'REGULAR') RETURNING *;`,
         ),
       ]);
       const orgsWithProjects = await Promise.all([
         await db.one<DbTypes.organizations>(
-          sql`INSERT INTO public.organizations (clean_id, name, user_id, type) VALUES ('personal-project', 'personal-project', ${user.id}, 'PERSONAL') RETURNING *;`,
+          sql`INSERT INTO organizations (clean_id, name, user_id, type) VALUES ('personal-project', 'personal-project', ${user.id}, 'PERSONAL') RETURNING *;`,
         ),
         await db.one<DbTypes.organizations>(
-          sql`INSERT INTO public.organizations (clean_id, name, user_id, type) VALUES ('regular-project', 'regular-project', ${user.id}, 'PERSONAL') RETURNING *;`,
+          sql`INSERT INTO organizations (clean_id, name, user_id, type) VALUES ('regular-project', 'regular-project', ${user.id}, 'PERSONAL') RETURNING *;`,
         ),
       ]);
 
@@ -53,22 +53,22 @@ await describe('drop-personal-org', async () => {
 
       // Only this one should be deleted, the rest should still exists
       assert.equal(
-        await db.maybeOne(sql`SELECT * FROM public.organizations WHERE id = ${emptyOrgs[0].id}`),
+        await db.maybeOne(sql`SELECT * FROM organizations WHERE id = ${emptyOrgs[0].id}`),
         null,
       );
       assert.notEqual(
-        await db.maybeOne(sql`SELECT * FROM public.organizations WHERE id = ${emptyOrgs[1].id}`),
+        await db.maybeOne(sql`SELECT * FROM organizations WHERE id = ${emptyOrgs[1].id}`),
         null,
       );
       assert.notEqual(
         await db.maybeOne(
-          sql`SELECT * FROM public.organizations WHERE id = ${orgsWithProjects[0].id}`,
+          sql`SELECT * FROM organizations WHERE id = ${orgsWithProjects[0].id}`,
         ),
         null,
       );
       assert.notEqual(
         await db.maybeOne(
-          sql`SELECT * FROM public.organizations WHERE id = ${orgsWithProjects[1].id}`,
+          sql`SELECT * FROM organizations WHERE id = ${orgsWithProjects[1].id}`,
         ),
         null,
       );

--- a/packages/migrations/test/2023.09.25T15.23.00.github-check-with-project-name.test.ts
+++ b/packages/migrations/test/2023.09.25T15.23.00.github-check-with-project-name.test.ts
@@ -44,7 +44,7 @@ await describe('github-check-with-project-name', async () => {
       // Check that the old project has github_check_with_project_name = FALSE
       assert.equal(
         await db.oneFirst(
-          sql`SELECT github_check_with_project_name FROM public.projects WHERE id = ${oldProject.id}`,
+          sql`SELECT github_check_with_project_name FROM projects WHERE id = ${oldProject.id}`,
         ),
         false,
       );
@@ -52,7 +52,7 @@ await describe('github-check-with-project-name', async () => {
       // Check that the new project has github_check_with_project_name = TRUE
       assert.equal(
         await db.oneFirst(
-          sql`SELECT github_check_with_project_name FROM public.projects WHERE id = ${newProject.id}`,
+          sql`SELECT github_check_with_project_name FROM projects WHERE id = ${newProject.id}`,
         ),
         true,
       );

--- a/packages/migrations/test/2023.11.02T14.41.41.schema-checks-dedup.test.ts
+++ b/packages/migrations/test/2023.11.02T14.41.41.schema-checks-dedup.test.ts
@@ -51,17 +51,17 @@ await describe('migration: schema-checks-dedup', async () => {
       const organization = await db.one<{
         id: string;
       }>(
-        sql`INSERT INTO public.organizations (clean_id, name, user_id) VALUES ('org-1', 'org-1', ${user.id}) RETURNING id;`,
+        sql`INSERT INTO organizations (clean_id, name, user_id) VALUES ('org-1', 'org-1', ${user.id}) RETURNING id;`,
       );
       const project = await db.one<{
         id: string;
       }>(
-        sql`INSERT INTO public.projects (clean_id, name, type, org_id) VALUES ('proj-1', 'proj-1', 'SINGLE', ${organization.id}) RETURNING id;`,
+        sql`INSERT INTO projects (clean_id, name, type, org_id) VALUES ('proj-1', 'proj-1', 'SINGLE', ${organization.id}) RETURNING id;`,
       );
       const target = await db.one<{
         id: string;
       }>(
-        sql`INSERT INTO public.targets (clean_id, name, project_id) VALUES ('proj-1', 'proj-1', ${project.id}) RETURNING id;`,
+        sql`INSERT INTO targets (clean_id, name, project_id) VALUES ('proj-1', 'proj-1', ${project.id}) RETURNING id;`,
       );
 
       const compositeSchemaSDL = `composite schema 1`;
@@ -76,7 +76,7 @@ await describe('migration: schema-checks-dedup', async () => {
         id: string;
       }>(
         sql`
-          INSERT INTO public.schema_log
+          INSERT INTO schema_log
               (
                 author,
                 commit,
@@ -102,7 +102,7 @@ await describe('migration: schema-checks-dedup', async () => {
         id: string;
       }>(
         sql`
-        INSERT INTO public.schema_versions
+        INSERT INTO schema_versions
         (
           is_composable,
           target_id,

--- a/packages/migrations/test/utils/testkit.ts
+++ b/packages/migrations/test/utils/testkit.ts
@@ -66,7 +66,7 @@ export async function initMigrationTestingEnvironment() {
         }
 
         return await slonik.one<DbTypes.users>(
-          sql`INSERT INTO public.users (email, display_name, full_name, supertoken_user_id) VALUES (${user.email}, ${user.display_name} , ${user.full_name}, ${user.supertoken_user_id ?? null}) RETURNING *;`,
+          sql`INSERT INTO users (email, display_name, full_name, supertoken_user_id) VALUES (${user.email}, ${user.display_name} , ${user.full_name}, ${user.supertoken_user_id ?? null}) RETURNING *;`,
         );
       },
       async organization({ user, organization }: {
@@ -77,7 +77,7 @@ export async function initMigrationTestingEnvironment() {
         }
       }) {
         return await slonik.one<DbTypes.organizations>(
-          sql`INSERT INTO public.organizations (clean_id, name, user_id) VALUES (${organization.cleanId}, ${organization.name}, ${user.id}) RETURNING *`,
+          sql`INSERT INTO organizations (clean_id, name, user_id) VALUES (${organization.cleanId}, ${organization.name}, ${user.id}) RETURNING *`,
         );
       },
       async project({ organization, project }: {
@@ -89,7 +89,7 @@ export async function initMigrationTestingEnvironment() {
         }
       }) {
         return await slonik.one<DbTypes.projects>(
-          sql`INSERT INTO public.projects (clean_id, name, type, org_id) VALUES (${project.cleanId}, ${project.name}, ${project.type}, ${organization.id}) RETURNING *`,
+          sql`INSERT INTO projects (clean_id, name, type, org_id) VALUES (${project.cleanId}, ${project.name}, ${project.type}, ${organization.id}) RETURNING *`,
         );
       },
       async target({ project, target }: {
@@ -100,7 +100,7 @@ export async function initMigrationTestingEnvironment() {
         }
       }) {
         return await slonik.one<DbTypes.targets>(
-          sql`INSERT INTO public.targets (name, clean_id, project_id) VALUES (${target.name}, ${target.cleanId}, ${project.id}) RETURNING *`,
+          sql`INSERT INTO targets (name, clean_id, project_id) VALUES (${target.name}, ${target.cleanId}, ${project.id}) RETURNING *`,
         );
       }
     },

--- a/packages/services/storage/src/tokens.ts
+++ b/packages/services/storage/src/tokens.ts
@@ -21,7 +21,7 @@ export async function createTokenStorage(connection: string, maximumPoolSize: nu
       const result = await pool.query<Slonik<tokens>>(
         sql`
           SELECT *
-          FROM public.tokens
+          FROM tokens
           WHERE
             target_id = ${target}
             AND deleted_at IS NULL
@@ -35,7 +35,7 @@ export async function createTokenStorage(connection: string, maximumPoolSize: nu
       return pool.maybeOne<Slonik<tokens>>(
         sql`
           SELECT *
-          FROM public.tokens
+          FROM tokens
           WHERE token = ${token} AND deleted_at IS NULL
           LIMIT 1
         `,
@@ -60,7 +60,7 @@ export async function createTokenStorage(connection: string, maximumPoolSize: nu
     }) {
       return pool.one<Slonik<tokens>>(
         sql`
-          INSERT INTO public.tokens
+          INSERT INTO tokens
             (name, token, token_alias, target_id, project_id, organization_id, scopes)
           VALUES
             (${name}, ${token}, ${tokenAlias}, ${target}, ${project}, ${organization}, ${sql.array(
@@ -74,13 +74,13 @@ export async function createTokenStorage(connection: string, maximumPoolSize: nu
     async deleteToken({ token }: { token: string }) {
       await pool.query(
         sql`
-          UPDATE public.tokens SET deleted_at = NOW() WHERE token = ${token}
+          UPDATE tokens SET deleted_at = NOW() WHERE token = ${token}
         `,
       );
     },
     async touchTokens({ tokens }: { tokens: Array<{ token: string; date: Date }> }) {
       await pool.query(sql`
-        UPDATE public.tokens as t
+        UPDATE tokens as t
         SET last_used_at = c.last_used_at
         FROM (
             VALUES


### PR DESCRIPTION
### Background

This PR fixes a bug which I found when I have used PostgreSQL user with a not default schema set via `search_path` - migration scripts were failing.

### Description

Fixes: https://github.com/kamilkisiela/graphql-hive/issues/3502

There should be no schema hardcoded (as a prefix) in SQL statements. `public` schema is a default one anyway.

### Checklist

- [x] pnpm test
- [ ] pnpm test:integration