### PR TITLE
new feature: date ranger filter suggest custom number interval

### DIFF
--- a/packages/web/app/src/components/ui/date-range-picker.tsx
+++ b/packages/web/app/src/components/ui/date-range-picker.tsx
@@ -270,7 +270,6 @@ export function DateRangePicker(props: DateRangePickerProps): JSX.Element {
     } else {
       setDynamicPresets([]);
     }
-
   }, [quickRangeFilter, validUnits]);
 
   presets = [...presets, ...dynamicPresets];

--- a/packages/web/app/src/components/ui/date-range-picker.tsx
+++ b/packages/web/app/src/components/ui/date-range-picker.tsx
@@ -169,6 +169,7 @@ export function DateRangePicker(props: DateRangePickerProps): JSX.Element {
   const [toValue, setToValue] = useState(activePreset?.range.to ?? '');
   const [range, setRange] = useState<DateRange | undefined>(undefined);
   const [quickRangeFilter, setQuickRangeFilter] = useState('');
+  console.log('quickRangeFilter', quickRangeFilter);
 
   const fromParsed = parse(fromValue);
   const toParsed = parse(toValue);
@@ -231,45 +232,45 @@ export function DateRangePicker(props: DateRangePickerProps): JSX.Element {
     );
   };
 
-  // Dynamic presets
   const [dynamicPresets, setDynamicPresets] = useState<Preset[]>([]);
   useEffect(() => {
-    if (quickRangeFilter.trim().match(/^Last [0-9]+$/)) {
-      const number = parseInt(quickRangeFilter.trim().split(' ')[1], 10);
-      const dynamicPresets: Preset[] = [
-        {
-          name: `last${number}m`,
-          label: `Last ${number} minutes`,
-          range: { from: `now-${number}m`, to: 'now' },
-        },
-        {
-          name: `last${number}h`,
-          label: `Last ${number} hours`,
-          range: { from: `now-${number}h`, to: 'now' },
-        },
-        {
-          name: `last${number}d`,
-          label: `Last ${number} days`,
-          range: { from: `now-${number}d`, to: 'now' },
-        },
-        {
-          name: `last${number}w`,
-          label: `Last ${number} weeks`,
-          range: { from: `now-${number}w`, to: 'now' },
-        },
-      ];
-
-      // Filter out dynamic presets that use invalid units
-      const validDynamicPresets = dynamicPresets.filter(preset => {
-        const isValidFromUnit = validUnits?.some(unit => preset.range.from.endsWith(unit));
-        const isValidToUnit = validUnits?.some(unit => preset.range.to.endsWith(unit));
-        return isValidFromUnit && isValidToUnit;
-      });
-
+    const number = parseInt(quickRangeFilter.replace(/\D/g, ''));
+    const dynamicPresets: Preset[] = [
+      {
+        name: `last${number}m`,
+        label: `Last ${number} minutes`,
+        range: { from: `now-${number}m`, to: 'now' },
+      },
+      {
+        name: `last${number}h`,
+        label: `Last ${number} hours`,
+        range: { from: `now-${number}h`, to: 'now' },
+      },
+      {
+        name: `last${number}d`,
+        label: `Last ${number} days`,
+        range: { from: `now-${number}d`, to: 'now' },
+      },
+      {
+        name: `last${number}w`,
+        label: `Last ${number} weeks`,
+        range: { from: `now-${number}w`, to: 'now' },
+      },
+    ];
+    const uniqueDynamicPresets = dynamicPresets.filter(
+      preset => !presets.some(p => p.name === preset.name),
+    );
+    const validDynamicPresets = uniqueDynamicPresets.filter(
+      preset =>
+        !hasInvalidUnitRegex?.test(preset.range.from) &&
+        !hasInvalidUnitRegex?.test(preset.range.to),
+    );
+    if (number > 0 && validDynamicPresets.length > 0) {
       setDynamicPresets(validDynamicPresets);
     } else {
       setDynamicPresets([]);
     }
+
   }, [quickRangeFilter, validUnits]);
 
   presets = [...presets, ...dynamicPresets];

--- a/packages/web/app/src/components/ui/date-range-picker.tsx
+++ b/packages/web/app/src/components/ui/date-range-picker.tsx
@@ -231,6 +231,49 @@ export function DateRangePicker(props: DateRangePickerProps): JSX.Element {
     );
   };
 
