### PR TITLE
Use redpanda instead of Kafka+Zookeeper in community docker compose file

### DIFF
--- a/docker/docker-compose.community.yml
+++ b/docker/docker-compose.community.yml
@@ -39,62 +39,41 @@ services:
     volumes:
       - ./.hive/clickhouse/db:/var/lib/clickhouse
 
-  zookeeper:
-    image: confluentinc/cp-zookeeper:7.6.1
-    hostname: zookeeper
-    networks:
-      - 'stack'
-    ulimits:
-      nofile:
-        soft: 20000
-        hard: 40000
-    environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
-      ZOOKEEPER_TICK_TIME: 2000
-    volumes:
-      - ./.hive/zookeeper/db:/var/lib/zookeeper/data
-
   broker:
-    image: confluentinc/cp-kafka:7.6.1
+    image: redpandadata/redpanda:v23.3.11
+    container_name: broker
     hostname: broker
-    depends_on:
-      zookeeper:
-        condition: service_started
     networks:
       - 'stack'
-    ulimits:
-      nofile:
-        soft: 20000
-        hard: 40000
+    ports:
+      - '0.0.0.0:9092:9092'
+      - '0.0.0.0:9644:9644'
+    command:
+      - redpanda
+      - start
+      - --smp
+      - '1'
+      - --set redpanda.empty_seed_starts_cluster=false
+      - --seeds "redpanda-1:33145"
+      - --kafka-addr
+      - PLAINTEXT://0.0.0.0:29092,OUTSIDE://0.0.0.0:9092
+      - --advertise-kafka-addr
+      - PLAINTEXT://broker:29092,OUTSIDE://localhost:9092
+      - --pandaproxy-addr
+      - PLAINTEXT://0.0.0.0:27082,OUTSIDE://0.0.0.0:7082
+      - --advertise-pandaproxy-addr
+      - PLAINTEXT://broker:27082,OUTSIDE://localhost:7082
+      - --advertise-rpc-addr redpanda-1:33145
+    mem_limit: 300m
+    mem_reservation: 100m
     healthcheck:
-      test:
-        [
-          'CMD',
-          'cub',
-          'kafka-ready',
-          '1',
-          '5',
-          '-b',
-          '127.0.0.1:9092',
-          '-c',
-          '/etc/kafka/kafka.properties',
-        ]
-      interval: 15s
-      timeout: 10s
+      test: 'curl -f http://localhost:9644/public_metrics'
+      interval: 3s
+      timeout: 3s
       retries: 6
-      start_period: 15s
-    environment:
-      KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_AUTO_CREATE_TOPICS_ENABLE: 'true'
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://broker:29092,PLAINTEXT_HOST://localhost:9092
-      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
-      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
-      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      start_period: 5s
     volumes:
-      - ./.hive/broker/db:/var/lib/kafka/data
+      - ./.hive/broker/db:/var/lib/redpanda/data
 
   redis:
     image: bitnami/redis:7.2.4


### PR DESCRIPTION
I mean... it's lightweight, consumes less resources, faster startup times and no need to spin up two containers.