### PR TITLE
Use short TTL for composition result when unexpected error is detected

### DIFF
--- a/deployment/services/schema.ts
+++ b/deployment/services/schema.ts
@@ -35,7 +35,7 @@ export function deploySchema({
         REQUEST_BROKER: '1',
         SCHEMA_CACHE_POLL_INTERVAL_MS: '150',
         SCHEMA_CACHE_TTL_MS: '65000' /* 65s */,
-        SCHEMA_CACHE_SUCCESS_TTL_MS: '86400000' /* 24h */,
+        SCHEMA_CACHE_SUCCESS_TTL_MS: '43200000' /* 12h */,
         SCHEMA_COMPOSITION_TIMEOUT_MS: '60000' /* 60s */,
       },
       readinessProbe: '/_readiness',

--- a/packages/services/schema/src/index.ts
+++ b/packages/services/schema/src/index.ts
@@ -108,7 +108,7 @@ async function main() {
       router: schemaBuilderApiRouter,
       createContext({ req }): Context {
         const cache = createCache({
-          prefix: 'schema-service',
+          prefix: 'schema-service-v2',
           redis,
           logger: req.log,
           pollIntervalMs: env.timings.cachePollInterval,

--- a/packages/services/schema/src/orchestrators.ts
+++ b/packages/services/schema/src/orchestrators.ts
@@ -399,7 +399,9 @@ type SubgraphInput = {
 function composeFederationV2(
   subgraphs: Array<SubgraphInput>,
   logger: ServiceLogger,
-): ComposerMethodResult {
+): ComposerMethodResult & {
+  includesException?: boolean;
+} {
   try {
     const result = nativeComposeServices(subgraphs);
 
@@ -438,6 +440,7 @@ function composeFederationV2(
         sdl: undefined,
       },
       includesNetworkError: false,
+      includesException: true,
     } as const;
   }
 }
@@ -565,6 +568,7 @@ const createFederation: (
     },
     CompositionResult & {
       includesNetworkError: boolean;
+      includesException?: boolean;
       tags: Array<string> | null;
     }
   >(
@@ -613,6 +617,7 @@ const createFederation: (
       {
         const tempResult: CompositionResult & {
           includesNetworkError: boolean;
+          includesException?: boolean;
         } = await compose(subgraphs);
 
         if (tempResult.type === 'success') {
@@ -735,7 +740,8 @@ const createFederation: (
       };
     },
     function pickCacheType(result) {
-      return 'includesNetworkError' in result && result.includesNetworkError === true
+      return ('includesNetworkError' in result && result.includesNetworkError === true) ||
+        ('includesException' in result && result.includesException === true)
         ? 'short'
         : 'long';
     },


### PR DESCRIPTION
In case of unexpected errors, store composition result for a short time (it's one minute in production), instead of 24h.

I changed the prefix from `schema-service` to `schema-service-v2` to nuke the Redis cache.

I also reduced the long time from 24h to 12h (Redis storage should decrease).