### PR TITLE
Add daily aggregation of requests per organization

### DIFF
--- a/packages/migrations/src/clickhouse-actions/008-daily-operations-log.ts
+++ b/packages/migrations/src/clickhouse-actions/008-daily-operations-log.ts
@@ -1,0 +1,55 @@
+import type { Action } from '../clickhouse';
+
+export const action: Action = async (exec, _query, isHiveCloud) => {
+  let where = 'WHERE notEmpty(organization)';
+
+  if (isHiveCloud) {
+    // Starts aggregating data the next day of the migration (deployment)
+    const tomorrow = new Date();
+    tomorrow.setUTCDate(tomorrow.getUTCDate() + 1);
+    const startOfTomorrow = tomorrow.toISOString().split('T')[0];
+
+    where += ` AND toDate(timestamp) >= toDate('${startOfTomorrow}')`;
+  }
+
+  await exec(`
+    CREATE TABLE IF NOT EXISTS daily_overview
+    (
+      organization LowCardinality(String) CODEC(ZSTD(1)),
+      date Date CODEC(DoubleDelta, ZSTD(1)),
+      total UInt32 CODEC(T64, ZSTD(1))
+    )
+    ENGINE = SummingMergeTree
+    PARTITION BY tuple()
+    PRIMARY KEY (organization)
+    ORDER BY (organization, date)
+    TTL date + INTERVAL 2 MONTH
+    SETTINGS index_granularity = 8192
+  `);
+
+  await exec(`
+    CREATE MATERIALIZED VIEW IF NOT EXISTS daily_overview_operations
+    TO daily_overview
+    AS
+      SELECT
+        organization,
+        toDate(timestamp) AS date,
+        count() AS total
+      FROM default.operations
+      WHERE ${where}
+      GROUP BY organization, date
+  `);
+
+  await exec(`
+    CREATE MATERIALIZED VIEW IF NOT EXISTS daily_overview_subscriptions
+    TO daily_overview
+    AS
+      SELECT
+        organization,
+        toDate(timestamp) AS date,
+        count() AS total
+      FROM default.subscription_operations
+      WHERE ${where}
+      GROUP BY organization, date
+  `);
+};

--- a/packages/migrations/src/clickhouse-actions/008-daily-operations-log.ts
+++ b/packages/migrations/src/clickhouse-actions/008-daily-operations-log.ts
@@ -36,7 +36,7 @@ export const action: Action = async (exec, _query, isHiveCloud) => {
         toDate(timestamp) AS date,
         count() AS total
       FROM default.operations
-      WHERE ${where}
+      ${where}
       GROUP BY organization, date
   `);
 
@@ -49,7 +49,7 @@ export const action: Action = async (exec, _query, isHiveCloud) => {
         toDate(timestamp) AS date,
         count() AS total
       FROM default.subscription_operations
-      WHERE ${where}
+      ${where}
       GROUP BY organization, date
   `);
 };

