### PR TITLE
fix: do not report operations that don't pass GraphQL validation

### DIFF
--- a/.changeset/eight-swans-teach.md
+++ b/.changeset/eight-swans-teach.md
@@ -1,0 +1,5 @@
+---
+"@graphql-hive/client": patch
+---
+
+Do not report operations that do not pass GraphQL validation.

--- a/packages/libraries/client/package.json
+++ b/packages/libraries/client/package.json
@@ -61,6 +61,7 @@
     "@apollo/server": "4.10.0",
     "@apollo/subgraph": "2.6.3",
     "@envelop/types": "5.0.0",
+    "@graphql-yoga/plugin-disable-introspection": "2.1.1",
     "@types/async-retry": "1.4.8",
     "graphql": "16.8.1",
     "graphql-yoga": "5.1.1",

--- a/packages/libraries/client/tests/yoga.spec.ts
+++ b/packages/libraries/client/tests/yoga.spec.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { GraphQLError } from 'graphql';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { createSchema, createYoga } from 'graphql-yoga';
 // eslint-disable-next-line import/no-extraneous-dependencies
@@ -320,6 +321,107 @@ it('does not report usage for operation that does not pass validation', async ()
     });
     expect(res.status).toBe(200);
     expect(await res.text()).toContain('GraphQL introspection has been disabled');
