### PR TITLE
chore: use node import specifier for crypto

### DIFF
--- a/.changeset/eleven-queens-share.md
+++ b/.changeset/eleven-queens-share.md
@@ -1,0 +1,8 @@
+---
+"@graphql-hive/cli": patch
+"@graphql-hive/client": patch
+"@graphql-hive/core": patch
+"@graphql-hive/external-composition": patch
+---
+
+Use node specifier for crypto import

--- a/integration-tests/tests/api/artifacts-cdn.spec.ts
+++ b/integration-tests/tests/api/artifacts-cdn.spec.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 import bcrypt from 'bcryptjs';
 import { ApolloGateway } from '@apollo/gateway';
 import { ApolloServer } from '@apollo/server';

--- a/packages/libraries/client/src/apollo.ts
+++ b/packages/libraries/client/src/apollo.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import axios from 'axios';
 import type { DocumentNode } from 'graphql';
 import type { ApolloServerPlugin } from '@apollo/server';

--- a/packages/libraries/client/src/gateways.ts
+++ b/packages/libraries/client/src/gateways.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import axios from 'axios';
 import type { SchemaFetcherOptions, ServicesFetcherOptions } from './internal/types.js';
 import { version } from './version.js';

--- a/packages/libraries/client/src/internal/utils.ts
+++ b/packages/libraries/client/src/internal/utils.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import { hiveClientSymbol } from '../client.js';
 import type {
   AsyncIterableIteratorOrValue,

--- a/packages/libraries/core/src/hash.ts
+++ b/packages/libraries/core/src/hash.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 
 export function hashOperation(operation: string) {
   return createHash('md5').update(operation, 'utf8').digest('hex');

--- a/packages/libraries/external-composition/src/index.ts
+++ b/packages/libraries/external-composition/src/index.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 
 export type ErrorCode = 'ERR_EMPTY_BODY' | 'ERR_INVALID_SIGNATURE';
 

--- a/packages/migrations/src/actions/2023.01.17T10.46.28.import-legacy-s3-keys-to-database.ts
+++ b/packages/migrations/src/actions/2023.01.17T10.46.28.import-legacy-s3-keys-to-database.ts
@@ -1,4 +1,4 @@
-import { createHmac } from 'crypto';
+import { createHmac } from 'node:crypto';
 import bcryptjs from 'bcryptjs';
 import pLimit from 'p-limit';
 import * as zod from 'zod';

--- a/packages/services/api/src/modules/organization/providers/organization-manager.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-manager.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import { Inject, Injectable, Scope } from 'graphql-modules';
 import { paramCase } from 'param-case';
 import { Organization, OrganizationMemberRole } from '../../../shared/entities';

--- a/packages/services/api/src/modules/schema/providers/schema-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-helper.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import { DocumentNode, print, visit } from 'graphql';
 import { Injectable, Scope } from 'graphql-modules';
 import objectHash from 'object-hash';

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import stringify from 'fast-json-stable-stringify';
 import { parse, print } from 'graphql';
 import { Inject, Injectable, Scope } from 'graphql-modules';

--- a/packages/services/api/src/modules/schema/resolvers.ts
+++ b/packages/services/api/src/modules/schema/resolvers.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import stringify from 'fast-json-stable-stringify';
 import {
   GraphQLEnumType,

--- a/packages/services/api/src/modules/shared/providers/crypto.ts
+++ b/packages/services/api/src/modules/shared/providers/crypto.ts
@@ -1,4 +1,4 @@
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 import { Inject, Injectable, InjectionToken, Scope } from 'graphql-modules';
 
 const ALG = 'aes256';

--- a/packages/services/api/src/shared/helpers.ts
+++ b/packages/services/api/src/shared/helpers.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import type { InjectionToken } from 'graphql-modules';
 import ms from 'ms';
 import type {

--- a/packages/services/api/src/shared/schema.ts
+++ b/packages/services/api/src/shared/schema.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import {
   buildASTSchema as buildASTSchemaGraphQL,
   ConstDirectiveNode,

--- a/packages/services/cdn-worker/tests/cdn.spec.ts
+++ b/packages/services/cdn-worker/tests/cdn.spec.ts
@@ -1,4 +1,4 @@
-import { createHmac } from 'crypto';
+import { createHmac } from 'node:crypto';
 import * as bcrypt from 'bcryptjs';
 import '../src/dev-polyfill';
 // eslint-disable-next-line import/no-extraneous-dependencies

--- a/packages/services/schema/src/cache.ts
+++ b/packages/services/schema/src/cache.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import stringify from 'fast-json-stable-stringify';
 import type { Redis } from 'ioredis';
 import pTimeout, { TimeoutError } from 'p-timeout';

--- a/packages/services/schema/src/index.ts
+++ b/packages/services/schema/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import crypto from 'crypto';
+import crypto from 'node:crypto';
 import { hostname } from 'os';
 import Redis from 'ioredis';
 import {

--- a/packages/services/schema/src/orchestrators.ts
+++ b/packages/services/schema/src/orchestrators.ts
@@ -1,4 +1,4 @@
-import { createHmac } from 'crypto';
+import { createHmac } from 'node:crypto';
 import type { FastifyRequest } from 'fastify';
 import got, { RequestError } from 'got';
 import type { DocumentNode } from 'graphql';

--- a/packages/services/tokens/src/api.ts
+++ b/packages/services/tokens/src/api.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import type { FastifyRequest } from 'fastify';
 import { Lru as LruType } from 'tiny-lru';
 import { z } from 'zod';

--- a/packages/services/usage-ingestor/src/processor.ts
+++ b/packages/services/usage-ingestor/src/processor.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import type {
   DefinitionNode,
   DocumentNode,

--- a/packages/services/usage/src/buffer.ts
+++ b/packages/services/usage/src/buffer.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'crypto';
+import { randomUUID } from 'node:crypto';
 import type { ServiceLogger } from '@hive/service-common';
 
 export class BufferTooBigError extends Error {

--- a/packages/services/usage/src/usage.ts
+++ b/packages/services/usage/src/usage.ts
@@ -1,4 +1,4 @@
-import { createHash, randomUUID } from 'crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { CompressionTypes, Kafka, logLevel, Partitioners, RetryOptions } from 'kafkajs';
 import type { ServiceLogger } from '@hive/service-common';
 import type { RawOperationMap, RawReport } from '@hive/usage-common';

--- a/packages/services/webhooks/src/jobs.ts
+++ b/packages/services/webhooks/src/jobs.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import type { Job, Queue } from 'bullmq';
 import { got } from 'got';
 import type { WebhookInput } from './scheduler';


### PR DESCRIPTION
### Background

Using graphql client with cloudflare workers and nodejs_compat, a lot of errors due to the node crypto import prevents building without patching core and client.

### Description

This PR adds a node specifier to the crypto imports.

### Checklist

This change has no side effects and shouldn't require a checklist.

