### PR TITLE
Fix Policy view for Project

### DIFF
--- a/packages/services/api/src/modules/policy/module.graphql.ts
+++ b/packages/services/api/src/modules/policy/module.graphql.ts
@@ -81,6 +81,7 @@ export default gql`
 
   extend type Project {
     schemaPolicy: SchemaPolicy
+    parentSchemaPolicy: SchemaPolicy
   }
 
   extend type Target {

--- a/packages/services/api/src/modules/policy/providers/schema-policy.provider.ts
+++ b/packages/services/api/src/modules/policy/providers/schema-policy.provider.ts
@@ -48,7 +48,7 @@ export class SchemaPolicyProvider {
   }> {
     await this.authManager.ensureTargetAccess({
       ...selector,
-      scope: TargetAccessScope.SETTINGS,
+      scope: TargetAccessScope.READ,
     });
 
     return this._getCalculatedPolicyForTarget(selector);
@@ -170,7 +170,7 @@ export class SchemaPolicyProvider {
   async getOrganizationPolicy(selector: OrganizationSelector) {
     await this.authManager.ensureOrganizationAccess({
       ...selector,
-      scope: OrganizationAccessScope.SETTINGS,
+      scope: OrganizationAccessScope.READ,
     });
 
     return this.storage.getSchemaPolicyForOrganization(selector.organization);
@@ -179,7 +179,7 @@ export class SchemaPolicyProvider {
   async getProjectPolicy(selector: ProjectSelector) {
     await this.authManager.ensureProjectAccess({
       ...selector,
-      scope: ProjectAccessScope.SETTINGS,
+      scope: ProjectAccessScope.READ,
     });
 
     return this.storage.getSchemaPolicyForProject(selector.project);

--- a/packages/services/api/src/modules/policy/providers/schema-policy.provider.ts
+++ b/packages/services/api/src/modules/policy/providers/schema-policy.provider.ts
@@ -48,7 +48,7 @@ export class SchemaPolicyProvider {
   }> {
     await this.authManager.ensureTargetAccess({
       ...selector,
-      scope: TargetAccessScope.READ,
+      scope: TargetAccessScope.SETTINGS,
     });
 
     return this._getCalculatedPolicyForTarget(selector);
@@ -170,7 +170,16 @@ export class SchemaPolicyProvider {
   async getOrganizationPolicy(selector: OrganizationSelector) {
     await this.authManager.ensureOrganizationAccess({
       ...selector,
-      scope: OrganizationAccessScope.READ,
+      scope: OrganizationAccessScope.SETTINGS,
+    });
+
+    return this.storage.getSchemaPolicyForOrganization(selector.organization);
+  }
+
+  async getOrganizationPolicyForProject(selector: ProjectSelector) {
+    await this.authManager.ensureProjectAccess({
+      ...selector,
+      scope: ProjectAccessScope.SETTINGS,
     });
 
     return this.storage.getSchemaPolicyForOrganization(selector.organization);
@@ -179,7 +188,7 @@ export class SchemaPolicyProvider {
   async getProjectPolicy(selector: ProjectSelector) {
     await this.authManager.ensureProjectAccess({
       ...selector,
-      scope: ProjectAccessScope.READ,
+      scope: ProjectAccessScope.SETTINGS,
     });
 
     return this.storage.getSchemaPolicyForProject(selector.project);

--- a/packages/services/api/src/modules/policy/resolvers.ts
+++ b/packages/services/api/src/modules/policy/resolvers.ts
@@ -33,6 +33,11 @@ export const resolvers: PolicyModule.Resolvers = {
         project: project.id,
         organization: project.orgId,
       }),
+    parentSchemaPolicy: async (project, _, { injector }) =>
+      injector.get(SchemaPolicyProvider).getOrganizationPolicyForProject({
+        project: project.id,
+        organization: project.orgId,
+      }),
   },
   Target: {
     schemaPolicy: async (target, _, { injector }) => {

--- a/packages/web/app/pages/[organizationId]/[projectId]/view/policy.tsx
+++ b/packages/web/app/pages/[organizationId]/[projectId]/view/policy.tsx
@@ -160,11 +160,11 @@ function ProjectPolicyContent() {
               )}
             </CardHeader>
             <CardContent>
-              {currentOrganization.schemaPolicy === null ||
-              currentOrganization.schemaPolicy?.allowOverrides ? (
+              {currentProject.parentSchemaPolicy === null ||
+              currentProject.parentSchemaPolicy?.allowOverrides ? (
                 <PolicySettings
                   saving={mutation.fetching}
-                  rulesInParent={currentOrganization.schemaPolicy?.rules.map(r => r.rule.id)}
+                  rulesInParent={currentProject.parentSchemaPolicy?.rules.map(r => r.rule.id)}
                   error={
                     mutation.error?.message ||
                     mutation.data?.updateSchemaPolicyForProject.error?.message

--- a/packages/web/app/pages/[organizationId]/[projectId]/view/policy.tsx
+++ b/packages/web/app/pages/[organizationId]/[projectId]/view/policy.tsx
@@ -17,16 +17,6 @@ const ProjectPolicyPageQuery = graphql(`
     organization(selector: { organization: $organizationId }) {
       organization {
         id
-        schemaPolicy {
-          id
-          updatedAt
-          allowOverrides
-          rules {
-            rule {
-              id
-            }
-          }
-        }
         me {
           id
           ...CanAccessProject_MemberFragment
@@ -42,6 +32,16 @@ const ProjectPolicyPageQuery = graphql(`
         id
         updatedAt
         ...PolicySettings_SchemaPolicyFragment
+      }
+      parentSchemaPolicy {
+        id
+        updatedAt
+        allowOverrides
+        rules {
+          rule {
+            id
+          }
+        }
       }
     }
     organizations {


### PR DESCRIPTION
When a user has `project.settings` access but not `organization.settings`, Policy page fails to load as its GraphQL query lacks permissions to read schema policy of an organization (`Organization.schemaPolicy` needs `organization.settings`).

To fix it, I added `Project.parentSchemaPolicy` field that resolves the same value, but expects `project.settings` access.