+
+    setTimeout(() => {
+      graphqlScope.done();
+      expect(callback).not.toHaveBeenCalled();
+      resolve();
+    }, 1000);
+  });
+});
+
+it('does not report usage if context creating raises an error', async () => {
+  const callback = vi.fn();
+  const graphqlScope = nock('http://localhost')
+    .post('/graphql')
+    .reply(200, {
+      data: {
+        __typename: 'Query',
+        tokenInfo: {
+          __typename: 'TokenInfo',
+          token: {
+            name: 'brrrt',
+          },
+          organization: {
+            name: 'mom',
+            cleanId: 'ur-mom',
+          },
+          project: {
+            name: 'projecto',
+            type: 'FEDERATION',
+            cleanId: 'projecto',
+          },
+          target: {
+            name: 'projecto',
+            cleanId: 'projecto',
+          },
+          canReportSchema: true,
+          canCollectUsage: true,
+          canReadOperations: true,
+        },
+      },
+    });
+
+  const yoga = createYoga({
+    schema: createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          hi: String
+        }
+      `,
+    }),
+    plugins: [
+      {
+        onContextBuilding() {
+          throw new GraphQLError('Not authenticated.');
+        },
+      },
+      useHive({
+        enabled: true,
+        debug: true,
+        token: 'brrrt',
+        selfHosting: {
+          applicationUrl: 'http://localhost/foo',
+          graphqlEndpoint: 'http://localhost/graphql',
+          usageEndpoint: 'http://localhost/usage',
+        },
+        usage: {
+          endpoint: 'http://localhost/usage',
+          clientInfo() {
+            return {
+              name: 'brrr',
+              version: '1',
+            };
+          },
+        },
+        agent: {
+          maxSize: 1,
+        },
+      }),
+    ],
+  });
+
+  // eslint-disable-next-line no-async-promise-executor
+  await new Promise<void>(async (resolve, reject) => {
+    nock.emitter.once('no match', (req: any) => {
+      reject(new Error(`Unexpected request was sent to ${req.path}`));
+    });
+
+    const res = await yoga.fetch('http://localhost/graphql', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: /* GraphQL */ `
+          {
+            hi
+          }
+        `,
+      }),
+    });
+    expect(res.status).toBe(200);
+    expect(await res.text()).toMatchInlineSnapshot(`{"errors":[{"message":"Not authenticated."}]}`);
 
     setTimeout(() => {
       graphqlScope.done();

--- a/packages/services/server/package.json
+++ b/packages/services/server/package.json
@@ -22,7 +22,7 @@
     "@escape.tech/graphql-armor-max-tokens": "2.3.0",
     "@graphql-hive/client": "workspace:*",
     "@graphql-yoga/plugin-persisted-operations": "3.1.1",
-    "@graphql-yoga/plugin-response-cache": "3.2.1",
+    "@graphql-yoga/plugin-response-cache": "3.3.0-alpha-20240116103344-655e7299",
     "@hive/api": "workspace:*",
     "@hive/cdn-script": "workspace:*",
     "@hive/service-common": "workspace:*",

--- a/packages/services/server/package.json
+++ b/packages/services/server/package.json
@@ -22,7 +22,7 @@
     "@escape.tech/graphql-armor-max-tokens": "2.3.0",
     "@graphql-hive/client": "workspace:*",
     "@graphql-yoga/plugin-persisted-operations": "3.1.1",
-    "@graphql-yoga/plugin-response-cache": "3.3.0-alpha-20240116103344-655e7299",
+    "@graphql-yoga/plugin-response-cache": "3.3.0",
     "@hive/api": "workspace:*",
     "@hive/cdn-script": "workspace:*",
     "@hive/service-common": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -434,6 +434,9 @@ importers:
       '@apollo/subgraph':
         specifier: 2.6.3
         version: 2.6.3(graphql@16.8.1)
+      '@graphql-yoga/plugin-disable-introspection':
+        specifier: 2.1.1
+        version: 2.1.1(graphql-yoga@5.1.1)(graphql@16.8.1)
       '@types/async-retry':
         specifier: 1.4.8
         version: 1.4.8
@@ -1049,8 +1052,8 @@ importers:
         specifier: 3.1.1
         version: 3.1.1(@graphql-tools/utils@10.0.12)(graphql-yoga@5.1.1)(graphql@16.8.1)
       '@graphql-yoga/plugin-response-cache':
-        specifier: 3.2.1
-        version: 3.2.1(@envelop/core@5.0.0)(graphql-yoga@5.1.1)(graphql@16.8.1)
+        specifier: 3.3.0-alpha-20240116103344-655e7299
+        version: 3.3.0-alpha-20240116103344-655e7299(@envelop/core@5.0.0)(graphql-yoga@5.1.1)(graphql@16.8.1)
       '@hive/api':
         specifier: workspace:*
         version: link:../api
@@ -7454,6 +7457,17 @@ packages:
       tslib: 2.6.2
     dev: true
 
+  /@graphql-yoga/plugin-disable-introspection@2.1.1(graphql-yoga@5.1.1)(graphql@16.8.1):
+    resolution: {integrity: sha512-vFeYDegjeCMa4agvKE/+1waINUBmckBTozpmRLSvElDlb18e18CWj1jm18hTDl6jV9R5GS4y5VMdpbFTukyh/w==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      graphql: ^15.2.0 || ^16.0.0
+      graphql-yoga: ^5.1.1
+    dependencies:
+      graphql: 16.8.1
+      graphql-yoga: 5.1.1(graphql@16.8.1)
+    dev: true
+
   /@graphql-yoga/plugin-persisted-operations@3.1.1(@graphql-tools/utils@10.0.12)(graphql-yoga@5.1.1)(graphql@16.8.1):
     resolution: {integrity: sha512-cD7+V19ipICnCZsUtLgOyZV9jcwtTiSFJOGYIZnUG25egUIzXfMmg+EWUZD1uGLKZBKbGWULn9ayc7UW52GSLg==}
     engines: {node: '>=18.0.0'}
@@ -7467,11 +7481,11 @@ packages:
       graphql-yoga: 5.1.1(graphql@16.8.1)
     dev: true
 
-  /@graphql-yoga/plugin-response-cache@3.2.1(@envelop/core@5.0.0)(graphql-yoga@5.1.1)(graphql@16.8.1):
-    resolution: {integrity: sha512-GBalsZzJxp3pTllLx/cdTyVFu3zR/YevfntC3bFJifQcBuBxnAXqsyrbHp87gc/boBiZP11u6NhG++Ta9mvxew==}
+  /@graphql-yoga/plugin-response-cache@3.3.0-alpha-20240116103344-655e7299(@envelop/core@5.0.0)(graphql-yoga@5.1.1)(graphql@16.8.1):
+    resolution: {integrity: sha512-MNaYFY5VMoPpP9H63FF2Q2Z2d8xLcuLgzRGSH5nuX4vM6tD+nvBThpYDEgP9XfM4qSncT/99PnExtcZxHB+D1A==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      graphql: ^15.2.0 || ^16.0.0
+      graphql: 16.6.0
       graphql-yoga: ^5.1.1
     dependencies:
       '@envelop/response-cache': 6.1.2(@envelop/core@5.0.0)(graphql@16.8.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1052,8 +1052,8 @@ importers:
         specifier: 3.1.1
         version: 3.1.1(@graphql-tools/utils@10.0.12)(graphql-yoga@5.1.1)(graphql@16.8.1)
       '@graphql-yoga/plugin-response-cache':
-        specifier: 3.3.0-alpha-20240116103344-655e7299
-        version: 3.3.0-alpha-20240116103344-655e7299(@envelop/core@5.0.0)(graphql-yoga@5.1.1)(graphql@16.8.1)
+        specifier: 3.3.0
+        version: 3.3.0(@envelop/core@5.0.0)(graphql-yoga@5.1.1)(graphql@16.8.1)
       '@hive/api':
         specifier: workspace:*
         version: link:../api
@@ -7481,11 +7481,11 @@ packages:
       graphql-yoga: 5.1.1(graphql@16.8.1)
     dev: true
 
-  /@graphql-yoga/plugin-response-cache@3.3.0-alpha-20240116103344-655e7299(@envelop/core@5.0.0)(graphql-yoga@5.1.1)(graphql@16.8.1):
-    resolution: {integrity: sha512-MNaYFY5VMoPpP9H63FF2Q2Z2d8xLcuLgzRGSH5nuX4vM6tD+nvBThpYDEgP9XfM4qSncT/99PnExtcZxHB+D1A==}
+  /@graphql-yoga/plugin-response-cache@3.3.0(@envelop/core@5.0.0)(graphql-yoga@5.1.1)(graphql@16.8.1):
+    resolution: {integrity: sha512-SoVpPqR3tBeSyrdVb81zBGehWgtdeqBxEh2HTuv10jhLCL62nvCrCMfe1DYD6AvRE8DlRfLY/uCn8lwS3CAOwg==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      graphql: 16.6.0
+      graphql: ^15.2.0 || ^16.0.0
       graphql-yoga: ^5.1.1
     dependencies:
       '@envelop/response-cache': 6.1.2(@envelop/core@5.0.0)(graphql@16.8.1)


### PR DESCRIPTION
### Background

Requires https://github.com/dotansimha/graphql-yoga/pull/3164 for properly handling response cache compatibility.

Closes https://github.com/kamilkisiela/graphql-hive/issues/3807

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
