### PR TITLE
Use sql.unnest for inserting large set or rows

### DIFF
--- a/packages/libraries/client/src/version.ts
+++ b/packages/libraries/client/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.26.0';
+export const version = '0.27.0';


### PR DESCRIPTION
`sql.unnest` creates a variable per every column; values for each column are passed as an array.
The previous solution created too many variable and we reached the limit a few times.

Fixes #3594