### PR TITLE
Auto-fix persisted composite schema sdl

### DIFF
--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -28,7 +28,7 @@
     "@sentry/types": "7.102.0",
     "@slack/web-api": "7.0.2",
     "@theguild/buddy": "0.1.0",
-    "@theguild/federation-composition": "0.8.1",
+    "@theguild/federation-composition": "0.8.2-alpha-20240222093720-e8f2bb3",
     "@trpc/client": "10.45.1",
     "@trpc/server": "10.45.1",
     "@types/bcryptjs": "2.4.6",

--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -28,7 +28,7 @@
     "@sentry/types": "7.102.0",
     "@slack/web-api": "7.0.2",
     "@theguild/buddy": "0.1.0",
-    "@theguild/federation-composition": "0.8.2-alpha-20240222093720-e8f2bb3",
+    "@theguild/federation-composition": "0.8.2",
     "@trpc/client": "10.45.1",
     "@trpc/server": "10.45.1",
     "@types/bcryptjs": "2.4.6",

--- a/packages/services/api/src/modules/operations/providers/operations-manager.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-manager.ts
@@ -209,7 +209,7 @@ export class OperationsManager {
     operations?: readonly string[];
     clients?: readonly string[];
   } & Listify<TargetSelector, 'target'>) {
-    this.logger.info('Counting requests and failures (period=%s, target=%s)', period, target);
+    this.logger.info('Counting requests and failures (period=%o, target=%s)', period, target);
     await this.authManager.ensureTargetAccess({
       organization,
       project,

--- a/packages/services/api/src/modules/schema/providers/registry-checks.ts
+++ b/packages/services/api/src/modules/schema/providers/registry-checks.ts
@@ -735,6 +735,7 @@ const federationTypes = new Set([
   'join__Graph',
   'link__Import',
   'link__Purpose',
+  'core__Purpose',
   'policy__Policy',
   'requiresScopes__Scope',
   'join__DirectiveArguments',
@@ -745,11 +746,13 @@ const federationDirectives = new Set([
   '@join__graph',
   '@join__implements',
   '@join__type',
+  '@join__owner',
   '@join__unionMember',
   '@link',
   '@federation__inaccessible',
   '@inaccessible',
   '@tag',
+  '@core',
   '@federation__tag',
 ]);
 

--- a/packages/services/api/src/modules/schema/providers/schema-manager.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-manager.ts
@@ -163,7 +163,7 @@ export class SchemaManager {
   }
 
   async getMaybeLatestValidVersion(selector: TargetSelector) {
-    this.logger.debug('Fetching latest valid version (selector=%o)', selector);
+    this.logger.debug('Fetching maybe latest valid version (selector=%o)', selector);
     await this.authManager.ensureTargetAccess({
       ...selector,
       scope: TargetAccessScope.REGISTRY_READ,

--- a/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
@@ -1,12 +1,18 @@
+import { print } from 'graphql';
 import { Injectable, Scope } from 'graphql-modules';
 import { CriticalityLevel } from '@graphql-inspector/core';
 import type { SchemaChangeType } from '@hive/storage';
+import {
+  containsSupergraphSpec,
+  transformSupergraphToPublicSchema,
+} from '@theguild/federation-composition';
 import { ProjectType } from '../../../shared/entities';
 import { cache } from '../../../shared/helpers';
 import type { SchemaVersion } from '../../../shared/mappers';
 import { parseGraphQLSource } from '../../../shared/schema';
 import { OrganizationManager } from '../../organization/providers/organization-manager';
 import { ProjectManager } from '../../project/providers/project-manager';
+import { Logger } from '../../shared/providers/logger';
 import { Storage } from '../../shared/providers/storage';
 import { RegistryChecks } from './registry-checks';
 import { ensureCompositeSchemas, SchemaHelper } from './schema-helper';
@@ -29,6 +35,7 @@ export class SchemaVersionHelper {
     private organizationManager: OrganizationManager,
     private registryChecks: RegistryChecks,
     private storage: Storage,
+    private logger: Logger,
   ) {}
 
   @cache<SchemaVersion>(version => version.id)
@@ -84,7 +91,9 @@ export class SchemaVersionHelper {
 
   async getCompositeSchemaSdl(schemaVersion: SchemaVersion) {
     if (schemaVersion.hasPersistedSchemaChanges) {
-      return schemaVersion.compositeSchemaSDL;
+      return schemaVersion.compositeSchemaSDL
+        ? this.autoFixCompositeSchemaSdl(schemaVersion.compositeSchemaSDL)
+        : null;
     }
 
     const composition = await this.composeSchemaVersion(schemaVersion);
@@ -97,7 +106,9 @@ export class SchemaVersionHelper {
 
   async getSupergraphSdl(schemaVersion: SchemaVersion) {
     if (schemaVersion.hasPersistedSchemaChanges) {
-      return schemaVersion.supergraphSDL;
+      return schemaVersion.supergraphSDL
+        ? this.autoFixCompositeSchemaSdl(schemaVersion.supergraphSDL)
+        : null;
     }
 
     const composition = await this.composeSchemaVersion(schemaVersion);
@@ -301,5 +312,34 @@ export class SchemaVersionHelper {
 
   async getIsValid(schemaVersion: SchemaVersion) {
     return schemaVersion.isComposable && schemaVersion.hasContractCompositionErrors === false;
+  }
+
+  /**
+   * There's a possibility that the composite schema SDL contains parts of the supergraph spec.
+   * This is a problem because we want to show the public schema to the user, and the supergraph spec is not part of that.
+   * This may happen when composite schema was produced with an old version of `transformSupergraphToPublicSchema`
+   * or when supergraph sdl contained something new.
+   *
+   * This function will check if the SDL contains supergraph spec and if it does, it will transform it to public schema.
+   */
+  private autoFixCompositeSchemaSdl(sdl: string) {
+    if (containsSupergraphSpec(sdl)) {
+      this.logger.warn(
+        'Composite schema SDL contains supergraph spec, transforming to public schema',
+      );
+      const transformedSdl = print(
+        transformSupergraphToPublicSchema(parseGraphQLSource(sdl, 'autoFixCompositeSchemaSdl')),
+      );
+
+      this.logger.debug(
+        transformedSdl === sdl
+          ? 'Transformation did not change the original SDL'
+          : 'Transformation changed the original SDL',
+      );
+
+      return transformedSdl;
+    }
+
+    return sdl;
   }
 }

--- a/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
@@ -106,9 +106,7 @@ export class SchemaVersionHelper {
 
   async getSupergraphSdl(schemaVersion: SchemaVersion) {
     if (schemaVersion.hasPersistedSchemaChanges) {
-      return schemaVersion.supergraphSDL
-        ? this.autoFixCompositeSchemaSdl(schemaVersion.supergraphSDL, schemaVersion.id)
-        : null;
+      return schemaVersion.supergraphSDL;
     }
 
     const composition = await this.composeSchemaVersion(schemaVersion);

--- a/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
@@ -321,7 +321,14 @@ export class SchemaVersionHelper {
    * This function will check if the SDL contains supergraph spec and if it does, it will transform it to public schema.
    */
   private autoFixCompositeSchemaSdl(sdl: string, versionId: string) {
-    if (!containsSupergraphSpec(sdl)) {
+    const isFederationV1Output = sdl.includes('@core');
+    /**
+     * If the SDL is clean from Supergraph spec or it's an output of @apollo/federation, we don't need to transform it.
+     * We ignore @apollo/federation, because we never really transformed the output of it to public schema.
+     * Doing so might be a breaking change for some users (like: removed join__Graph type).
+     */
+
+    if (isFederationV1Output || !containsSupergraphSpec(sdl)) {
       return sdl;
     }
 
@@ -329,6 +336,7 @@ export class SchemaVersionHelper {
       'Composite schema SDL contains supergraph spec, transforming to public schema (versionId: %s)',
       versionId,
     );
+
     const transformedSdl = print(
       transformSupergraphToPublicSchema(parseGraphQLSource(sdl, 'autoFixCompositeSchemaSdl')),
     );

--- a/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
@@ -92,7 +92,7 @@ export class SchemaVersionHelper {
   async getCompositeSchemaSdl(schemaVersion: SchemaVersion) {
     if (schemaVersion.hasPersistedSchemaChanges) {
       return schemaVersion.compositeSchemaSDL
-        ? this.autoFixCompositeSchemaSdl(schemaVersion.compositeSchemaSDL)
+        ? this.autoFixCompositeSchemaSdl(schemaVersion.compositeSchemaSDL, schemaVersion.id)
         : null;
     }
 
@@ -107,7 +107,7 @@ export class SchemaVersionHelper {
   async getSupergraphSdl(schemaVersion: SchemaVersion) {
     if (schemaVersion.hasPersistedSchemaChanges) {
       return schemaVersion.supergraphSDL
-        ? this.autoFixCompositeSchemaSdl(schemaVersion.supergraphSDL)
+        ? this.autoFixCompositeSchemaSdl(schemaVersion.supergraphSDL, schemaVersion.id)
         : null;
     }
 
@@ -322,10 +322,11 @@ export class SchemaVersionHelper {
    *
    * This function will check if the SDL contains supergraph spec and if it does, it will transform it to public schema.
    */
-  private autoFixCompositeSchemaSdl(sdl: string) {
+  private autoFixCompositeSchemaSdl(sdl: string, versionId: string) {
     if (containsSupergraphSpec(sdl)) {
       this.logger.warn(
-        'Composite schema SDL contains supergraph spec, transforming to public schema',
+        'Composite schema SDL contains supergraph spec, transforming to public schema (versionId: %s)',
+        versionId,
       );
       const transformedSdl = print(
         transformSupergraphToPublicSchema(parseGraphQLSource(sdl, 'autoFixCompositeSchemaSdl')),

--- a/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
@@ -321,24 +321,24 @@ export class SchemaVersionHelper {
    * This function will check if the SDL contains supergraph spec and if it does, it will transform it to public schema.
    */
   private autoFixCompositeSchemaSdl(sdl: string, versionId: string) {
-    if (containsSupergraphSpec(sdl)) {
-      this.logger.warn(
-        'Composite schema SDL contains supergraph spec, transforming to public schema (versionId: %s)',
-        versionId,
-      );
-      const transformedSdl = print(
-        transformSupergraphToPublicSchema(parseGraphQLSource(sdl, 'autoFixCompositeSchemaSdl')),
-      );
-
-      this.logger.debug(
-        transformedSdl === sdl
-          ? 'Transformation did not change the original SDL'
-          : 'Transformation changed the original SDL',
-      );
-
-      return transformedSdl;
+    if (!containsSupergraphSpec(sdl)) {
+      return sdl;
     }
 
-    return sdl;
+    this.logger.warn(
+      'Composite schema SDL contains supergraph spec, transforming to public schema (versionId: %s)',
+      versionId,
+    );
+    const transformedSdl = print(
+      transformSupergraphToPublicSchema(parseGraphQLSource(sdl, 'autoFixCompositeSchemaSdl')),
+    );
+
+    this.logger.debug(
+      transformedSdl === sdl
+        ? 'Transformation did not change the original SDL'
+        : 'Transformation changed the original SDL',
+    );
+
+    return transformedSdl;
   }
 }

--- a/packages/services/schema/package.json
+++ b/packages/services/schema/package.json
@@ -16,7 +16,7 @@
     "@graphql-tools/stitching-directives": "3.0.0",
     "@hive/service-common": "workspace:*",
     "@sentry/node": "7.102.0",
-    "@theguild/federation-composition": "0.8.1",
+    "@theguild/federation-composition": "0.8.2-alpha-20240222093720-e8f2bb3",
     "@trpc/server": "10.45.1",
     "@types/async-retry": "1.4.8",
     "@types/ioredis-mock": "8.2.5",

--- a/packages/services/schema/package.json
+++ b/packages/services/schema/package.json
@@ -16,7 +16,7 @@
     "@graphql-tools/stitching-directives": "3.0.0",
     "@hive/service-common": "workspace:*",
     "@sentry/node": "7.102.0",
-    "@theguild/federation-composition": "0.8.2-alpha-20240222093720-e8f2bb3",
+    "@theguild/federation-composition": "0.8.2",
     "@trpc/server": "10.45.1",
     "@types/async-retry": "1.4.8",
     "@types/ioredis-mock": "8.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -593,8 +593,8 @@ importers:
         specifier: 0.1.0
         version: 0.1.0(patch_hash=ryylgra5xglhidfoiaxehn22hq)
       '@theguild/federation-composition':
-        specifier: 0.8.2-alpha-20240222093720-e8f2bb3
-        version: 0.8.2-alpha-20240222093720-e8f2bb3(graphql@16.8.1)
+        specifier: 0.8.2
+        version: 0.8.2(graphql@16.8.1)
       '@trpc/client':
         specifier: 10.45.1
         version: 10.45.1(@trpc/server@10.45.1)
@@ -971,8 +971,8 @@ importers:
         specifier: 7.102.0
         version: 7.102.0
       '@theguild/federation-composition':
-        specifier: 0.8.2-alpha-20240222093720-e8f2bb3
-        version: 0.8.2-alpha-20240222093720-e8f2bb3(graphql@16.8.1)
+        specifier: 0.8.2
+        version: 0.8.2(graphql@16.8.1)
       '@trpc/server':
         specifier: 10.45.1
         version: 10.45.1
@@ -13203,8 +13203,8 @@ packages:
       - supports-color
     dev: true
 
-  /@theguild/federation-composition@0.8.2-alpha-20240222093720-e8f2bb3(graphql@16.8.1):
-    resolution: {integrity: sha512-eAyAGju1gAFwUu6a1z9WkgDKVEotPI5JqjWrjHWftLhDtRFksbqr85XocrXtToTv/hSlnDzIQFiS5TODdYyuSw==}
+  /@theguild/federation-composition@0.8.2(graphql@16.8.1):
+    resolution: {integrity: sha512-uHFgxqEcTX7mV0x+hh0drm0rHs9y8SEpH8U+Uh9Y2n1nKkAEPVwEFogLMgBB55iiTRNXrlLAOzRPx5/RWAQi6Q==}
     engines: {node: '>=18'}
     peerDependencies:
       graphql: ^16.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -593,8 +593,8 @@ importers:
         specifier: 0.1.0
         version: 0.1.0(patch_hash=ryylgra5xglhidfoiaxehn22hq)
       '@theguild/federation-composition':
-        specifier: 0.8.1
-        version: 0.8.1(graphql@16.8.1)
+        specifier: 0.8.2-alpha-20240222093720-e8f2bb3
+        version: 0.8.2-alpha-20240222093720-e8f2bb3(graphql@16.8.1)
       '@trpc/client':
         specifier: 10.45.1
         version: 10.45.1(@trpc/server@10.45.1)
@@ -971,8 +971,8 @@ importers:
         specifier: 7.102.0
         version: 7.102.0
       '@theguild/federation-composition':
-        specifier: 0.8.1
-        version: 0.8.1(graphql@16.8.1)
+        specifier: 0.8.2-alpha-20240222093720-e8f2bb3
+        version: 0.8.2-alpha-20240222093720-e8f2bb3(graphql@16.8.1)
       '@trpc/server':
         specifier: 10.45.1
         version: 10.45.1
@@ -13203,8 +13203,8 @@ packages:
       - supports-color
     dev: true
 
-  /@theguild/federation-composition@0.8.1(graphql@16.8.1):
-    resolution: {integrity: sha512-yRKCWiCBmIrOzhygiMJgCwLRbWTnxJeb+lEZKINMCok/EW9o7g6Xl4Ln4mAvS98OF92y+6ht0Kf8u+iwmfus8g==}
+  /@theguild/federation-composition@0.8.2-alpha-20240222093720-e8f2bb3(graphql@16.8.1):
+    resolution: {integrity: sha512-eAyAGju1gAFwUu6a1z9WkgDKVEotPI5JqjWrjHWftLhDtRFksbqr85XocrXtToTv/hSlnDzIQFiS5TODdYyuSw==}
     engines: {node: '>=18'}
     peerDependencies:
       graphql: ^16.0.0


### PR DESCRIPTION
There's a possibility that the composite schema SDL contains parts of the spergraph spec. This is a problem because we want to show the public schema to the user, and the supergraph spec is not part of that. This may happen when composite schema was produced with an old version of transformSupergraphToPublicSchema or when supergraph sdl contained something new.

the-guild-org/federation#44