### PR TITLE
refactor: use composition result for diff and policy checks

### DIFF
--- a/packages/services/api/src/modules/schema/providers/models/composite-legacy.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite-legacy.ts
@@ -93,25 +93,26 @@ export class CompositeLegacyModel {
       };
     }
 
-    const [compositionCheck, diffCheck] = await Promise.all([
-      this.checks.composition({
-        orchestrator,
-        project,
-        organization,
-        schemas,
-        baseSchema,
-      }),
-      this.checks.diff({
-        orchestrator,
-        project,
-        organization,
-        schemas,
-        selector,
-        version: latestVersion,
-        includeUrlChanges: false,
-        approvedChanges: null,
-      }),
-    ]);
+    const compositionCheck = await this.checks.composition({
+      orchestrator,
+      project,
+      organization,
+      schemas,
+      baseSchema,
+    });
+
+    const diffCheck = await this.checks.diff({
+      orchestrator,
+      project,
+      organization,
+      schemas,
+      selector,
+      version: latestVersion,
+      includeUrlChanges: false,
+      approvedChanges: null,
+      incomingSdl:
+        compositionCheck.result?.fullSchemaSdl ?? compositionCheck.reason?.fullSchemaSdl ?? null,
+    });
 
     if (compositionCheck.status === 'failed' || diffCheck.status === 'failed') {
       return {
@@ -234,14 +235,15 @@ export class CompositeLegacyModel {
       };
     }
 
-    const [compositionCheck, diffCheck, metadataCheck] = await Promise.all([
-      this.checks.composition({
-        orchestrator,
-        project,
-        organization,
-        schemas,
-        baseSchema,
-      }),
+    const compositionCheck = await this.checks.composition({
+      orchestrator,
+      project,
+      organization,
+      schemas,
+      baseSchema,
+    });
+
+    const [diffCheck, metadataCheck] = await Promise.all([
       this.checks.diff({
         orchestrator,
         selector: {
@@ -255,6 +257,7 @@ export class CompositeLegacyModel {
         version: latestVersion,
         includeUrlChanges: true,
         approvedChanges: null,
+        incomingSdl: compositionCheck.result?.fullSchemaSdl ?? null,
       }),
       isFederation
         ? {

--- a/packages/services/api/src/modules/schema/resolvers.ts
+++ b/packages/services/api/src/modules/schema/resolvers.ts
@@ -65,7 +65,7 @@ import { stripUsedSchemaCoordinatesFromDocumentNode } from './lib/unused-graphql
 import { Inspector } from './providers/inspector';
 import { SchemaBuildError } from './providers/orchestrators/errors';
 import { detectUrlChanges } from './providers/registry-checks';
-import { ensureSDL, SchemaHelper } from './providers/schema-helper';
+import { ensureSDL, isCompositeSchema, SchemaHelper } from './providers/schema-helper';
 import { SchemaManager } from './providers/schema-manager';
 import { SchemaPublisher } from './providers/schema-publisher';
 import { toGraphQLSchemaCheck, toGraphQLSchemaCheckCurry } from './to-graphql-schema-check';
@@ -629,7 +629,12 @@ export const resolvers: SchemaModule.Resolvers = {
             changes.push(...(await injector.get(Inspector).diff(previousSchema, currentSchema)));
           }
 
-          changes.push(...detectUrlChanges(schemasBefore, schemasAfter));
+          changes.push(
+            ...detectUrlChanges(
+              schemasBefore.filter(isCompositeSchema),
+              schemasAfter.filter(isCompositeSchema),
+            ),
+          );
 
           const result: SchemaCompareResult = {
             result: {


### PR DESCRIPTION
### Background

related https://github.com/kamilkisiela/graphql-hive/issues/3491

### Description

This is a small improvement, that avoids unnecessary composition calls for the registry checks "diff" and "schemaPolicy". There can be additional improvements, as stated in https://github.com/kamilkisiela/graphql-hive/issues/3491, this however, would require more refactoring. This change is a quick win and helps for what I am working on in https://github.com/kamilkisiela/graphql-hive/pull/3506

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
