### PR TITLE
feat: Make schema file path configurable in router registry plugin

### DIFF
--- a/packages/web/docs/src/pages/docs/integrations/apollo-router.mdx
+++ b/packages/web/docs/src/pages/docs/integrations/apollo-router.mdx
@@ -130,6 +130,7 @@ used for authenticating the supergraph polling from the CDN.
 - `HIVE_CDN_POLL_INTERVAL` - polling interval (default is 10 seconds)
 - `HIVE_CDN_ACCEPT_INVALID_CERTS` - accepts invalid SSL certificates (default is `false`)
 - `HIVE_REGISTRY_LOG` - defines the log level for the registry (default is `INFO`)
+- `HIVE_CDN_SCHEMA_FILE_PATH` - where to download the supergraph schema (default is `./supergraph-schema.graphql`)
 
 <Callout>
   The `HIVE_CDN_ENDPOINT` variable should not include any artifact suffix (for example,


### PR DESCRIPTION
### Background

Make it easier to as non root by allowing the user to specify where to download the supergraph schema file from the hive cdn. Typically, /tmp is writable and is a suitable place to download the file to. Alternatively, if using kubernetes, one could create an emptyDir volume and download the schema file to there.

### Description

The change affects the router rust package, specifically the registry module.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
