### PR TITLE
Limit date range filter of Explorer to days

### DIFF
--- a/packages/web/app/src/components/target/explorer/filter.tsx
+++ b/packages/web/app/src/components/target/explorer/filter.tsx
@@ -138,7 +138,7 @@ export function DateRangeFilter() {
 
   return (
     <DateRangePicker
-      validUnits={['y', 'M', 'w', 'd', 'h']}
+      validUnits={['y', 'M', 'w', 'd']}
       onUpdate={value => {
         periodSelector.setPeriod(value.preset.range);
       }}


### PR DESCRIPTION
### Background

We don't aggregate data hourly or minutely for schema coordinates, so no data to display for Last X hours.