### PR TITLE
Apply clients filter to Insight's Clients section

### DIFF
--- a/packages/services/api/src/modules/operations/providers/operations-manager.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-manager.ts
@@ -687,10 +687,12 @@ export class OperationsManager {
     project,
     target,
     operations,
+    clients,
     schemaCoordinate,
   }: {
     period: DateRange;
     operations?: readonly string[];
+    clients?: readonly string[];
     schemaCoordinate?: string;
   } & TargetSelector) {
     this.logger.info('Counting unique clients (period=%o, target=%s)', period, target);
@@ -705,6 +707,7 @@ export class OperationsManager {
       target,
       period,
       operations,
+      clients,
       schemaCoordinate,
     });
   }

--- a/packages/services/api/src/modules/operations/providers/operations-reader.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-reader.ts
@@ -796,11 +796,13 @@ export class OperationsReader {
     target,
     period,
     operations,
+    clients,
     schemaCoordinate,
   }: {
     target: string;
     period: DateRange;
     operations?: readonly string[];
+    clients?: readonly string[];
     schemaCoordinate?: string;
   }): Promise<
     Array<{
@@ -832,6 +834,7 @@ export class OperationsReader {
                 target,
                 period,
                 operations,
+                clients,
                 extra: schemaCoordinate
                   ? [
                       sql`hash IN (SELECT hash FROM coordinates_daily ${this.createFilter({
@@ -859,6 +862,7 @@ export class OperationsReader {
                 target,
                 period,
                 operations,
+                clients,
                 extra: schemaCoordinate
                   ? [
                       sql`hash IN (SELECT hash FROM coordinates_daily ${this.createFilter({
@@ -886,6 +890,7 @@ export class OperationsReader {
                 target,
                 period,
                 operations,
+                clients,
                 extra: schemaCoordinate
                   ? [
                       sql`hash IN (SELECT hash FROM coordinates_daily ${this.createFilter({

--- a/packages/services/api/src/modules/operations/resolvers.ts
+++ b/packages/services/api/src/modules/operations/resolvers.ts
@@ -433,7 +433,7 @@ export const resolvers: OperationsModule.Resolvers = {
       });
     },
     clients(
-      { organization, project, target, period, operations: operationsFilter },
+      { organization, project, target, period, operations: operationsFilter, clients },
       _,
       { injector },
     ) {
@@ -443,6 +443,7 @@ export const resolvers: OperationsModule.Resolvers = {
         organization,
         period,
         operations: operationsFilter,
+        clients,
       });
     },
     duration(


### PR DESCRIPTION
Filtering insights by Clients will filter all page sections except the Clients section.