### PR TITLE
fix: correctly handle schema check composition skip

### DIFF
--- a/packages/services/api/src/modules/schema/providers/models/composite-legacy.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite-legacy.ts
@@ -89,8 +89,7 @@ export class CompositeLegacyModel {
     // Short-circuit if there are no changes
     if (checksumCheck.status === 'completed' && checksumCheck.result === 'unchanged') {
       return {
-        conclusion: SchemaCheckConclusion.Success,
-        state: null,
+        conclusion: SchemaCheckConclusion.Skip,
       };
     }
 

--- a/packages/services/api/src/modules/schema/providers/models/composite.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite.ts
@@ -147,18 +147,20 @@ export class CompositeModel {
     const schemas = latestVersion
       ? swapServices(latestVersion.schemas, incoming).schemas
       : [incoming];
-    const compareToLatest = organization.featureFlags.compareToPreviousComposableVersion === false;
+    const comparedVersion =
+      organization.featureFlags.compareToPreviousComposableVersion === false
+        ? latest
+        : latestComposable;
 
     const checksumCheck = await this.checks.checksum({
       schemas,
-      latestVersion,
+      latestVersion: comparedVersion,
     });
 
     // Short-circuit if there are no changes
     if (checksumCheck.status === 'completed' && checksumCheck.result === 'unchanged') {
       return {
-        conclusion: SchemaCheckConclusion.Success,
-        state: null,
+        conclusion: SchemaCheckConclusion.Skip,
       };
     }
 
@@ -187,7 +189,7 @@ export class CompositeModel {
 
     const previousVersionSdl = await this.checks.retrievePreviousVersionSdl({
       orchestrator,
-      version: compareToLatest ? latest : latestComposable,
+      version: comparedVersion,
       organization,
       project,
     });

--- a/packages/services/api/src/modules/schema/providers/models/shared.ts
+++ b/packages/services/api/src/modules/schema/providers/models/shared.ts
@@ -41,6 +41,10 @@ export const SchemaCheckConclusion = {
    * Schema is either not composable or has breaking changes
    */
   Failure: 'FAILURE',
+  /**
+   * Skipped as the schemas have not changed from the compared schema version
+   */
+  Skip: 'SKIP',
 } as const;
 
 export const SchemaDeleteConclusion = {
@@ -87,7 +91,7 @@ export type SchemaCheckWarning = {
 export type SchemaCheckSuccess = {
   conclusion: (typeof SchemaCheckConclusion)['Success'];
   // state is null in case the check got skipped.
-  state: null | {
+  state: {
     schemaChanges: null | {
       breaking: Array<SchemaChangeType> | null;
       safe: Array<SchemaChangeType> | null;
@@ -113,6 +117,11 @@ export type SchemaCheckSuccess = {
       };
     }>;
   };
+};
+
+export type SchemaCheckSkip = {
+  conclusion: (typeof SchemaCheckConclusion)['Skip'];
+  state?: never;
 };
 
 type SchemaCheckCompositionState =
@@ -159,7 +168,7 @@ export type SchemaCheckFailure = {
   };
 };
 
-export type SchemaCheckResult = SchemaCheckFailure | SchemaCheckSuccess;
+export type SchemaCheckResult = SchemaCheckFailure | SchemaCheckSuccess | SchemaCheckSkip;
 
 export const PublishIgnoreReasonCode = {
   NoChanges: 'NO_CHANGES',

--- a/packages/services/api/src/modules/schema/providers/models/single-legacy.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single-legacy.ts
@@ -74,8 +74,7 @@ export class SingleLegacyModel {
     if (checksumCheck.status === 'completed' && checksumCheck.result === 'unchanged') {
       this.logger.debug('No changes detected, skipping schema check');
       return {
-        conclusion: SchemaCheckConclusion.Success,
-        state: null,
+        conclusion: SchemaCheckConclusion.Skip,
       };
     }
 

--- a/packages/services/api/src/modules/schema/providers/models/single.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single.ts
@@ -70,21 +70,22 @@ export class SingleModel {
       metadata: null,
     };
 
-    const latestVersion = latest;
     const schemas = [incoming] as [SingleSchema];
-    const compareToLatest = organization.featureFlags.compareToPreviousComposableVersion === false;
+    const comparedVersion =
+      organization.featureFlags.compareToPreviousComposableVersion === false
+        ? latest
+        : latestComposable;
 
     const checksumCheck = await this.checks.checksum({
       schemas,
-      latestVersion,
+      latestVersion: comparedVersion,
     });
 
     // Short-circuit if there are no changes
     if (checksumCheck.status === 'completed' && checksumCheck.result === 'unchanged') {
       this.logger.debug('No changes detected, skipping schema check');
       return {
-        conclusion: SchemaCheckConclusion.Success,
-        state: null,
+        conclusion: SchemaCheckConclusion.Skip,
       };
     }
 
@@ -99,7 +100,7 @@ export class SingleModel {
 
     const previousVersionSdl = await this.checks.retrievePreviousVersionSdl({
       orchestrator: this.orchestrator,
-      version: compareToLatest ? latest : latestComposable,
+      version: comparedVersion,
       organization,
       project,
     });

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -362,17 +362,14 @@ export class SchemaPublisher {
 
     let checkResult: SchemaCheckResult;
 
+    let approvedSchemaChanges: Map<string, SchemaChangeType> | null = new Map();
     let approvedContractChanges: Map<string, Map<string, SchemaChangeType>> | null = null;
-    const approvedSchemaChanges = new Map<string, SchemaChangeType>();
 
     if (contextId !== null) {
-      const changes = await this.storage.getApprovedSchemaChangesForContextId({
+      approvedSchemaChanges = await this.storage.getApprovedSchemaChangesForContextId({
         targetId: target.id,
         contextId,
       });
-      for (const change of changes) {
-        approvedSchemaChanges.set(change.id, change);
-      }
 
       if (contracts?.length) {
         approvedContractChanges = await this.contracts.getApprovedSchemaChangesForContracts({

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -15,7 +15,6 @@ import { sentry } from '../../../shared/sentry';
 import { AlertsManager } from '../../alerts/providers/alerts-manager';
 import { AuthManager } from '../../auth/providers/auth-manager';
 import { TargetAccessScope } from '../../auth/providers/target-access';
-import { CdnProvider } from '../../cdn/providers/cdn.provider';
 import {
   GitHubIntegrationManager,
   type GitHubCheckRun,
@@ -129,7 +128,6 @@ export class SchemaPublisher {
     private projectManager: ProjectManager,
     private organizationManager: OrganizationManager,
     private alertsManager: AlertsManager,
-    private cdn: CdnProvider,
     private gitHubIntegrationManager: GitHubIntegrationManager,
     private distributedCache: DistributedCache,
     private helper: SchemaHelper,
@@ -472,6 +470,15 @@ export class SchemaPublisher {
     const retention = await this.rateLimit.getRetention({ targetId: target.id });
     const expiresAt = retention ? new Date(Date.now() + retention * millisecondsPerDay) : null;
 
+    const comparedVersion =
+      organization.featureFlags.compareToPreviousComposableVersion === false
+        ? latestVersion
+        : latestComposableVersion;
+    const comparedSchemaVersion =
+      organization.featureFlags.compareToPreviousComposableVersion === false
+        ? latestSchemaVersion
+        : latestComposableSchemaVersion;
+
     if (checkResult.conclusion === SchemaCheckConclusion.Failure) {
       schemaCheck = await this.storage.createSchemaCheck({
         schemaSDL: sdl,
@@ -518,51 +525,7 @@ export class SchemaPublisher {
             safeSchemaChanges: contract.schemaChanges?.safe ?? null,
           })) ?? null,
       });
-    }
-
-    if (checkResult.conclusion === SchemaCheckConclusion.Success) {
-      let composition = checkResult.state?.composition ?? null;
-      // in case of a skip this is null
-      if (composition === null) {
-        if (latestVersion == null || latestSchemaVersion == null) {
-          throw new Error(
-            'Composition yielded no composite schema SDL but there is no latest version to fall back to.',
-          );
-        }
-
-        if (latestSchemaVersion.compositeSchemaSDL) {
-          composition = {
-            compositeSchemaSDL: latestSchemaVersion.compositeSchemaSDL,
-            supergraphSDL: latestSchemaVersion.supergraphSDL,
-          };
-        } else {
-          // LEGACY CASE if the schema version record has no sdl
-          // -> we need to do manual composition
-          const orchestrator = this.schemaManager.matchOrchestrator(project.type);
-
-          const result = await orchestrator.composeAndValidate(
-            latestVersion.schemas.map(s => this.helper.createSchemaObject(s)),
-            {
-              external: project.externalComposition,
-              native: this.schemaManager.checkProjectNativeFederationSupport({
-                project,
-                organization,
-              }),
-              contracts: null,
-            },
-          );
-
-          if (result.sdl == null) {
-            throw new Error('Manual composition yielded no composite schema SDL.');
-          }
-
-          composition = {
-            compositeSchemaSDL: result.sdl,
-            supergraphSDL: result.supergraph,
-          };
-        }
-      }
-
+    } else if (checkResult.conclusion === SchemaCheckConclusion.Success) {
       schemaCheck = await this.storage.createSchemaCheck({
         schemaSDL: sdl,
         serviceName: input.service ?? null,
@@ -575,8 +538,8 @@ export class SchemaPublisher {
         schemaPolicyWarnings: checkResult.state?.schemaPolicyWarnings ?? null,
         schemaPolicyErrors: null,
         schemaCompositionErrors: null,
-        compositeSchemaSDL: composition.compositeSchemaSDL,
-        supergraphSDL: composition.supergraphSDL,
+        compositeSchemaSDL: checkResult.state.composition.compositeSchemaSDL,
+        supergraphSDL: checkResult.state.composition.supergraphSDL,
         isManuallyApproved: false,
         manualApprovalUserId: null,
         githubCheckRunId: githubCheckRun?.id ?? null,
@@ -600,13 +563,73 @@ export class SchemaPublisher {
             safeSchemaChanges: contract.schemaChanges?.safe ?? null,
           })) ?? null,
       });
+    } else if (checkResult.conclusion === SchemaCheckConclusion.Skip) {
+      if (!comparedVersion || !comparedSchemaVersion) {
+        throw new Error('This cannot happen :)');
+      }
+
+      const contractVersions = await this.contracts.getContractVersionsForSchemaVersion({
+        schemaVersionId: comparedSchemaVersion.id,
+      });
+
+      schemaCheck = await this.storage.createSchemaCheck({
+        schemaSDL: sdl,
+        serviceName: input.service ?? null,
+        meta: input.meta ?? null,
+        targetId: target.id,
+        schemaVersionId: comparedVersion?.version ?? null,
+        breakingSchemaChanges: null,
+        safeSchemaChanges: null,
+        schemaPolicyWarnings: null,
+        schemaPolicyErrors: null,
+        ...(comparedSchemaVersion.isComposable
+          ? {
+              isSuccess: true,
+              schemaCompositionErrors: null,
+              // TODO: dem types bruv
+              compositeSchemaSDL: comparedSchemaVersion.compositeSchemaSDL!,
+              supergraphSDL: comparedSchemaVersion.supergraphSDL,
+            }
+          : {
+              isSuccess: false,
+              // TODO: dem types bruv
+              schemaCompositionErrors: comparedSchemaVersion.schemaCompositionErrors!,
+              compositeSchemaSDL: null,
+              supergraphSDL: null,
+            }),
+        isManuallyApproved: false,
+        manualApprovalUserId: null,
+        githubCheckRunId: githubCheckRun?.id ?? null,
+        githubRepository: githubCheckRun
+          ? githubCheckRun.owner + '/' + githubCheckRun.repository
+          : null,
+        githubSha: githubCheckRun?.commit ?? null,
+        expiresAt,
+        contextId,
+        contracts:
+          contractVersions?.edges.map(edge => ({
+            contractId: edge.node.contractId,
+            contractName: edge.node.contractName,
+            // TODO: this is not correct, we should compare with the latest valid version...
+            comparedContractVersionId:
+              edge.node.schemaCompositionErrors === null
+                ? edge.node.id
+                : contractVersionIdByContractName.get(edge.node.contractName) ?? null,
+            isSuccess: !!edge.node.schemaCompositionErrors,
+            compositeSchemaSdl: edge.node.compositeSchemaSdl,
+            supergraphSchemaSdl: edge.node.supergraphSdl,
+            schemaCompositionErrors: edge.node.schemaCompositionErrors,
+            breakingSchemaChanges: null,
+            safeSchemaChanges: null,
+          })) ?? null,
+      });
     }
 
     if (githubCheckRun) {
-      const failedContractCompositionCount =
-        checkResult?.state?.contracts?.filter(c => !c.isSuccessful).length ?? 0;
-
       if (checkResult.conclusion === SchemaCheckConclusion.Success) {
+        const failedContractCompositionCount =
+          checkResult.state.contracts?.filter(c => !c.isSuccessful).length ?? 0;
+
         increaseSchemaCheckCountMetric('accepted');
         return await this.updateGithubCheckRunForSchemaCheck({
           project,
@@ -624,23 +647,74 @@ export class SchemaPublisher {
         });
       }
 
+      if (checkResult.conclusion === SchemaCheckConclusion.Failure) {
+        const failedContractCompositionCount =
+          checkResult.state.contracts?.filter(c => !c.isSuccessful).length ?? 0;
+
+        increaseSchemaCheckCountMetric('rejected');
+        return await this.updateGithubCheckRunForSchemaCheck({
+          project,
+          target,
+          organization,
+          conclusion: checkResult.conclusion,
+          changes: [
+            ...(checkResult.state.schemaChanges?.breaking ?? []),
+            ...(checkResult.state.schemaChanges?.safe ?? []),
+          ],
+          breakingChanges: checkResult.state.schemaChanges?.breaking ?? [],
+          compositionErrors: checkResult.state.composition.errors ?? [],
+          warnings: checkResult.state.schemaPolicy?.warnings ?? [],
+          errors: checkResult.state.schemaPolicy?.errors?.map(formatPolicyError) ?? [],
+          schemaCheckId: schemaCheck?.id ?? null,
+          githubCheckRun: githubCheckRun,
+          failedContractCompositionCount,
+        });
+      }
+
+      // SchemaCheckConclusion.Skip
+
+      if (!comparedVersion || !comparedSchemaVersion) {
+        throw new Error('This cannot happen :)');
+      }
+
+      if (comparedSchemaVersion.isComposable) {
+        increaseSchemaCheckCountMetric('accepted');
+        const contracts = await this.contracts.getContractVersionsForSchemaVersion({
+          schemaVersionId: comparedSchemaVersion.id,
+        });
+        const failedContractCompositionCount =
+          contracts?.edges.filter(edge => edge.node.schemaCompositionErrors !== null).length ?? 0;
+
+        return await this.updateGithubCheckRunForSchemaCheck({
+          project,
+          target,
+          organization,
+          conclusion: SchemaCheckConclusion.Success,
+          changes: null,
+          breakingChanges: null,
+          warnings: null,
+          compositionErrors: null,
+          errors: null,
+          schemaCheckId: schemaCheck?.id ?? null,
+          githubCheckRun: githubCheckRun,
+          failedContractCompositionCount,
+        });
+      }
+
       increaseSchemaCheckCountMetric('rejected');
       return await this.updateGithubCheckRunForSchemaCheck({
         project,
         target,
         organization,
-        conclusion: checkResult.conclusion,
-        changes: [
-          ...(checkResult.state.schemaChanges?.breaking ?? []),
-          ...(checkResult.state.schemaChanges?.safe ?? []),
-        ],
-        breakingChanges: checkResult.state.schemaChanges?.breaking ?? [],
-        compositionErrors: checkResult.state.composition.errors ?? [],
-        warnings: checkResult.state.schemaPolicy?.warnings ?? [],
-        errors: checkResult.state.schemaPolicy?.errors?.map(formatPolicyError) ?? [],
+        conclusion: SchemaCheckConclusion.Failure,
+        changes: null,
+        breakingChanges: null,
+        compositionErrors: comparedSchemaVersion.schemaCompositionErrors,
+        warnings: null,
+        errors: null,
         schemaCheckId: schemaCheck?.id ?? null,
         githubCheckRun: githubCheckRun,
-        failedContractCompositionCount,
+        failedContractCompositionCount: 0,
       });
     }
 
@@ -673,43 +747,91 @@ export class SchemaPublisher {
       } as const;
     }
 
-    increaseSchemaCheckCountMetric('rejected');
+    if (checkResult.conclusion === SchemaCheckConclusion.Failure) {
+      increaseSchemaCheckCountMetric('rejected');
 
-    return {
-      __typename: 'SchemaCheckError',
-      valid: false,
-      changes: [
-        ...(checkResult.state.schemaChanges?.all ?? []),
-        ...(checkResult.state.contracts?.flatMap(contract => [
-          ...(contract.schemaChanges?.all?.map(change => ({
-            ...change,
-            message: `[${contract.contractName}] ${change.message}`,
-          })) ?? []),
-        ]) ?? []),
-      ],
-      warnings: checkResult.state.schemaPolicy?.warnings ?? [],
-      errors: [
-        ...(checkResult.state.schemaChanges?.breaking?.filter(
-          breaking => breaking.approvalMetadata == null && breaking.isSafeBasedOnUsage === false,
-        ) ?? []),
-        ...(checkResult.state.schemaPolicy?.errors?.map(formatPolicyError) ?? []),
-        ...(checkResult.state.composition.errors ?? []),
-        ...(checkResult.state.contracts?.flatMap(contract => [
-          ...(contract.composition.errors?.map(error => ({
-            message: `[${contract.contractName}] ${error.message}`,
-            source: error.source,
-          })) ?? []),
-        ]) ?? []),
-        ...(checkResult.state.contracts?.flatMap(contract => [
-          ...(contract.schemaChanges?.breaking
-            ?.filter(
-              breaking =>
-                breaking.approvalMetadata == null && breaking.isSafeBasedOnUsage === false,
-            )
-            .map(change => ({
+      return {
+        __typename: 'SchemaCheckError',
+        valid: false,
+        changes: [
+          ...(checkResult.state.schemaChanges?.all ?? []),
+          ...(checkResult.state.contracts?.flatMap(contract => [
+            ...(contract.schemaChanges?.all?.map(change => ({
               ...change,
               message: `[${contract.contractName}] ${change.message}`,
             })) ?? []),
+          ]) ?? []),
+        ],
+        warnings: checkResult.state.schemaPolicy?.warnings ?? [],
+        errors: [
+          ...(checkResult.state.schemaChanges?.breaking?.filter(
+            breaking => breaking.approvalMetadata == null && breaking.isSafeBasedOnUsage === false,
+          ) ?? []),
+          ...(checkResult.state.schemaPolicy?.errors?.map(formatPolicyError) ?? []),
+          ...(checkResult.state.composition.errors ?? []),
+          ...(checkResult.state.contracts?.flatMap(contract => [
+            ...(contract.composition.errors?.map(error => ({
+              message: `[${contract.contractName}] ${error.message}`,
+              source: error.source,
+            })) ?? []),
+          ]) ?? []),
+          ...(checkResult.state.contracts?.flatMap(contract => [
+            ...(contract.schemaChanges?.breaking
+              ?.filter(
+                breaking =>
+                  breaking.approvalMetadata == null && breaking.isSafeBasedOnUsage === false,
+              )
+              .map(change => ({
+                ...change,
+                message: `[${contract.contractName}] ${change.message}`,
+              })) ?? []),
+          ]) ?? []),
+        ],
+        schemaCheck: toGraphQLSchemaCheck(schemaCheckSelector, schemaCheck),
+      } as const;
+    }
+
+    // SchemaCheckConclusion.Skip
+
+    if (!comparedVersion || !comparedSchemaVersion) {
+      throw new Error('This cannot happen :)');
+    }
+
+    if (comparedSchemaVersion.isComposable) {
+      increaseSchemaCheckCountMetric('accepted');
+      return {
+        __typename: 'SchemaCheckSuccess',
+        valid: true,
+        changes: [],
+        warnings: [],
+        initial: false,
+        schemaCheck: toGraphQLSchemaCheck(schemaCheckSelector, schemaCheck),
+      } as const;
+    }
+
+    const contractVersions = await this.contracts.getContractVersionsForSchemaVersion({
+      schemaVersionId: comparedSchemaVersion.id,
+    });
+
+    increaseSchemaCheckCountMetric('rejected');
+    return {
+      __typename: 'SchemaCheckError',
+      valid: false,
+      changes: [],
+      warnings: [],
+      errors: [
+        ...(comparedSchemaVersion.schemaCompositionErrors?.map(error => ({
+          message: error.message,
+          source: error.source,
+        })) ?? []),
+        ...(contractVersions?.edges.flatMap(edge => [
+          ...(edge.node.schemaCompositionErrors?.map(
+            error =>
+              ({
+                message: `[${edge.node.contractName}] ${error.message}`,
+                source: error.source,
+              }) ?? [],
+          ) ?? []),
         ]) ?? []),
       ],
       schemaCheck: toGraphQLSchemaCheck(schemaCheckSelector, schemaCheck),

--- a/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
@@ -8,7 +8,6 @@ import { parseGraphQLSource } from '../../../shared/schema';
 import { OrganizationManager } from '../../organization/providers/organization-manager';
 import { ProjectManager } from '../../project/providers/project-manager';
 import { Storage } from '../../shared/providers/storage';
-import { ContractsManager } from './contracts-manager';
 import { RegistryChecks } from './registry-checks';
 import { ensureCompositeSchemas, SchemaHelper } from './schema-helper';
 import { SchemaManager } from './schema-manager';
@@ -30,7 +29,6 @@ export class SchemaVersionHelper {
     private organizationManager: OrganizationManager,
     private registryChecks: RegistryChecks,
     private storage: Storage,
-    private contractsManager: ContractsManager,
   ) {}
 
   @cache<SchemaVersion>(version => version.id)

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -795,7 +795,7 @@ export interface Storage {
   getApprovedSchemaChangesForContextId(args: {
     targetId: string;
     contextId: string;
-  }): Promise<Array<SchemaChangeType>>;
+  }): Promise<Map<string, SchemaChangeType>>;
 
   getTargetBreadcrumbForTargetId(_: { targetId: string }): Promise<TargetBreadcrumb | null>;
 

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -4227,7 +4227,12 @@ export async function createStorage(connection: string, maximumPoolSize: number)
           AND "context_id" = ${args.contextId}
       `);
 
-      return result.map(record => HiveSchemaChangeModel.parse(record));
+      const approvedSchemaChanges = new Map<string, SchemaChangeType>();
+      for (const record of result) {
+        const change = HiveSchemaChangeModel.parse(record);
+        approvedSchemaChanges.set(change.id, change);
+      }
+      return approvedSchemaChanges;
     },
     async getPaginatedSchemaChecksForTarget(args) {
       let cursor: null | {


### PR DESCRIPTION
### Background

An error popped up within our error monitoring system regarding this code

### Description

We made the wrong assumption that a skipped schema check is always successful. This resolves it by determining the schema check result based on the schema version we compared against.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
