### PR TITLE
Relax SchemaPolicyWarningModel

### DIFF
--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -801,8 +801,8 @@ export default gql`
 
   type SchemaPolicyWarning {
     message: String!
-    ruleId: String!
-    start: CodePosition!
+    ruleId: String
+    start: CodePosition
     end: CodePosition
   }
 

--- a/packages/services/storage/src/schema-change-model.ts
+++ b/packages/services/storage/src/schema-change-model.ts
@@ -794,7 +794,7 @@ export const SchemaCompositionErrorModel = z.object({
 
 export type SchemaCompositionError = z.TypeOf<typeof SchemaCompositionErrorModel>;
 
-const SchemaPolicyWarningModel = z.object({
+export const SchemaPolicyWarningModel = z.object({
   message: z.string(),
   line: z.number().nullable().optional(),
   column: z.number().nullable().optional(),

--- a/packages/services/storage/src/schema-change-model.ts
+++ b/packages/services/storage/src/schema-change-model.ts
@@ -794,13 +794,13 @@ export const SchemaCompositionErrorModel = z.object({
 
 export type SchemaCompositionError = z.TypeOf<typeof SchemaCompositionErrorModel>;
 
-export const SchemaPolicyWarningModel = z.object({
+const SchemaPolicyWarningModel = z.object({
   message: z.string(),
-  line: z.number(),
-  column: z.number(),
-  ruleId: z.string(),
-  endLine: z.number().nullable(),
-  endColumn: z.number().nullable(),
+  line: z.number().nullable().optional(),
+  column: z.number().nullable().optional(),
+  ruleId: z.string().nullable(),
+  endLine: z.number().nullable().optional(),
+  endColumn: z.number().nullable().optional(),
 });
 
 function createSchemaChangeId(change: { type: string; meta: Record<string, unknown> }): string {


### PR DESCRIPTION
Some errors (like GraphQL errors) don't have `ruleId` defined (it's `null`), the same applies to `line` and `column` as well.