### PR TITLE
Fixed: Deletion of organization results in error

### DIFF
--- a/packages/web/app/src/components/v2/modals/delete-organization.tsx
+++ b/packages/web/app/src/components/v2/modals/delete-organization.tsx
@@ -69,8 +69,8 @@ export const DeleteOrganizationModal = ({
                 organization: router.organizationId,
               },
             });
+            void (await replace('/'));
             toggleModalOpen();
-            void replace(`/${organization.cleanId}`);
           }}
         >
           Delete

--- a/packages/web/app/src/components/v2/modals/delete-organization.tsx
+++ b/packages/web/app/src/components/v2/modals/delete-organization.tsx
@@ -2,7 +2,7 @@ import { ReactElement } from 'react';
 import { useRouter } from 'next/router';
 import { useMutation } from 'urql';
 import { Button, Heading, Modal } from '@/components/v2';
-import { FragmentType, graphql, useFragment } from '@/gql';
+import { FragmentType, graphql } from '@/gql';
 import { useRouteSelector } from '@/lib/hooks';
 import { TrashIcon } from '@radix-ui/react-icons';
 
@@ -29,7 +29,6 @@ const DeleteOrganizationModal_OrganizationFragment = graphql(`
 export const DeleteOrganizationModal = ({
   isOpen,
   toggleModalOpen,
-  ...props
 }: {
   isOpen: boolean;
   toggleModalOpen: () => void;

--- a/packages/web/app/src/components/v2/modals/delete-organization.tsx
+++ b/packages/web/app/src/components/v2/modals/delete-organization.tsx
@@ -35,10 +35,6 @@ export const DeleteOrganizationModal = ({
   toggleModalOpen: () => void;
   organization: FragmentType<typeof DeleteOrganizationModal_OrganizationFragment>;
 }): ReactElement => {
-  const organization = useFragment(
-    DeleteOrganizationModal_OrganizationFragment,
-    props.organization,
-  );
   const [, mutate] = useMutation(DeleteOrganizationDocument);
   const router = useRouteSelector();
   const { replace } = useRouter();


### PR DESCRIPTION
### Background
https://github.com/kamilkisiela/graphql-hive/issues/3706

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

Changed route to `/` after delete organization:

1. When we have 1 organization or more: the router will navigate to the last organization.
2. When we have 0 organization, the router will navigate to `/org/new`

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