+  // Dynamic presets
+  const [dynamicPresets, setDynamicPresets] = useState<Preset[]>([]);
+  useEffect(() => {
+    if (quickRangeFilter.trim().match(/^Last [0-9]+$/)) {
+      const number = parseInt(quickRangeFilter.trim().split(' ')[1], 10);
+      const dynamicPresets: Preset[] = [
+        {
+          name: `last${number}m`,
+          label: `Last ${number} minutes`,
+          range: { from: `now-${number}m`, to: 'now' },
+        },
+        {
+          name: `last${number}h`,
+          label: `Last ${number} hours`,
+          range: { from: `now-${number}h`, to: 'now' },
+        },
+        {
+          name: `last${number}d`,
+          label: `Last ${number} days`,
+          range: { from: `now-${number}d`, to: 'now' },
+        },
+        {
+          name: `last${number}w`,
+          label: `Last ${number} weeks`,
+          range: { from: `now-${number}w`, to: 'now' },
+        },
+      ];
+
+      // Filter out dynamic presets that use invalid units
+      const validDynamicPresets = dynamicPresets.filter(preset => {
+        const isValidFromUnit = validUnits?.some(unit => preset.range.from.endsWith(unit));
+        const isValidToUnit = validUnits?.some(unit => preset.range.to.endsWith(unit));
+        return isValidFromUnit && isValidToUnit;
+      });
+
+      setDynamicPresets(validDynamicPresets);
+    } else {
+      setDynamicPresets([]);
+    }
+  }, [quickRangeFilter, validUnits]);
+
+  presets = [...presets, ...dynamicPresets];
+
   return (
     <Popover
       modal
@@ -353,7 +396,9 @@ export function DateRangePicker(props: DateRangePickerProps): JSX.Element {
           </div>
           <div className="flex w-full flex-1 flex-col items-start gap-1 overflow-y-scroll pb-2 pt-1">
             {presets
-              .filter(preset => preset.label.toLowerCase().includes(quickRangeFilter.trim()))
+              .filter(preset =>
+                preset.label.toLowerCase().includes(quickRangeFilter.toLowerCase().trim()),
+              )
               .map(preset => (
                 <PresetButton key={preset.name} preset={preset} />
               ))}

--- a/packages/web/app/src/components/ui/date-range-picker.tsx
+++ b/packages/web/app/src/components/ui/date-range-picker.tsx
@@ -169,7 +169,6 @@ export function DateRangePicker(props: DateRangePickerProps): JSX.Element {
   const [toValue, setToValue] = useState(activePreset?.range.to ?? '');
   const [range, setRange] = useState<DateRange | undefined>(undefined);
   const [quickRangeFilter, setQuickRangeFilter] = useState('');
-  console.log('quickRangeFilter', quickRangeFilter);
 
   const fromParsed = parse(fromValue);
   const toParsed = parse(toValue);
@@ -265,6 +264,7 @@ export function DateRangePicker(props: DateRangePickerProps): JSX.Element {
         !hasInvalidUnitRegex?.test(preset.range.from) &&
         !hasInvalidUnitRegex?.test(preset.range.to),
     );
+
     if (number > 0 && validDynamicPresets.length > 0) {
       setDynamicPresets(validDynamicPresets);
     } else {

--- a/packages/web/app/src/components/ui/date-range-picker.tsx
+++ b/packages/web/app/src/components/ui/date-range-picker.tsx
@@ -272,7 +272,15 @@ export function DateRangePicker(props: DateRangePickerProps): JSX.Element {
     }
   }, [quickRangeFilter, validUnits]);
 
-  presets = [...presets, ...dynamicPresets];
+  presets = [...presets, ...dynamicPresets].sort((a, b) => {
+    if (a.label < b.label) {
+      return -1;
+    }
+    if (a.label > b.label) {
+      return 1;
+    }
+    return 0;
+  });
 
   return (
     <Popover


### PR DESCRIPTION
### Background
Task: #4229  

### Description
Enhance DateRangePicker to dynamically suggest time presets while respecting valid time units specified by the user.

### Live Video
https://github.com/kamilkisiela/graphql-hive/assets/37614975/faee8145-23dd-45a4-9b55-5311cd560a2d

### Note
The list of suggestions based on the `dynamicPresets` prop.


