### PR TITLE
docs: remove duplicated bounded ports reference

### DIFF
--- a/packages/web/docs/src/pages/docs/self-hosting/get-started.mdx
+++ b/packages/web/docs/src/pages/docs/self-hosting/get-started.mdx
@@ -355,15 +355,6 @@ Go to the `Schema` tab in your project target and you're going to see your lates
 
 ## Next Steps
 
-## Bounded Ports Reference
-
-| Port | Purpose                      |
-| ---- | ---------------------------- |
-| 8080 | Hive's Main App UI           |
-| 8081 | The Usage Reporting Endpoint |
-| 8082 | The GraphQL API              |
-| 8083 | The Artifacts Bucket         |
-
 After doing your first testing with GraphQL Hive you should consider the following steps:
 
 - Evaluate whether you want to run Databases yourself within Docker or instead use a managed


### PR DESCRIPTION
Removes a duplicated reference of bounded ports

### Background

docs update

### Description

see above

### Checklist

N/A