### PR TITLE
Patch slonik and add pool.on(error) handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,8 @@
       "nextra-theme-docs@2.12.3": "patches/nextra-theme-docs@2.12.3.patch",
       "@theguild/components@5.2.4": "patches/@theguild__components@5.2.4.patch",
       "nextra@2.12.3": "patches/nextra@2.12.3.patch",
-      "got@14.2.1": "patches/got@14.2.1.patch"
+      "got@14.2.1": "patches/got@14.2.1.patch",
+      "slonik@30.4.4": "patches/slonik@30.4.4.patch"
     }
   }
 }

--- a/patches/slonik@30.4.4.patch
+++ b/patches/slonik@30.4.4.patch
@@ -1,0 +1,21 @@
+diff --git a/dist/src/factories/createPool.js b/dist/src/factories/createPool.js
+index b91a9fe433dc340f5cdf096ca4c568297c343ab3..401df1272d1c7f344bb956b38cc7dbde29231742 100644
+--- a/dist/src/factories/createPool.js
++++ b/dist/src/factories/createPool.js
+@@ -44,6 +44,16 @@ const createPool = async (connectionUri, clientConfigurationInput) => {
+             getTypeParser,
+         },
+     });
++
++    // https://github.com/gajus/slonik/issues/471
++    // https://github.com/brianc/node-postgres/issues/2764#issuecomment-1163475426
++    // Slonik did not have a way to handle errors emitted by the pool, which resulted in an uncaught exception, which would crash the process.
++    pool.on('error', (error) => {
++        poolLog.error({
++            error: (0, serialize_error_1.serializeError)(error),
++        }, 'client error');
++    });
++
+     state_1.poolStateMap.set(pool, {
+         ended: false,
+         mock: false,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ patchedDependencies:
   oclif@3.17.2:
     hash: p4jeiorqjhwzipwrwepbyei4ba
     path: patches/oclif@3.17.2.patch
+  slonik@30.4.4:
+    hash: jxrvl4xmdvyktjijg7yfdkb34i
+    path: patches/slonik@30.4.4.patch
 
 importers:
 
@@ -325,7 +328,7 @@ importers:
         version: 5.3.2
       slonik:
         specifier: 30.4.4
-        version: 30.4.4
+        version: 30.4.4(patch_hash=jxrvl4xmdvyktjijg7yfdkb34i)
       strip-ansi:
         specifier: 7.1.0
         version: 7.1.0
@@ -539,7 +542,7 @@ importers:
         version: 11.5.4
       slonik:
         specifier: 30.4.4
-        version: 30.4.4
+        version: 30.4.4(patch_hash=jxrvl4xmdvyktjijg7yfdkb34i)
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.4.8)(@types/node@20.11.28)(typescript@5.4.2)
@@ -693,7 +696,7 @@ importers:
         version: 5.0.0-beta.2
       slonik:
         specifier: 30.4.4
-        version: 30.4.4
+        version: 30.4.4(patch_hash=jxrvl4xmdvyktjijg7yfdkb34i)
       supertokens-node:
         specifier: 15.2.1
         version: 15.2.1
@@ -1180,7 +1183,7 @@ importers:
         version: 11.5.4
       slonik:
         specifier: 30.4.4
-        version: 30.4.4
+        version: 30.4.4(patch_hash=jxrvl4xmdvyktjijg7yfdkb34i)
       slonik-interceptor-query-logging:
         specifier: 1.4.7
         version: 1.4.7(slonik@30.4.4)
@@ -29821,7 +29824,7 @@ packages:
       crack-json: 1.3.0
       pretty-ms: 7.0.1
       serialize-error: 8.1.0
-      slonik: 30.4.4
+      slonik: 30.4.4(patch_hash=jxrvl4xmdvyktjijg7yfdkb34i)
     dev: true
 
   /slonik-utilities@1.9.4(slonik@30.4.4):
@@ -29836,10 +29839,10 @@ packages:
       lodash: 4.17.21
       roarr: 7.14.3
       serialize-error: 5.0.0
-      slonik: 30.4.4
+      slonik: 30.4.4(patch_hash=jxrvl4xmdvyktjijg7yfdkb34i)
     dev: true
 
-  /slonik@30.4.4:
+  /slonik@30.4.4(patch_hash=jxrvl4xmdvyktjijg7yfdkb34i):
     resolution: {integrity: sha512-5Z1QJhRCDyq0J+0yiUN6COETKtvrYdmukeQn5RZUSt7EvzYo4oTm7D4j2ZV4DN0DMHsaQBSnW/tIgX+UHRJYmQ==}
     engines: {node: '>=10.0'}
     dependencies:
@@ -29866,6 +29869,7 @@ packages:
     transitivePeerDependencies:
       - pg-native
     dev: true
+    patched: true
 
   /smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}


### PR DESCRIPTION
Error: read ETIMEDOUT (db connection) causes uncaught exception that leads to teardown of a process due to lack of pool.on('error') handler in Slonik.