### PR TITLE
feat: capture analytics about composability of external composition r…

### DIFF
--- a/packages/services/service-common/src/trpc.ts
+++ b/packages/services/service-common/src/trpc.ts
@@ -43,7 +43,7 @@ export const handleTRPCError = experimental_standaloneMiddleware<{
       });
     }
 
-    opts.ctx.req.log.error(result.error.message);
+    opts.ctx.req.log.error(result.error.stack ?? result.error);
   }
 
   return result;


### PR DESCRIPTION
…esults

### Background

It might make sense that we use the `parseResult.data.result.sdl` instead of `print(transformSupergraphToPublicSchema(parse(parseResult.data.result.supergraph)))`  here: https://github.com/kamilkisiela/graphql-hive/blob/eb03be4dbe7684fedb1b1bd5e9f055824aac16f1/packages/services/schema/src/orchestrators.ts#L514

Also, we should probably validate the SDL we get from the external service to ensure we don't break Hive.

This PR will add some metric collection in grafana to check whether introducing this change would affect some of our customers.

See https://github.com/kamilkisiela/graphql-hive/pull/4076

### Description

This will help us see whether the SDL we get from external composition passed GraphQL parsing and validation.
-> If we don't get errors it would be safe to enable rejecting SDL that is unparsable/does not pass GraphQL validation.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
