### PR TITLE
Remove `@deprecated` from Hive.dispose()

### DIFF
--- a/packages/libraries/client/src/internal/types.ts
+++ b/packages/libraries/client/src/internal/types.ts
@@ -8,9 +8,6 @@ export interface HiveClient {
   info(): Promise<void>;
   reportSchema: SchemaReporter['report'];
   collectUsage(): CollectUsageCallback;
-  /**
-   * @deprecated https://github.com/kamilkisiela/graphql-hive/issues/659
-   */
   dispose(): Promise<void>;
 }
 


### PR DESCRIPTION
It was originally on `operationStore` property and moved here probably because of incorrect merge conflict resolution.
