### PR TITLE
Support Apollo Client directives in hive operations:check

### DIFF
--- a/.changeset/sweet-dots-relate.md
+++ b/.changeset/sweet-dots-relate.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': minor
+---
+
+Support Apollo Client directives in operations:check command (pass --apolloClient flag)


### PR DESCRIPTION
As we don't want to allow users to pass JSON object with GraphQL Inspector specific configuration (version of @graphql-inspector/core may change over time and it could lead to breaking changes at Hive CLI level),  we prefer to control the available flags and support them long term by moving some logic into Hive CLI.
This way we are aware of the actual usage of these flags and can predict/prevent breaking change.

Closes #3356