### PR TITLE
Allow to enable native Federation composition

### DIFF
--- a/codegen.mts
+++ b/codegen.mts
@@ -27,6 +27,8 @@ const config: CodegenConfig = {
         contextType: 'GraphQLModules.ModuleContext',
         enumValues: {
           ProjectType: '../shared/entities#ProjectType',
+          NativeFederationCompatibilityStatus:
+            '../shared/entities#NativeFederationCompatibilityStatus',
           TargetAccessScope: '../modules/auth/providers/target-access#TargetAccessScope',
           ProjectAccessScope: '../modules/auth/providers/project-access#ProjectAccessScope',
           OrganizationAccessScope:

--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -28,6 +28,7 @@
     "@sentry/types": "7.86.0",
     "@slack/web-api": "6.10.0",
     "@theguild/buddy": "0.1.0",
+    "@theguild/federation-composition": "0.4.0",
     "@trpc/client": "10.44.1",
     "@trpc/server": "10.44.1",
     "@types/bcryptjs": "2.4.6",

--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -28,7 +28,7 @@
     "@sentry/types": "7.86.0",
     "@slack/web-api": "6.10.0",
     "@theguild/buddy": "0.1.0",
-    "@theguild/federation-composition": "0.4.0",
+    "@theguild/federation-composition": "0.5.0",
     "@trpc/client": "10.44.1",
     "@trpc/server": "10.44.1",
     "@types/bcryptjs": "2.4.6",

--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -16,6 +16,7 @@ export default gql`
     schemaDelete(input: SchemaDeleteInput!): SchemaDeleteResult!
     updateSchemaVersionStatus(input: SchemaVersionUpdateInput!): SchemaVersion!
     updateBaseSchema(input: UpdateBaseSchemaInput!): UpdateBaseSchemaResult!
+    updateNativeFederation(input: UpdateNativeFederationInput!): UpdateNativeFederationResult!
     enableExternalSchemaComposition(
       input: EnableExternalSchemaCompositionInput!
     ): EnableExternalSchemaCompositionResult!
@@ -53,6 +54,24 @@ export default gql`
     testExternalSchemaComposition(
       selector: TestExternalSchemaCompositionInput!
     ): TestExternalSchemaCompositionResult!
+  }
+
+  input UpdateNativeFederationInput {
+    organization: ID!
+    project: ID!
+    enabled: Boolean!
+  }
+
+  """
+  @oneOf
+  """
+  type UpdateNativeFederationResult {
+    ok: Project
+    error: UpdateNativeFederationError
+  }
+
+  type UpdateNativeFederationError implements Error {
+    message: String!
   }
 
   input DisableExternalSchemaCompositionInput {
@@ -132,10 +151,18 @@ export default gql`
     registryModel: RegistryModel!
     schemaVersionsCount(period: DateRangeInput): Int!
     isNativeFederationEnabled: Boolean!
+    nativeFederationCompatibility: NativeFederationCompatibilityStatus!
   }
 
   extend type Target {
     schemaVersionsCount(period: DateRangeInput): Int!
+  }
+
+  enum NativeFederationCompatibilityStatus {
+    COMPATIBLE
+    INCOMPATIBLE
+    UNKNOWN
+    NOT_APPLICABLE
   }
 
   type EnableExternalSchemaCompositionError implements Error {

--- a/packages/services/api/src/modules/schema/providers/orchestrators/federation.ts
+++ b/packages/services/api/src/modules/schema/providers/orchestrators/federation.ts
@@ -67,7 +67,10 @@ export class FederationOrchestrator implements Orchestrator {
       native: boolean;
     },
   ) {
-    this.logger.debug('Composing and Validating Federated Schemas');
+    this.logger.debug(
+      'Composing and Validating Federated Schemas (method=%s)',
+      config.native ? 'native' : config.external.enabled ? 'external' : 'v1',
+    );
     const result = await this.schemaService.composeAndValidate.mutate({
       type: 'federation',
       schemas: schemas.map(s => ({

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -257,6 +257,12 @@ export interface Storage {
     _: ProjectSelector & Pick<Project, 'name' | 'cleanId'> & { user: string },
   ): Promise<Project | never>;
 
+  updateNativeSchemaComposition(
+    _: ProjectSelector & {
+      enabled: boolean;
+    },
+  ): Promise<Project>;
+
   enableExternalSchemaComposition(
     _: ProjectSelector & {
       endpoint: string;

--- a/packages/services/api/src/shared/entities.ts
+++ b/packages/services/api/src/shared/entities.ts
@@ -157,6 +157,13 @@ export enum ProjectType {
   SINGLE = 'SINGLE',
 }
 
+export enum NativeFederationCompatibilityStatus {
+  COMPATIBLE = 'COMPATIBLE',
+  INCOMPATIBLE = 'INCOMPATIBLE',
+  UNKNOWN = 'UNKNOWN',
+  NOT_APPLICABLE = 'NOT_APPLICABLE',
+}
+
 export interface OrganizationGetStarted {
   id: string;
   creatingProject: boolean;

--- a/packages/web/app/pages/[organizationId]/[projectId]/view/settings.tsx
+++ b/packages/web/app/pages/[organizationId]/[projectId]/view/settings.tsx
@@ -8,6 +8,7 @@ import { authenticated } from '@/components/authenticated-container';
 import { Page, ProjectLayout } from '@/components/layouts/project';
 import { ExternalCompositionSettings } from '@/components/project/settings/external-composition';
 import { ModelMigrationSettings } from '@/components/project/settings/model-migration';
+import { NativeCompositionSettings } from '@/components/project/settings/native-composition';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -194,6 +195,7 @@ const ProjectSettingsPage_OrganizationFragment = graphql(`
       ...CanAccessProject_MemberFragment
     }
     ...ExternalCompositionSettings_OrganizationFragment
+    ...NativeCompositionSettings_OrganizationFragment
   }
 `);
 
@@ -204,6 +206,7 @@ const ProjectSettingsPage_ProjectFragment = graphql(`
     isProjectNameInGitHubCheckEnabled
     ...ModelMigrationSettings_ProjectFragment
     ...ExternalCompositionSettings_ProjectFragment
