### PR TITLE
Update Apollo Server integrations docs

### DIFF
--- a/packages/web/docs/src/pages/docs/integrations/apollo-server.mdx
+++ b/packages/web/docs/src/pages/docs/integrations/apollo-server.mdx
@@ -79,7 +79,8 @@ This will result in all operations sent to the Apollo Server being reported to t
 
 In case you want to also associate a client name and version with any operation reported to Hive,
 you need to send the `x-graphql-client-name` and `x-graphql-client-version` HTTP headers for
-requests to the Apollo Server instance from your client.
+requests to the Apollo Server instance from your client. You must include both of these headers,
+otherwise the data will not be passed along.
 
 ```bash filename="Example HTTP Request with client headers" {2-3}
 curl \


### PR DESCRIPTION
Emphasize that both headers must be present in order for Apollo Server to pass this information to Hive.

### Background

I was not able to have metadata about clients show up in Hive. It turns out I missed the `and` in the previous sentence. I just want to emphasize this fact more.

### Description

N/A

### Checklist

N/A