### PR TITLE
Fix Slack's "goodbye" message to the deleted channel

### DIFF
--- a/packages/services/api/src/modules/alerts/providers/adapters/slack.ts
+++ b/packages/services/api/src/modules/alerts/providers/adapters/slack.ts
@@ -85,9 +85,10 @@ export class SlackCommunicationAdapter implements CommunicationAdapter {
 
   async sendChannelConfirmation(input: ChannelConfirmationInput) {
     this.logger.debug(
-      `Sending Channel Confirmation over Slack (organization=%s, project=%s)`,
+      `Sending Channel Confirmation over Slack (organization=%s, project=%s, channel=%s)`,
       input.event.organization.id,
       input.event.project.id,
+      input.channel.slackChannel,
     );
 
     const token = input.integrations.slack.token;

--- a/packages/services/api/src/modules/alerts/providers/alerts-manager.ts
+++ b/packages/services/api/src/modules/alerts/providers/alerts-manager.ts
@@ -274,7 +274,7 @@ export class AlertsManager {
 
       await this.slack.sendChannelConfirmation({
         event: {
-          kind: 'created',
+          kind: input.kind,
           organization: {
             id: organization.id,
             cleanId: organization.cleanId,

--- a/packages/web/docs/src/pages/docs/management/projects.mdx
+++ b/packages/web/docs/src/pages/docs/management/projects.mdx
@@ -135,6 +135,10 @@ Hive project:
   className="mt-6 max-w-sm rounded-lg drop-shadow-md"
 />
 
+<Callout type="info">
+  To send messages to private channels, invite the @GraphQLHive account first. Without this invitation, our Slack app will be unable to post messages to the channel.
+</Callout>
+
 #### HTTP Webhook
 
 You can implement a custom HTTP webhook to receive alerts and notifications from Hive, when an alert

--- a/packages/web/docs/src/pages/docs/management/projects.mdx
+++ b/packages/web/docs/src/pages/docs/management/projects.mdx
@@ -136,7 +136,8 @@ Hive project:
 />
 
 <Callout type="info">
-  To send messages to private channels, invite the @GraphQLHive account first. Without this invitation, our Slack app will be unable to post messages to the channel.
+  To send messages to private channels, invite the @GraphQLHive account first. Without this
+  invitation, our Slack app will be unable to post messages to the channel.
 </Callout>
 
 #### HTTP Webhook


### PR DESCRIPTION
- explain private channels in docs
- add channel name to the printed log