+    ...NativeCompositionSettings_ProjectFragment
   }
 `);
 
@@ -362,6 +365,10 @@ function ProjectSettingsContent() {
 
                 {project.type === ProjectType.Federation ? (
                   <ExternalCompositionSettings project={project} organization={organization} />
+                ) : null}
+
+                {project.type === ProjectType.Federation ? (
+                  <NativeCompositionSettings project={project} organization={organization} />
                 ) : null}
 
                 {canAccessProject(ProjectAccessScope.Delete, organization.me) && (

--- a/packages/web/app/src/components/project/settings/external-composition.tsx
+++ b/packages/web/app/src/components/project/settings/external-composition.tsx
@@ -3,7 +3,7 @@ import { useFormik } from 'formik';
 import { useMutation, useQuery } from 'urql';
 import * as Yup from 'yup';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { DocsLink, DocsNote, Input, Spinner, Switch, Tooltip } from '@/components/v2';
 import { ProductUpdatesLink } from '@/components/v2/docs-note';
 import { FragmentType, graphql, useFragment } from '@/gql';
@@ -307,10 +307,6 @@ export const ExternalCompositionSettings = (props: {
     [disableComposition, setEnabled, notify],
   );
 
-  if (project.isNativeFederationEnabled) {
-    return null;
-  }
-
   const externalCompositionConfig = projectQuery.data?.project?.externalSchemaComposition;
   const initialEnabled = !!externalCompositionConfig;
   const isEnabled = typeof enabled === 'boolean' ? enabled : initialEnabled;
@@ -335,13 +331,14 @@ export const ExternalCompositionSettings = (props: {
             )}
           </div>
         </CardTitle>
+        <CardDescription>
+          <ProductUpdatesLink href="#native-composition">
+            You can enable native Apollo Federation v2 support in Hive
+          </ProductUpdatesLink>
+        </CardDescription>
       </CardHeader>
 
       <CardContent>
-        <ProductUpdatesLink href="2023-10-10-native-federation-2">
-          We're rolling out native Apollo Federation support in Hive!
-        </ProductUpdatesLink>
-
         <DocsNote>
           External Schema Composition is required for using Apollo Federation 2 with Hive.
           <br />

--- a/packages/web/app/src/components/project/settings/native-composition.tsx
+++ b/packages/web/app/src/components/project/settings/native-composition.tsx
@@ -1,0 +1,238 @@
+import { useCallback } from 'react';
+import Link from 'next/link';
+import { FlaskConicalIcon, HeartCrackIcon, PartyPopperIcon, RefreshCcwIcon } from 'lucide-react';
+import { useMutation } from 'urql';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { useToast } from '@/components/ui/use-toast';
+import { ProductUpdatesLink } from '@/components/v2/docs-note';
+import { FragmentType, graphql, useFragment } from '@/gql';
+import { NativeFederationCompatibilityStatus } from '@/gql/graphql';
+
+const NativeCompositionSettings_OrganizationFragment = graphql(`
+  fragment NativeCompositionSettings_OrganizationFragment on Organization {
+    id
+    cleanId
+  }
+`);
+
+const NativeCompositionSettings_ProjectFragment = graphql(`
+  fragment NativeCompositionSettings_ProjectFragment on Project {
+    id
+    cleanId
+    nativeFederationCompatibility
+    isNativeFederationEnabled
+    externalSchemaComposition {
+      endpoint
+    }
+  }
+`);
+
+const NativeCompositionSettings_UpdateNativeCompositionMutation = graphql(`
+  mutation NativeCompositionSettings_UpdateNativeCompositionMutation(
+    $input: UpdateNativeFederationInput!
+  ) {
+    updateNativeFederation(input: $input) {
+      ok {
+        ...NativeCompositionSettings_ProjectFragment
+      }
+      error {
+        message
+      }
+    }
+  }
+`);
+
+export function NativeCompositionSettings(props: {
+  organization: FragmentType<typeof NativeCompositionSettings_OrganizationFragment>;
+  project: FragmentType<typeof NativeCompositionSettings_ProjectFragment>;
+}) {
+  const organization = useFragment(
+    NativeCompositionSettings_OrganizationFragment,
+    props.organization,
+  );
+  const project = useFragment(NativeCompositionSettings_ProjectFragment, props.project);
+  const [mutationState, mutate] = useMutation(
+    NativeCompositionSettings_UpdateNativeCompositionMutation,
+  );
+  const { toast } = useToast();
+
+  const update = useCallback(
+    async (enabled: boolean) => {
+      const action = enabled ? 'enabled' : 'disabled';
+
+      try {
+        const result = await mutate({
+          input: {
+            organization: organization.cleanId,
+            project: project.cleanId,
+            enabled,
+          },
+        });
+
+        if (result.error) {
+          toast({
+            variant: 'destructive',
+            title: `Failed to ${action} native composition`,
+            description: result.error.message,
+          });
+        } else if (result.data?.updateNativeFederation.error) {
+          toast({
+            variant: 'destructive',
+            title: `Failed to ${action} native composition`,
+            description: result.data.updateNativeFederation.error.message,
+          });
+        } else if (result.data?.updateNativeFederation.ok) {
+          toast({
+            title: `Successfully ${action} native composition`,
+            description: enabled
+              ? project.externalSchemaComposition?.endpoint
+                ? 'You can now disable external composition in your project settings.'
+                : 'Your project is now using our Open Source composition library for Apollo Federation.'
+              : 'Your project is no longer using our Open Source composition library for Apollo Federation.',
+          });
+        }
+      } catch (error) {
+        console.log(`Failed to ${action} native composition`);
+        console.error(error);
+        toast({
+          variant: 'destructive',
+          title: `Failed to ${action} native composition`,
+          description: String(error),
+        });
+      }
+    },
+    [mutate, toast, organization.cleanId, project.cleanId],
+  );
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <a id="native-composition">Native Composition</a>
+        </CardTitle>
+        <CardDescription>Native Apollo Federation v2 support for your project.</CardDescription>
+        {project.isNativeFederationEnabled ? null : (
+          <CardDescription>
+            <ProductUpdatesLink href="2023-10-10-native-federation-2">
+              Read the announcement!
+            </ProductUpdatesLink>
+          </CardDescription>
+        )}
+      </CardHeader>
+
+      {project.isNativeFederationEnabled ? null : (
+        <CardContent>
+          <div className="flex flex-row items-center gap-x-4">
+            <div>
+              {project.nativeFederationCompatibility ===
+              NativeFederationCompatibilityStatus.Compatible ? (
+                <PartyPopperIcon className="h-10 w-10 text-emerald-500" />
+              ) : null}
+              {project.nativeFederationCompatibility ===
+              NativeFederationCompatibilityStatus.Incompatible ? (
+                <HeartCrackIcon className="h-10 w-10 text-red-500" />
+              ) : null}
+              {project.nativeFederationCompatibility ===
+              NativeFederationCompatibilityStatus.Unknown ? (
+                <FlaskConicalIcon className="h-10 w-10 text-orange-500" />
+              ) : null}
+            </div>
+            <div>
+              <div className="text-base font-semibold">
+                {project.nativeFederationCompatibility ===
+                NativeFederationCompatibilityStatus.Compatible
+                  ? 'Your project is compatible'
+                  : null}
+                {project.nativeFederationCompatibility ===
+                NativeFederationCompatibilityStatus.Incompatible
+                  ? 'Your project is not yet supported'
+                  : null}
+                {project.nativeFederationCompatibility ===
+                NativeFederationCompatibilityStatus.Unknown
+                  ? 'Unclear whether your project is compatible'
+                  : null}
+              </div>
+              <div className="text-muted-foreground text-sm">
+                {project.nativeFederationCompatibility ===
+                NativeFederationCompatibilityStatus.Compatible ? (
+                  <>
+                    Subgraphs of this project are composed and validated correctly by our{' '}
+                    <Link
+                      className="text-muted-foreground font-semibold underline-offset-4 hover:underline"
+                      href="https://github.com/the-guild-org/federation"
+                    >
+                      Open Source composition library
+                    </Link>{' '}
+                    for Apollo Federation.
+                  </>
+                ) : null}
+                {project.nativeFederationCompatibility ===
+                NativeFederationCompatibilityStatus.Incompatible ? (
+                  <>
+                    Our{' '}
+                    <Link
+                      className="text-muted-foreground font-semibold underline-offset-4 hover:underline"
+                      href="https://github.com/the-guild-org/federation"
+                    >
+                      Open Source composition library
+                    </Link>{' '}
+                    is not yet compatible with subgraphs of your project. We're working on it!
+                  </>
+                ) : null}
+                {project.nativeFederationCompatibility ===
+                NativeFederationCompatibilityStatus.Unknown ? (
+                  <>
+                    Your project appears to lack any subgraphs at the moment, making it impossible
+                    for us to assess compatibility with our{' '}
+                    <Link
+                      className="text-muted-foreground font-semibold underline-offset-4 hover:underline"
+                      href="https://github.com/the-guild-org/federation"
+                    >
+                      Open Source composition library
+                    </Link>
+                    .
+                  </>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        </CardContent>
+      )}
+      <CardFooter>
+        <div className="flex flex-row items-center gap-x-2">
+          <Button
+            variant={project.isNativeFederationEnabled ? 'destructive' : 'default'}
+            onClick={() => update(!project.isNativeFederationEnabled)}
+            disabled={mutationState.fetching}
+          >
+            {mutationState.fetching ? (
+              <>
+                <RefreshCcwIcon className="mr-2 h-4 w-4 animate-spin" />
+                Please wait
+              </>
+            ) : project.isNativeFederationEnabled ? (
+              'Disable Native Composition'
+            ) : (
+              'Enable Native Composition'
+            )}
+          </Button>
+          <div>
+            <Button variant="link" className="text-orange-500" asChild>
+              <Link href="https://github.com/the-guild-org/federation?tab=readme-ov-file#compatibility">
+                Learn more about risks and compatibility with Apollo Composition
+              </Link>
+            </Button>
+          </div>
+        </div>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/packages/web/app/src/components/v2/docs-note.tsx
+++ b/packages/web/app/src/components/v2/docs-note.tsx
@@ -59,19 +59,26 @@ export const ProductUpdatesLink = ({
   children?: React.ReactNode;
   className?: string;
 }) => {
-  const fullUrl = href.startsWith('http') ? href : getProductUpdatesUrl(href);
+  const fullUrl = href.startsWith('http')
+    ? href
+    : href.startsWith('#')
+      ? href
+      : getProductUpdatesUrl(href);
+
+  const isExternal = !href.startsWith('#');
 
   return (
     <Button variant="link" className={cn('p-0 text-blue-500', className)} asChild>
       <NextLink
         href={fullUrl}
-        target="_blank"
+        target={isExternal ? '_blank' : undefined}
         rel="noreferrer"
         className="font-medium transition-colors hover:underline"
+        scroll={false}
       >
         {icon ?? <Megaphone className="mr-2 h-4 w-4" />}
         {children}
-        <ExternalLinkIcon className="inline pl-1" />
+        {isExternal ? <ExternalLinkIcon className="inline pl-1" /> : null}
       </NextLink>
     </Button>
   );

--- a/packages/web/docs/src/pages/product-updates/2023-10-10-native-federation-2.mdx
+++ b/packages/web/docs/src/pages/product-updates/2023-10-10-native-federation-2.mdx
@@ -9,8 +9,8 @@ authors: [kamil]
 We're currently developing a new functionality that enables you to utilize Apollo Federation v2
 seamlessly with Hive Cloud, **eliminating the need for you to manage your own composition server**.
 
-To gain early access to this feature, submit a support ticket (_🛟 Support_ in user menu) asking for
-Native Federation v2, and we'll activate it for your project.
+To gain early access to this feature, go to your project settings and enable it in "Native
+Composition" section.
 
 > We recently introduced an
 > [Open Source alternative to Apollo Federation composition library](https://the-guild.dev/blog/open-source-apollo-federation)!

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -586,6 +586,9 @@ importers:
       '@theguild/buddy':
         specifier: 0.1.0
         version: 0.1.0(patch_hash=ryylgra5xglhidfoiaxehn22hq)
+      '@theguild/federation-composition':
+        specifier: 0.4.0
+        version: 0.4.0(graphql@16.8.1)
       '@trpc/client':
         specifier: 10.44.1
         version: 10.44.1(@trpc/server@10.44.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -587,8 +587,8 @@ importers:
         specifier: 0.1.0
         version: 0.1.0(patch_hash=ryylgra5xglhidfoiaxehn22hq)
       '@theguild/federation-composition':
-        specifier: 0.4.0
-        version: 0.4.0(graphql@16.8.1)
+        specifier: 0.5.0
+        version: 0.5.0(graphql@16.8.1)
       '@trpc/client':
         specifier: 10.44.1
         version: 10.44.1(@trpc/server@10.44.1)


### PR DESCRIPTION
Adds "Native Composition" component to project settings to enable / disable native composition.

User will see one of the following statuses:
![Screenshot 2023-12-14 at 11 40 47](https://github.com/kamilkisiela/graphql-hive/assets/8167190/c8487a11-3a9b-4437-b345-d09d98a3088c)

We check compatibility by comparing the most recent supergraphs from all project's targets.
If all of them are identical: COMPATIBLE
If some of them are not: NOT COMPATIBLE
if project has no supergraphs: UNKNOWN