--- a/packages/migrations/src/clickhouse.ts
+++ b/packages/migrations/src/clickhouse.ts
@@ -158,6 +158,7 @@ export async function migrateClickHouse(
     import('./clickhouse-actions/005-subscription-conditional-breaking-changes'),
     import('./clickhouse-actions/006-monthly-operations-log'),
     import('./clickhouse-actions/007-james-bond-aggregates-hourly-and-minutely'),
+    import('./clickhouse-actions/008-daily-operations-log'),
   ]);
 
   async function actionRunner(action: Action, index: number) {

--- a/packages/migrations/src/scripts/008-cloud.ts
+++ b/packages/migrations/src/scripts/008-cloud.ts
@@ -1,0 +1,268 @@
+import got from 'got';
+import pLimit from 'p-limit';
+import z from 'zod';
+import { env } from './environment.js';
+
+function log(...args: any[]) {
+  console.log(new Date().toLocaleString(), '| INFO  |', ...args);
+}
+
+function logError(...args: any[]) {
+  console.error(new Date().toLocaleString(), '| ERROR |', ...args);
+}
+
+const SuccessfulClickHouseResponse = z.object({
+  rows: z.number(),
+});
+
+const FailedClickHouseResponse = z.object({
+  exception: z.string().optional(),
+});
+
+const FirstDateOfMigrationResponse = z.union([
+  SuccessfulClickHouseResponse.extend({
+    data: z.array(
+      z.object({
+        date: z.string(),
+      }),
+    ),
+  }),
+  FailedClickHouseResponse,
+]);
+
+const OrganizationsResponse = z.union([
+  SuccessfulClickHouseResponse.extend({
+    data: z.array(
+      z.object({
+        organization: z.string(),
+      }),
+    ),
+  }),
+  FailedClickHouseResponse,
+]);
+
+const TargetsResponse = z.union([
+  SuccessfulClickHouseResponse.extend({
+    data: z.array(
+      z.object({
+        target: z.string(),
+      }),
+    ),
+  }),
+  FailedClickHouseResponse,
+]);
+
+const PastMonthOperationsResponse = z.union([
+  SuccessfulClickHouseResponse.extend({
+    data: z.array(
+      z.object({
+        total: z.string().transform(value => Number(value)),
+        date: z.string(),
+      }),
+    ),
+  }),
+  FailedClickHouseResponse,
+]);
+
+const PreviousMonthsResponse = z.union([
+  SuccessfulClickHouseResponse.extend({
+    data: z.array(
+      z.object({
+        total: z.string().transform(value => Number(value)),
+        date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/, 'YYYY-MM-DD format required'),
+      }),
+    ),
+  }),
+  FailedClickHouseResponse,
+]);
+
+type DataProp<T> = T extends { data: Array<infer R> } ? R[] : never;
+
+function ensureData<
+  T extends
+    | {
+        exception?: string | undefined;
+      }
+    | {
+        rows: number;
+        data: unknown[];
+      },
+>(parsed: z.SafeParseReturnType<unknown, T>, label: string): DataProp<T> {
+  if (!parsed.success) {
+    logError(parsed.error);
+    throw new Error('Failed to parse response of ' + label);
+  }
+
+  if ('exception' in parsed.data) {
+    logError(parsed.data.exception);
+    throw new Error('Failed to fetch date of ' + label);
+  }
+
+  if (!('data' in parsed.data)) {
+    throw new Error('No "data" property in the response of ' + label);
+  }
+
+  return parsed.data.data as DataProp<T>;
+}
+
+async function main() {
+  if (env.clickhouse === null) {
+    throw new Error('WTF');
+  }
+
+  const { clickhouse } = env;
+  const poolSize = 5;
+  const limit = pLimit(poolSize);
+  const startedAt = Date.now();
+
+  const endpoint = `${clickhouse.protocol}://${clickhouse.host}:${clickhouse.port}`;
+
+  function execute(
+    query: string,
+    options?: {
+      settings?: Record<string, string>;
+    },
+  ) {
+    return got
+      .post(endpoint, {
+        body: query,
+        searchParams: {
+          default_format: 'JSON',
+          wait_end_of_query: '1',
+          ...options?.settings,
+        },
+        headers: {
+          'Accept-Encoding': 'gzip',
+          Accept: 'application/json',
+        },
+        decompress: true,
+        username: clickhouse.username,
+        password: clickhouse.password,
+        responseType: 'json',
+      })
+      .catch(error => {
+        const body = error?.response?.body;
+        if (body) {
+          logError(body);
+        }
+
+        return Promise.reject(error);
+      });
+  }
+
+  async function fetchDateOfMigration() {
+    const response = await execute('SELECT date FROM daily_overview ORDER BY date ASC LIMIT 1');
+    const parsed = FirstDateOfMigrationResponse.safeParse(response.body);
+
+    if (parsed.success) {
+      parsed.data;
+    }
+
+    const data = ensureData(parsed, 'fetchDateOfMigration');
+
+    if (data.length !== 1) {
+      throw new Error('Expected exactly one row in the response of fetchDateOfMigration');
+    }
+
+    return data[0].date;
+  }
+
+  async function fetchOrganizations() {
+    log('Fetching organizations');
+    const response = await execute(
+      `
+        SELECT organization FROM monthly_overview
+        WHERE date >= toDate(toStartOfMonth(now() - INTERVAL 2 MONTH))
+        GROUP BY organization
+      `,
+    );
+
+    const parsed = OrganizationsResponse.safeParse(response.body);
+
+    return ensureData(parsed, 'fetchOrganizations').map(row => row.organization);
+  }
+
+  async function fetchTargets(organizationId: string) {
+    log(`Fetching targets for organization ${organizationId}`);
+
+    const response = await execute(
+      `
+        SELECT DISTINCT target FROM operations_daily
+        WHERE timestamp >= toStartOfMonth(now() - INTERVAL 2 MONTH) AND organization = '${organizationId}'
+      `,
+    );
+
+    const parsed = TargetsResponse.safeParse(response.body);
+
+    return ensureData(parsed, 'fetchTargets').map(row => row.target);
+  }
+
+  async function migrateOrganization(organizationId: string, migrationDate: string): Promise<void> {
+    const startedAt = Date.now();
+    log(`Migrating organization ${organizationId}`);
+    const targets = await fetchTargets(organizationId);
+
+    if (targets.length === 0) {
+      log(`No targets found for organization ${organizationId}`);
+      return;
+    }
+
+    const targetIdsArray = `'` + targets.join(`','`) + `'`;
+
+    // insert the amount of operations from the past 30 days until `migrationDate`
+    log(`Fetching past month operations for organization ${organizationId}`);
+    const pastMonthResponse = await execute(
+      `
+        SELECT sum(total) as total, toDate(timestamp) as date FROM operations_daily
+        WHERE 
+          target IN (${targetIdsArray})
+          AND toDate(timestamp) >= (toDate('${migrationDate}') - INTERVAL 1 MONTH)
+          AND toDate(timestamp) < toDate('${migrationDate}')
+        GROUP BY date
+      `,
+    ).catch(error => {
+      logError(`Failed to fetch past month operations for organization ${organizationId}`);
+      return Promise.reject(error);
+    });
+
+    const pastMonth = PastMonthOperationsResponse.safeParse(pastMonthResponse.body);
+
+    const data = ensureData(pastMonth, 'fetchPastMonthOperations');
+
+    // update the daily_overview table
+    log(`Updating daily_overview for organization ${organizationId}`);
+    if (data.length) {
+      await execute(`
+        INSERT INTO daily_overview
+        (organization, date, total)
+        VALUES
+        ${data.map(row => `('${organizationId}', toDate('${row.date}'), ${row.total})`).join(', ')}
+      `);
+    } else {
+      log('No records');
+    }
+
+    log(`Migrated organization ${organizationId} in ${Date.now() - startedAt}ms`);
+  }
+
+  const organizations = await fetchOrganizations();
+
+  log(`Found ${organizations.length} organizations to migrate`);
+
+  const migrationDate = await fetchDateOfMigration();
+  await Promise.all(
+    organizations.map(organizationId =>
+      limit(() =>
+        migrateOrganization(organizationId, migrationDate).catch(error => {
+          logError(error);
+          logError(`Failed to migrate organization ${organizationId}`);
+          return Promise.resolve();
+        }),
+      ),
+    ),
+  );
+
+  log(`Finished in ${Math.round((Date.now() - startedAt) / 1000)}s`);
+}
+
+main();


### PR DESCRIPTION
Make it possible to quickly count operations reported by organization X from last N days without dealing with targets.