### PR TITLE
Enable Native Composition by default for newly created projects

### DIFF
--- a/integration-tests/tests/api/schema/external-composition.spec.ts
+++ b/integration-tests/tests/api/schema/external-composition.spec.ts
@@ -7,7 +7,7 @@ import { generateUnique } from '../../../testkit/utils';
 test.concurrent('call an external service to compose and validate services', async () => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject, organization } = await createOrg();
-  const { createToken, project } = await createProject(ProjectType.Federation);
+  const { createToken, project, setNativeFederation } = await createProject(ProjectType.Federation);
 
   // Create a token with write rights
   const writeToken = await createToken({
@@ -36,8 +36,7 @@ test.concurrent('call an external service to compose and validate services', asy
     })
     .then(r => r.expectNoGraphQLErrors());
 
-  // Schema publish should be unsuccessful (Fed v2 features are not enabled yet)
-  expect(publishUsersResult.schemaPublish.__typename).toBe('SchemaPublishError');
+  expect(publishUsersResult.schemaPublish.__typename).toBe('SchemaPublishSuccess');
 
   // expect `users` service to be composed internally
   await expect(history()).resolves.not.toContainEqual(usersServiceName);
@@ -60,6 +59,9 @@ test.concurrent('call an external service to compose and validate services', asy
     externalCompositionResult.enableExternalSchemaComposition.ok?.externalSchemaComposition
       ?.endpoint,
   ).toBe(`http://${dockerAddress}/compose`);
+
+  // set native federation to false to force external composition
+  await setNativeFederation(false);
 
   const productsServiceName = generateUnique();
   const publishProductsResult = await writeToken
@@ -92,7 +94,9 @@ test.concurrent(
   async () => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject, organization } = await createOrg();
-    const { createToken, project } = await createProject(ProjectType.Federation);
+    const { createToken, project, setNativeFederation } = await createProject(
+      ProjectType.Federation,
+    );
 
     // Create a token with write rights
     const writeToken = await createToken({
@@ -144,6 +148,9 @@ test.concurrent(
         ?.endpoint,
     ).toBe(`http://${dockerAddress}/fail_on_signature`);
 
+    // set native federation to false to force external composition
+    await setNativeFederation(false);
+
     const productsServiceName = generateUnique();
     const publishProductsResult = await writeToken
       .publishSchema({
@@ -187,7 +194,9 @@ test.concurrent(
   async () => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject, organization } = await createOrg();
-    const { createToken, project } = await createProject(ProjectType.Federation);
+    const { createToken, project, setNativeFederation } = await createProject(
+      ProjectType.Federation,
+    );
 
     // Create a token with write rights
     const writeToken = await createToken({
@@ -238,6 +247,8 @@ test.concurrent(
       externalCompositionResult.enableExternalSchemaComposition.ok?.externalSchemaComposition
         ?.endpoint,
     ).toBe(`http://${dockerAddress}/non-existing-endpoint`);
+    // set native federation to false to force external composition
+    await setNativeFederation(false);
 
     const productsServiceName = generateUnique();
     const publishProductsResult = await writeToken
@@ -280,7 +291,7 @@ test.concurrent(
 test.concurrent('a timeout error should be visible to the user', async ({ expect }) => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject, organization } = await createOrg();
-  const { createToken, project } = await createProject(ProjectType.Federation);
+  const { createToken, project, setNativeFederation } = await createProject(ProjectType.Federation);
 
   // Create a token with write rights
   const writeToken = await createToken({
@@ -331,6 +342,8 @@ test.concurrent('a timeout error should be visible to the user', async ({ expect
     externalCompositionResult.enableExternalSchemaComposition.ok?.externalSchemaComposition
       ?.endpoint,
   ).toBe(`http://${dockerAddress}/timeout`);
+  // set native federation to false to force external composition
+  await setNativeFederation(false);
 
   const productsServiceName = generateUnique();
   const publishProductsResult = await writeToken

--- a/integration-tests/tests/models/federation.spec.ts
+++ b/integration-tests/tests/models/federation.spec.ts
@@ -5,31 +5,27 @@ import { prepareProject } from '../../testkit/registry-models';
 import { initSeed } from '../../testkit/seed';
 
 const cases = [
-  ['default' as const, [] as [string, boolean][], false],
+  ['default' as const, [] as [string, boolean][]],
   [
     'compareToPreviousComposableVersion' as const,
     [['compareToPreviousComposableVersion', true]] as [string, boolean][],
-    false,
   ],
-  [
-    'nativeFederation' as const,
-    [['compareToPreviousComposableVersion', true]] as [string, boolean][],
-    true,
-  ],
+  ['@apollo/federation' as const, [] as [string, boolean][]],
 ] as Array<
   [
-    'default' | 'compareToPreviousComposableVersion' | 'nativeFederation',
+    'default' | 'compareToPreviousComposableVersion' | '@apollo/federation',
     Array<[string, boolean]>,
-    boolean,
   ]
 >;
 
 describe('publish', () => {
-  describe.concurrent.each(cases)('%s', (caseName, ffs, nativeFederation) => {
+  describe.concurrent.each(cases)('%s', (caseName, ffs) => {
+    const legacyComposition = caseName === '@apollo/federation';
+
     test.concurrent('accepted: composable', async () => {
       const {
         cli: { publish },
-      } = await prepare(ffs, nativeFederation);
+      } = await prepare(ffs, legacyComposition);
       await publish({
         sdl: `type Query { topProductName: String }`,
         serviceName: 'products',
@@ -41,7 +37,7 @@ describe('publish', () => {
     test.concurrent('accepted: composable, breaking changes', async () => {
       const {
         cli: { publish },
-      } = await prepare(ffs, nativeFederation);
+      } = await prepare(ffs, legacyComposition);
       await publish({
         sdl: /* GraphQL */ `
           type Query {
@@ -66,11 +62,11 @@ describe('publish', () => {
     });
 
     test.concurrent(
-      `${caseName === 'default' ? 'rejected' : 'accepted'}: not composable (graphql errors)`,
+      `${caseName === '@apollo/federation' ? 'rejected' : 'accepted'}: not composable (graphql errors)`,
       async () => {
         const {
           cli: { publish },
-        } = await prepare(ffs, nativeFederation);
+        } = await prepare(ffs, legacyComposition);
 
         // non-composable
         await publish({
@@ -81,7 +77,7 @@ describe('publish', () => {
           `,
           serviceName: 'products',
           serviceUrl: 'http://products:3000/graphql',
-          expect: caseName === 'default' ? 'rejected' : 'latest',
+          expect: caseName === '@apollo/federation' ? 'rejected' : 'latest',
         });
       },
     );
@@ -89,7 +85,7 @@ describe('publish', () => {
     test.concurrent('accepted: composable, previous version was not', async () => {
       const {
         cli: { publish },
-      } = await prepare(ffs, nativeFederation);
+      } = await prepare(ffs, legacyComposition);
 
       // non-composable
       await publish({
@@ -127,7 +123,7 @@ describe('publish', () => {
     test.concurrent('accepted: composable, no changes', async () => {
       const {
         cli: { publish },
-      } = await prepare(ffs, nativeFederation);
+      } = await prepare(ffs, legacyComposition);
 
       // composable
       await publish({
@@ -157,7 +153,7 @@ describe('publish', () => {
     test.concurrent('accepted: composable, no changes, no metadata modification', async () => {
       const {
         cli: { publish },
-      } = await prepare(ffs, nativeFederation);
+      } = await prepare(ffs, legacyComposition);
 
       // composable
       await publish({
@@ -189,7 +185,7 @@ describe('publish', () => {
     test.concurrent('accepted: composable, new url', async () => {
       const {
         cli: { publish },
-      } = await prepare(ffs, nativeFederation);
+      } = await prepare(ffs, legacyComposition);
 
       // composable
       await publish({
@@ -219,7 +215,7 @@ describe('publish', () => {
     test.concurrent('accepted: composable, new metadata', async () => {
       const {
         cli: { publish },
-      } = await prepare(ffs, nativeFederation);
+      } = await prepare(ffs, legacyComposition);
 
       // composable
       await publish({
@@ -251,7 +247,7 @@ describe('publish', () => {
     test.concurrent('rejected: missing service name', async () => {
       const {
         cli: { publish },
-      } = await prepare(ffs, nativeFederation);
+      } = await prepare(ffs, legacyComposition);
 
       // composable
       await publish({
@@ -268,7 +264,7 @@ describe('publish', () => {
     test.concurrent('rejected: missing service url', async () => {
       const {
         cli: { publish },
-      } = await prepare(ffs, nativeFederation);
+      } = await prepare(ffs, legacyComposition);
 
       // composable
       await publish({
@@ -285,7 +281,7 @@ describe('publish', () => {
     test.concurrent('CLI output', async ({ expect }) => {
       const {
         cli: { publish },
-      } = await prepare(ffs, nativeFederation);
+      } = await prepare(ffs, legacyComposition);
 
       const service = {
         serviceName: 'products',
@@ -345,11 +341,13 @@ describe('publish', () => {
 });
 
 describe('check', () => {
-  describe.concurrent.each(cases)('%s', (caseName, ffs, nativeFederation) => {
+  describe.concurrent.each(cases)('%s', (caseName, ffs) => {
+    const legacyComposition = caseName === '@apollo/federation';
+
     test.concurrent('accepted: composable, no breaking changes', async () => {
       const {
         cli: { publish, check },
-      } = await prepare(ffs, nativeFederation);
+      } = await prepare(ffs, legacyComposition);
 
       await publish({
         sdl: /* GraphQL */ `
@@ -379,7 +377,7 @@ describe('check', () => {
     test.concurrent('accepted: composable, previous version was not', async () => {
       const {
         cli: { publish, check },
-      } = await prepare(ffs, nativeFederation);
+      } = await prepare(ffs, legacyComposition);
 
       await publish({
         sdl: /* GraphQL */ `
@@ -415,7 +413,7 @@ describe('check', () => {
     test.concurrent('accepted: no changes', async () => {
       const {
         cli: { publish, check },
-      } = await prepare(ffs, nativeFederation);
+      } = await prepare(ffs, legacyComposition);
 
       await publish({
         sdl: /* GraphQL */ `
@@ -442,7 +440,7 @@ describe('check', () => {
     test.concurrent('rejected: missing service name', async () => {
       const {
         cli: { check },
-      } = await prepare(ffs, nativeFederation);
+      } = await prepare(ffs, legacyComposition);
 
       const message = await check({
         sdl: /* GraphQL */ `
@@ -459,7 +457,7 @@ describe('check', () => {
     test.concurrent('rejected: composable, breaking changes', async () => {
       const {
         cli: { publish, check },
-      } = await prepare(ffs, nativeFederation);
+      } = await prepare(ffs, legacyComposition);
 
       await publish({
         sdl: /* GraphQL */ `
@@ -488,7 +486,7 @@ describe('check', () => {
     test.concurrent('rejected: not composable, no breaking changes', async () => {
       const {
         cli: { publish, check },
-      } = await prepare(ffs, nativeFederation);
+      } = await prepare(ffs, legacyComposition);
 
       await publish({
         sdl: /* GraphQL */ `
@@ -518,7 +516,7 @@ describe('check', () => {
     test.concurrent('rejected: not composable, breaking changes', async () => {
       const {
         cli: { publish, check },
-      } = await prepare(ffs, nativeFederation);
+      } = await prepare(ffs, legacyComposition);
 
       await publish({
         sdl: /* GraphQL */ `
@@ -553,20 +551,22 @@ describe('check', () => {
         }),
       );
 
-      if (caseName === 'nativeFederation') {
-        expect(message).toContain('Cannot query field it on type Product');
-      } else {
+      if (legacyComposition) {
         expect(message).toMatch('Product.it');
         expect(message).toMatch('topProduct');
+      } else {
+        expect(message).toContain('Cannot query field it on type Product');
       }
     });
   });
 });
 
 describe('delete', () => {
-  describe.concurrent.each(cases)('%s', (_, ffs, nativeFederation) => {
+  describe.concurrent.each(cases)('%s', (caseName, ffs) => {
+    const legacyComposition = caseName === '@apollo/federation';
+
     test.concurrent('accepted: composable before and after', async () => {
-      const { cli } = await prepare(ffs, nativeFederation);
+      const { cli } = await prepare(ffs, legacyComposition);
 
       await cli.publish({
         sdl: /* GraphQL */ `
@@ -609,7 +609,7 @@ describe('delete', () => {
     });
 
     test.concurrent('rejected: unknown service', async () => {
-      const { cli } = await prepare(ffs, nativeFederation);
+      const { cli } = await prepare(ffs, legacyComposition);
 
       await cli.publish({
         sdl: /* GraphQL */ `
@@ -661,7 +661,7 @@ describe('other', () => {
       ]);
 
       const supergraph = await fetchSupergraph();
-      expect(supergraph).toMatch('(name: "users" url: "https://api.com/users-subgraph")');
+      expect(supergraph).toMatch('(name: "users", url: "https://api.com/users-subgraph")');
     });
 
     test.concurrent(
@@ -905,7 +905,7 @@ describe('other', () => {
   });
 });
 
-async function prepare(featureFlags: Array<[string, boolean]> = [], nativeFederation = false) {
+async function prepare(featureFlags: Array<[string, boolean]> = [], legacyComposition = false) {
   const { tokens, setFeatureFlag, setNativeFederation, cdn } = await prepareProject(
     ProjectType.Federation,
   );
@@ -914,8 +914,8 @@ async function prepare(featureFlags: Array<[string, boolean]> = [], nativeFedera
     await setFeatureFlag(name, enabled);
   }
 
-  if (nativeFederation === true) {
-    await setNativeFederation(true);
+  if (legacyComposition === true) {
+    await setNativeFederation(false);
   }
 
   return {

--- a/packages/services/api/src/modules/schema/providers/models/composite.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite.ts
@@ -144,11 +144,9 @@ export class CompositeModel {
     const schemas = latest ? swapServices(latest.schemas, incoming).schemas : [incoming];
     schemas.sort((a, b) => a.service_name.localeCompare(b.service_name));
 
-    const compareToPreviousComposableVersion = organization.featureFlags.compareToPreviousComposableVersion || project.nativeFederation;
-    const comparedVersion =
-    compareToPreviousComposableVersion
-        ? latestComposable
-        : latest;
+    const compareToPreviousComposableVersion =
+      organization.featureFlags.compareToPreviousComposableVersion || project.nativeFederation;
+    const comparedVersion = compareToPreviousComposableVersion ? latestComposable : latest;
 
     const checksumCheck = await this.checks.checksum({
       existing: comparedVersion
@@ -320,7 +318,8 @@ export class CompositeModel {
     const previousService = swap?.existing;
     const schemas = swap?.schemas ?? [incoming];
     schemas.sort((a, b) => a.service_name.localeCompare(b.service_name));
-    const compareToLatestComposable = organization.featureFlags.compareToPreviousComposableVersion || project.nativeFederation;
+    const compareToLatestComposable =
+      organization.featureFlags.compareToPreviousComposableVersion || project.nativeFederation;
     const schemaVersionToCompareAgainst = compareToLatestComposable ? latestComposable : latest;
 
     const [serviceNameCheck, serviceUrlCheck] = await Promise.all([
@@ -544,7 +543,8 @@ export class CompositeModel {
     };
 
     const latestVersion = latest;
-    const compareToLatestComposable = organization.featureFlags.compareToPreviousComposableVersion || project.nativeFederation;
+    const compareToLatestComposable =
+      organization.featureFlags.compareToPreviousComposableVersion || project.nativeFederation;
 
     const serviceNameCheck = await this.checks.serviceName({
       name: incoming.service_name,

--- a/packages/services/api/src/modules/schema/providers/models/single.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single.ts
@@ -73,11 +73,9 @@ export class SingleModel {
     };
 
     const schemas = [incoming] as [SingleSchema];
-    const compareToPreviousComposableVersion = organization.featureFlags.compareToPreviousComposableVersion;
-    const comparedVersion =
-    compareToPreviousComposableVersion
-        ? latestComposable
-        : latest;
+    const compareToPreviousComposableVersion =
+      organization.featureFlags.compareToPreviousComposableVersion;
+    const comparedVersion = compareToPreviousComposableVersion ? latestComposable : latest;
 
     const checksumResult = await this.checks.checksum({
       existing: comparedVersion
@@ -201,11 +199,9 @@ export class SingleModel {
 
     const latestVersion = latest;
     const schemas = [incoming] as [SingleSchema];
-    const compareToPreviousComposableVersion = organization.featureFlags.compareToPreviousComposableVersion;
-    const comparedVersion =
-    compareToPreviousComposableVersion
-        ? latestComposable
-        : latest;
+    const compareToPreviousComposableVersion =
+      organization.featureFlags.compareToPreviousComposableVersion;
+    const comparedVersion = compareToPreviousComposableVersion ? latestComposable : latest;
 
     const checksumCheck = await this.checks.checksum({
       existing: comparedVersion

--- a/packages/services/api/src/modules/schema/providers/models/single.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single.ts
@@ -73,10 +73,11 @@ export class SingleModel {
     };
 
     const schemas = [incoming] as [SingleSchema];
+    const compareToPreviousComposableVersion = organization.featureFlags.compareToPreviousComposableVersion;
     const comparedVersion =
-      organization.featureFlags.compareToPreviousComposableVersion === false
-        ? latest
-        : latestComposable;
+    compareToPreviousComposableVersion
+        ? latestComposable
+        : latest;
 
     const checksumResult = await this.checks.checksum({
       existing: comparedVersion
@@ -200,10 +201,11 @@ export class SingleModel {
 
     const latestVersion = latest;
     const schemas = [incoming] as [SingleSchema];
+    const compareToPreviousComposableVersion = organization.featureFlags.compareToPreviousComposableVersion;
     const comparedVersion =
-      organization.featureFlags.compareToPreviousComposableVersion === false
-        ? latest
-        : latestComposable;
+    compareToPreviousComposableVersion
+        ? latestComposable
+        : latest;
 
     const checksumCheck = await this.checks.checksum({
       existing: comparedVersion

--- a/packages/services/api/src/modules/schema/providers/registry-checks.ts
+++ b/packages/services/api/src/modules/schema/providers/registry-checks.ts
@@ -689,15 +689,6 @@ export class RegistryChecks {
       return false;
     }
 
-    if (organization.featureFlags.compareToPreviousComposableVersion === false) {
-      this.logger.warn(
-        'Organization has compareToPreviousComposableVersion FF disabled, ignoring native Federation support (organization=%s, project=%s)',
-        organization.id,
-        project.id,
-      );
-      return false;
-    }
-
     this.logger.debug(
       'Native Federation support available (organization=%s, project=%s)',
       organization.id,

--- a/packages/services/api/src/modules/schema/providers/schema-manager.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-manager.ts
@@ -987,7 +987,8 @@ export class SchemaManager {
       target: args.target,
       beforeVersionId: args.beforeVersionId,
       beforeVersionCreatedAt: args.beforeVersionCreatedAt,
-      onlyComposable: organization.featureFlags.compareToPreviousComposableVersion || project.nativeFederation,
+      onlyComposable:
+        organization.featureFlags.compareToPreviousComposableVersion || project.nativeFederation,
     });
 
     if (!schemaVersion) {

--- a/packages/services/api/src/modules/schema/providers/schema-manager.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-manager.ts
@@ -971,9 +971,15 @@ export class SchemaManager {
   }) {
     this.logger.debug('Fetch version before version id. (args=%o)', args);
 
-    const organization = await this.organizationManager.getOrganization({
-      organization: args.organization,
-    });
+    const [organization, project] = await Promise.all([
+      this.organizationManager.getOrganization({
+        organization: args.organization,
+      }),
+      this.projectManager.getProject({
+        organization: args.organization,
+        project: args.project,
+      }),
+    ]);
 
     const schemaVersion = await this.storage.getVersionBeforeVersionId({
       organization: args.organization,
@@ -981,7 +987,7 @@ export class SchemaManager {
       target: args.target,
       beforeVersionId: args.beforeVersionId,
       beforeVersionCreatedAt: args.beforeVersionCreatedAt,
-      onlyComposable: organization.featureFlags.compareToPreviousComposableVersion,
+      onlyComposable: organization.featureFlags.compareToPreviousComposableVersion || project.nativeFederation,
     });
 
     if (!schemaVersion) {
@@ -1035,15 +1041,6 @@ export class SchemaManager {
     if (input.project.legacyRegistryModel === true) {
       this.logger.warn(
         'Project is using legacy registry model, ignoring native Federation support (organization=%s, project=%s)',
-        input.organization.id,
-        input.project.id,
-      );
-      return false;
-    }
-
-    if (input.organization.featureFlags.compareToPreviousComposableVersion === false) {
-      this.logger.warn(
-        'Organization has compareToPreviousComposableVersion FF disabled, ignoring native Federation support (organization=%s, project=%s)',
         input.organization.id,
         input.project.id,
       );

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -498,16 +498,15 @@ export class SchemaPublisher {
       );
     });
 
-    const compareToPreviousComposableVersion = organization.featureFlags.compareToPreviousComposableVersion || project.nativeFederation;
+    const compareToPreviousComposableVersion =
+      organization.featureFlags.compareToPreviousComposableVersion || project.nativeFederation;
 
-    const comparedVersion =
-    compareToPreviousComposableVersion
-        ? latestComposableVersion
-        : latestVersion;
-    const comparedSchemaVersion =
-    compareToPreviousComposableVersion
-        ? latestComposableSchemaVersion
-        : latestSchemaVersion;
+    const comparedVersion = compareToPreviousComposableVersion
+      ? latestComposableVersion
+      : latestVersion;
+    const comparedSchemaVersion = compareToPreviousComposableVersion
+      ? latestComposableSchemaVersion
+      : latestSchemaVersion;
 
     const conditionalBreakingChangeConfiguration =
       await this.getConditionalBreakingChangeConfiguration({
@@ -1183,7 +1182,8 @@ export class SchemaPublisher {
           }),
         ]);
 
-        const compareToPreviousComposableVersion = organization.featureFlags.compareToPreviousComposableVersion || project.nativeFederation;
+        const compareToPreviousComposableVersion =
+          organization.featureFlags.compareToPreviousComposableVersion || project.nativeFederation;
 
         const modelVersion = project.legacyRegistryModel ? 'legacy' : 'modern';
 
@@ -1280,10 +1280,7 @@ export class SchemaPublisher {
         });
 
         let diffSchemaVersionId: string | null = null;
-        if (
-          compareToPreviousComposableVersion &&
-          latestComposableSchemaVersion
-        ) {
+        if (compareToPreviousComposableVersion && latestComposableSchemaVersion) {
           diffSchemaVersionId = latestComposableSchemaVersion.id;
         }
 
@@ -1598,11 +1595,11 @@ export class SchemaPublisher {
       );
     }
 
-    const compareToPreviousComposableVersion = organization.featureFlags.compareToPreviousComposableVersion || project.nativeFederation;
-    const comparedSchemaVersion =
-      compareToPreviousComposableVersion
-        ? latestComposableSchemaVersion
-        : latestSchemaVersion;
+    const compareToPreviousComposableVersion =
+      organization.featureFlags.compareToPreviousComposableVersion || project.nativeFederation;
+    const comparedSchemaVersion = compareToPreviousComposableVersion
+      ? latestComposableSchemaVersion
+      : latestSchemaVersion;
     const schemaVersionContracts = comparedSchemaVersion
       ? await this.contracts.getContractVersionsForSchemaVersion({
           schemaVersionId: comparedSchemaVersion.id,
@@ -1824,10 +1821,7 @@ export class SchemaPublisher {
     const supergraph = publishResult.state.supergraph ?? null;
 
     let diffSchemaVersionId: string | null = null;
-    if (
-      compareToPreviousComposableVersion &&
-      latestComposableSchemaVersion
-    ) {
+    if (compareToPreviousComposableVersion && latestComposableSchemaVersion) {
       diffSchemaVersionId = latestComposableSchemaVersion.id;
     }
 

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -498,14 +498,16 @@ export class SchemaPublisher {
       );
     });
 
+    const compareToPreviousComposableVersion = organization.featureFlags.compareToPreviousComposableVersion || project.nativeFederation;
+
     const comparedVersion =
-      organization.featureFlags.compareToPreviousComposableVersion === false
-        ? latestVersion
-        : latestComposableVersion;
+    compareToPreviousComposableVersion
+        ? latestComposableVersion
+        : latestVersion;
     const comparedSchemaVersion =
-      organization.featureFlags.compareToPreviousComposableVersion === false
-        ? latestSchemaVersion
-        : latestComposableSchemaVersion;
+    compareToPreviousComposableVersion
+        ? latestComposableSchemaVersion
+        : latestSchemaVersion;
 
     const conditionalBreakingChangeConfiguration =
       await this.getConditionalBreakingChangeConfiguration({
@@ -1181,6 +1183,8 @@ export class SchemaPublisher {
           }),
         ]);
 
+        const compareToPreviousComposableVersion = organization.featureFlags.compareToPreviousComposableVersion || project.nativeFederation;
+
         const modelVersion = project.legacyRegistryModel ? 'legacy' : 'modern';
 
         schemaDeleteCount.inc({ model: modelVersion, projectType: project.type });
@@ -1277,13 +1281,13 @@ export class SchemaPublisher {
 
         let diffSchemaVersionId: string | null = null;
         if (
-          organization.featureFlags.compareToPreviousComposableVersion &&
+          compareToPreviousComposableVersion &&
           latestComposableSchemaVersion
         ) {
           diffSchemaVersionId = latestComposableSchemaVersion.id;
         }
 
-        if (!organization.featureFlags.compareToPreviousComposableVersion && latestSchemaVersion) {
+        if (!compareToPreviousComposableVersion && latestSchemaVersion) {
           diffSchemaVersionId = latestSchemaVersion.id;
         }
 
@@ -1594,10 +1598,11 @@ export class SchemaPublisher {
       );
     }
 
+    const compareToPreviousComposableVersion = organization.featureFlags.compareToPreviousComposableVersion || project.nativeFederation;
     const comparedSchemaVersion =
-      organization.featureFlags.compareToPreviousComposableVersion === false
-        ? latestSchemaVersion
-        : latestComposableSchemaVersion;
+      compareToPreviousComposableVersion
+        ? latestComposableSchemaVersion
+        : latestSchemaVersion;
     const schemaVersionContracts = comparedSchemaVersion
       ? await this.contracts.getContractVersionsForSchemaVersion({
           schemaVersionId: comparedSchemaVersion.id,
@@ -1820,13 +1825,13 @@ export class SchemaPublisher {
 
     let diffSchemaVersionId: string | null = null;
     if (
-      organization.featureFlags.compareToPreviousComposableVersion &&
+      compareToPreviousComposableVersion &&
       latestComposableSchemaVersion
     ) {
       diffSchemaVersionId = latestComposableSchemaVersion.id;
     }
 
-    if (!organization.featureFlags.compareToPreviousComposableVersion && latestSchemaVersion) {
+    if (!compareToPreviousComposableVersion && latestSchemaVersion) {
       diffSchemaVersionId = latestSchemaVersion.id;
     }
 

--- a/packages/web/app/src/components/project/settings/external-composition.tsx
+++ b/packages/web/app/src/components/project/settings/external-composition.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery } from 'urql';
 import * as Yup from 'yup';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
-import { DocsLink, DocsNote, Input, Spinner, Switch, Tooltip } from '@/components/v2';
+import { DocsNote, Input, Spinner, Switch, Tooltip } from '@/components/v2';
 import { ProductUpdatesLink } from '@/components/v2/docs-note';
 import { FragmentType, graphql, useFragment } from '@/gql';
 import { useNotifications } from '@/lib/hooks';

--- a/packages/web/app/src/components/project/settings/external-composition.tsx
+++ b/packages/web/app/src/components/project/settings/external-composition.tsx
@@ -15,6 +15,7 @@ export const ExternalCompositionStatus_TestQuery = graphql(`
     testExternalSchemaComposition(selector: $selector) {
       ok {
         id
+        isNativeFederationEnabled
         externalSchemaComposition {
           endpoint
         }
@@ -31,6 +32,7 @@ export const ExternalCompositionForm_EnableMutation = graphql(`
     enableExternalSchemaComposition(input: $input) {
       ok {
         id
+        isNativeFederationEnabled
         externalSchemaComposition {
           endpoint
         }
@@ -226,6 +228,7 @@ export const ExternalComposition_DisableMutation = graphql(`
     disableExternalSchemaComposition(input: $input) {
       ok {
         id
+        isNativeFederationEnabled
         externalSchemaComposition {
           endpoint
         }
@@ -240,6 +243,7 @@ export const ExternalComposition_ProjectConfigurationQuery = graphql(`
     project(selector: $selector) {
       id
       cleanId
+      isNativeFederationEnabled
       externalSchemaComposition {
         endpoint
       }
@@ -312,6 +316,7 @@ export const ExternalCompositionSettings = (props: {
   const isEnabled = typeof enabled === 'boolean' ? enabled : initialEnabled;
   const isLoading = projectQuery.fetching || mutation.fetching;
   const isFormVisible = isEnabled && !isLoading;
+  const isNativeCompositionEnabled = projectQuery.data?.project?.isNativeFederationEnabled;
 
   return (
     <Card>
@@ -339,13 +344,12 @@ export const ExternalCompositionSettings = (props: {
       </CardHeader>
 
       <CardContent>
-        <DocsNote>
-          External Schema Composition is required for using Apollo Federation 2 with Hive.
-          <br />
-          <DocsLink href="/management/external-schema-composition">
-            Learn more about Apollo Federation 2 support
-          </DocsLink>
-        </DocsNote>
+        {isNativeCompositionEnabled ? (
+          <DocsNote warn>
+            It appears that Native Federation v2 Composition is activated, external composition
+            won't have any effect.
+          </DocsNote>
+        ) : null}
 
         {isFormVisible ? (
           <ExternalCompositionForm

--- a/packages/web/app/src/components/project/settings/native-composition.tsx
+++ b/packages/web/app/src/components/project/settings/native-composition.tsx
@@ -134,7 +134,7 @@ export function NativeCompositionSettings(props: {
     <Card>
       <CardHeader>
         <CardTitle>
-          <a id="native-composition">Native Composition</a>
+          <a id="native-composition">Native Federation v2 Composition</a>
         </CardTitle>
         <CardDescription>Native Apollo Federation v2 support for your project.</CardDescription>
         {project.isNativeFederationEnabled ? null : (


### PR DESCRIPTION
Every new project will use native composition by default.
It's possible to opt-out in project settings.

--

It's also no longer required to update organization's `compareToPreviousComposableVersion` feature flag as it no longer has any effect when native composition is detected.