### PR TITLE
fix: avoid @inaccessible directive on apollo federation supergraph types

### DIFF
--- a/integration-tests/tests/schema/contracts.spec.ts
+++ b/integration-tests/tests/schema/contracts.spec.ts
@@ -225,6 +225,11 @@ describe('schema service can process contracts', () => {
         id: String!
       }
     `);
+
+    // there should be no @inaccessible on federation specific types otherwise apollo router goes brrrt
+    expect(result.contracts?.[0].supergraph).toContain('enum join__Graph {');
+    expect(result.contracts?.[0].supergraph).toContain('scalar link__Import\n');
+    expect(result.contracts?.[0].supergraph).toContain('scalar join__FieldSet\n');
   });
 });
 

--- a/packages/services/api/src/modules/schema/providers/registry-checks.ts
+++ b/packages/services/api/src/modules/schema/providers/registry-checks.ts
@@ -737,6 +737,7 @@ const federationTypes = new Set([
   'link__Purpose',
   'policy__Policy',
   'requiresScopes__Scope',
+  'join__DirectiveArguments',
 ]);
 const federationDirectives = new Set([
   '@join__enumValue',

--- a/packages/services/api/src/modules/schema/providers/registry-checks.ts
+++ b/packages/services/api/src/modules/schema/providers/registry-checks.ts
@@ -730,7 +730,14 @@ const toSchemaCheckWarning = (record: CheckPolicyResponse[number]): SchemaCheckW
   endLine: record.endLine ?? null,
 });
 
-const federationTypes = new Set(['join__FieldSet', 'join__Graph', 'link__Import', 'link__Purpose']);
+const federationTypes = new Set([
+  'join__FieldSet',
+  'join__Graph',
+  'link__Import',
+  'link__Purpose',
+  'policy__Policy',
+  'requiresScopes__Scope',
+]);
 const federationDirectives = new Set([
   '@join__enumValue',
   '@join__field',

--- a/packages/services/schema/src/lib/reachable-type-filter.ts
+++ b/packages/services/schema/src/lib/reachable-type-filter.ts
@@ -122,14 +122,14 @@ function createAddDirectiveIfNotExists(directiveName: string) {
 /**
  * For a given GraphQL schema document node, add a directive with a given name to all types not in the provided set.
  */
-export function addDirectiveOnExcludedTypes(
-  documentNode: DocumentNode,
+export function addDirectiveOnTypes(args: {
+  documentNode: DocumentNode;
   /** a set of excluded types. e.g. as retrieved from the `getReachableTypes` function. */
-  typeNames: Set<string>,
+  excludedTypeNames: Set<string>;
   /** name of the directive that should be added on the types. */
-  directiveName: string,
-): DocumentNode {
-  const addDirectiveIfNotExists = createAddDirectiveIfNotExists(directiveName);
+  directiveName: string;
+}): DocumentNode {
+  const addDirectiveIfNotExists = createAddDirectiveIfNotExists(args.directiveName);
 
   function onNamedTypeDefinitionNode(
     node:
@@ -140,7 +140,7 @@ export function addDirectiveOnExcludedTypes(
       | EnumTypeDefinitionNode
       | InputObjectTypeDefinitionNode,
   ) {
-    if (typeNames.has(node.name.value)) {
+    if (args.excludedTypeNames.has(node.name.value)) {
       return;
     }
     return {
@@ -149,7 +149,7 @@ export function addDirectiveOnExcludedTypes(
     };
   }
 
-  return visit(documentNode, {
+  return visit(args.documentNode, {
     [Kind.OBJECT_TYPE_DEFINITION]: onNamedTypeDefinitionNode,
     [Kind.INTERFACE_TYPE_DEFINITION]: onNamedTypeDefinitionNode,
     [Kind.UNION_TYPE_DEFINITION]: onNamedTypeDefinitionNode,

--- a/packages/services/schema/src/orchestrators.ts
+++ b/packages/services/schema/src/orchestrators.ts
@@ -522,6 +522,7 @@ const federationTypes = new Set([
   'link__Purpose',
   'policy__Policy',
   'requiresScopes__Scope',
+  'join__DirectiveArguments',
 ]);
 
 const createFederation: (


### PR DESCRIPTION
### Background

Apollo router will fail to process and startup a supergraph that contains `@inaccessible` on federation types.

### Description

This changes the federation contract filtering to exclude the federation types from being marked as inaccessible.

Closes https://github.com/kamilkisiela/graphql-hive/issues/4013

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
