### PR TITLE
Disable tailwindcss/no-unnecessary-arbitrary-value rule

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -152,6 +152,7 @@ module.exports = {
       rules: {
         // conflicts with official prettier-plugin-tailwindcss and tailwind v3
         'tailwindcss/classnames-order': 'off',
+        'tailwindcss/no-unnecessary-arbitrary-value': 'off',
         // set more strict to highlight in editor
         'tailwindcss/enforces-shorthand': 'error',
         'tailwindcss/no-custom-classname': 'error',


### PR DESCRIPTION
> 'divide-y-[1px]' could be replaced by 'divide-y-DEFAULT'

I believe I prefer `divide-y-[1px]` over `divide-y-DEFAULT` :))
