### PR TITLE
Toast on save for better user feedback

### DIFF
--- a/packages/web/app/pages/[organizationId]/[projectId]/[targetId]/settings.tsx
+++ b/packages/web/app/pages/[organizationId]/[projectId]/[targetId]/settings.tsx
@@ -42,6 +42,7 @@ import { ProjectType } from '@/gql/graphql';
 import { canAccessTarget, TargetAccessScope } from '@/lib/access/target';
 import { subDays } from '@/lib/date-time';
 import { useRouteSelector, useToggle } from '@/lib/hooks';
+import { useToast } from '@/components/ui/use-toast';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const TargetSettings_TargetValidationSettingsFragment = graphql(`
@@ -228,6 +229,8 @@ const ExtendBaseSchema = (props: { baseSchema: string }): ReactElement => {
   const [mutation, mutate] = useMutation(Settings_UpdateBaseSchemaMutation);
   const router = useRouteSelector();
   const [baseSchema, setBaseSchema] = useState(props.baseSchema);
+  const { toast } = useToast();
+
 
   const isUnsaved = baseSchema?.trim() !== props.baseSchema?.trim();
 
@@ -277,6 +280,20 @@ const ExtendBaseSchema = (props: { baseSchema: string }): ReactElement => {
                 target: router.targetId,
                 newBase: baseSchema,
               },
+            }).then(() => {
+              if (mutation.error) {
+                toast({
+                  variant: 'destructive',
+                  title: 'Error',
+                  description: mutation.error.message,
+                });
+              } else {
+                toast({
+                  variant: 'default',
+                  title: 'Success',
+                  description: 'Base schema updated successfully',
+                })
+              }
             });
           }}
         >
@@ -449,6 +466,7 @@ const ConditionalBreakingChanges = (): ReactElement => {
   const settings = targetSettings.data?.target?.validationSettings;
   const isEnabled = settings?.enabled || false;
   const possibleTargets = targetSettings.data?.targets.nodes;
+  const { toast } = useToast();
 
   const {
     handleSubmit,
@@ -485,6 +503,20 @@ const ConditionalBreakingChanges = (): ReactElement => {
           target: router.targetId,
           ...values,
         },
+      }).then(() => {
+        if (mutation.error) {
+          toast({
+            variant: 'destructive',
+            title: 'Error',
+            description: mutation.error.message,
+          });
+        } else {
+          toast({
+            variant: 'default',
+            title: 'Success',
+            description: 'Conditional breaking changes settings updated successfully',
+          })
+        }
       }),
   });
 
@@ -686,6 +718,7 @@ function TargetName(props: {
   targetId: string;
 }) {
   const router = useRouteSelector();
+  const { toast } = useToast();
 
   const [mutation, mutate] = useMutation(TargetSettingsPage_UpdateTargetNameMutation);
   const { handleSubmit, values, handleChange, handleBlur, isSubmitting, errors, touched } =
@@ -711,6 +744,20 @@ function TargetName(props: {
             void router.replace(
               `/${router.organizationId}/${router.projectId}/${newTargetId}/settings`,
             );
+          }
+        }).then(() => {
+          if (mutation.error) {
+            toast({
+              variant: 'destructive',
+              title: 'Error',
+              description: mutation.error.message,
+            });
+          } else {
+            toast({
+              variant: 'default',
+              title: 'Success',
+              description: 'Target name updated successfully',
+            })
           }
         }),
     });
@@ -791,6 +838,7 @@ function GraphQLEndpointUrl(props: {
   targetId: string;
 }): ReactElement {
   const router = useRouteSelector();
+  const { toast } = useToast();
   const [mutation, mutate] = useMutation(TargetSettingsPage_UpdateTargetGraphQLEndpointUrl);
   const { handleSubmit, values, handleChange, handleBlur, isSubmitting, errors, touched } =
     useFormik({
@@ -812,6 +860,20 @@ function GraphQLEndpointUrl(props: {
             target: props.targetId,
             graphqlEndpointUrl: values.graphqlEndpointUrl === '' ? null : values.graphqlEndpointUrl,
           },
+        }).then(() => {
+          if (mutation.error) {
+            toast({
+              variant: 'destructive',
+              title: 'Error',
+              description: mutation.error.message,
+            });
+          } else {
+            toast({
+              variant: 'default',
+              title: 'Success',
+              description: 'GraphQL endpoint url updated successfully',
+            })
+          }
         }),
     });
 

--- a/packages/web/app/pages/[organizationId]/[projectId]/[targetId]/settings.tsx
+++ b/packages/web/app/pages/[organizationId]/[projectId]/[targetId]/settings.tsx
@@ -22,6 +22,7 @@ import {
 import { Checkbox } from '@/components/ui/checkbox';
 import { Subtitle, Title } from '@/components/ui/page';
 import { QueryError } from '@/components/ui/query-error';
+import { useToast } from '@/components/ui/use-toast';
 import {
   DocsLink,
   Input,
@@ -42,7 +43,6 @@ import { ProjectType } from '@/gql/graphql';
 import { canAccessTarget, TargetAccessScope } from '@/lib/access/target';
 import { subDays } from '@/lib/date-time';
 import { useRouteSelector, useToggle } from '@/lib/hooks';
-import { useToast } from '@/components/ui/use-toast';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const TargetSettings_TargetValidationSettingsFragment = graphql(`
@@ -231,7 +231,6 @@ const ExtendBaseSchema = (props: { baseSchema: string }): ReactElement => {
   const [baseSchema, setBaseSchema] = useState(props.baseSchema);
   const { toast } = useToast();
 
-
   const isUnsaved = baseSchema?.trim() !== props.baseSchema?.trim();
 
   return (
@@ -292,7 +291,7 @@ const ExtendBaseSchema = (props: { baseSchema: string }): ReactElement => {
                   variant: 'default',
                   title: 'Success',
                   description: 'Base schema updated successfully',
-                })
+                });
               }
             });
           }}
@@ -515,7 +514,7 @@ const ConditionalBreakingChanges = (): ReactElement => {
             variant: 'default',
             title: 'Success',
             description: 'Conditional breaking changes settings updated successfully',
-          })
+          });
         }
       }),
   });
@@ -738,28 +737,30 @@ function TargetName(props: {
             target: props.targetId,
             name: values.name,
           },
-        }).then(result => {
-          if (result?.data?.updateTargetName?.ok) {
-            const newTargetId = result.data.updateTargetName.ok.updatedTarget.cleanId;
-            void router.replace(
-              `/${router.organizationId}/${router.projectId}/${newTargetId}/settings`,
-            );
-          }
-        }).then(() => {
-          if (mutation.error) {
-            toast({
-              variant: 'destructive',
-              title: 'Error',
-              description: mutation.error.message,
-            });
-          } else {
-            toast({
-              variant: 'default',
-              title: 'Success',
-              description: 'Target name updated successfully',
-            })
-          }
-        }),
+        })
+          .then(result => {
+            if (result?.data?.updateTargetName?.ok) {
+              const newTargetId = result.data.updateTargetName.ok.updatedTarget.cleanId;
+              void router.replace(
+                `/${router.organizationId}/${router.projectId}/${newTargetId}/settings`,
+              );
+            }
+          })
+          .then(() => {
+            if (mutation.error) {
+              toast({
+                variant: 'destructive',
+                title: 'Error',
+                description: mutation.error.message,
+              });
+            } else {
+              toast({
+                variant: 'default',
+                title: 'Success',
+                description: 'Target name updated successfully',
+              });
+            }
+          }),
     });
 
   return (
@@ -872,7 +873,7 @@ function GraphQLEndpointUrl(props: {
               variant: 'default',
               title: 'Success',
               description: 'GraphQL endpoint url updated successfully',
-            })
+            });
           }
         }),
     });

--- a/packages/web/app/pages/[organizationId]/[projectId]/view/policy.tsx
+++ b/packages/web/app/pages/[organizationId]/[projectId]/view/policy.tsx
@@ -6,12 +6,12 @@ import { PolicySettings } from '@/components/policy/policy-settings';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Subtitle, Title } from '@/components/ui/page';
 import { QueryError } from '@/components/ui/query-error';
+import { useToast } from '@/components/ui/use-toast';
 import { DocsLink, MetaTitle } from '@/components/v2';
 import { graphql } from '@/gql';
 import { ProjectAccessScope, RegistryModel } from '@/gql/graphql';
 import { useProjectAccess } from '@/lib/access/project';
 import { useRouteSelector } from '@/lib/hooks';
-import { useToast } from '@/components/ui/use-toast';
 
 const ProjectPolicyPageQuery = graphql(`
   query ProjectPolicyPageQuery($organizationId: ID!, $projectId: ID!) {
@@ -163,7 +163,7 @@ function ProjectPolicyContent() {
             </CardHeader>
             <CardContent>
               {currentProject.parentSchemaPolicy === null ||
-                currentProject.parentSchemaPolicy?.allowOverrides ? (
+              currentProject.parentSchemaPolicy?.allowOverrides ? (
                 <PolicySettings
                   saving={mutation.fetching}
                   rulesInParent={currentProject.parentSchemaPolicy?.rules.map(r => r.rule.id)}
@@ -190,7 +190,7 @@ function ProjectPolicyContent() {
                           variant: 'default',
                           title: 'Success',
                           description: 'Policy updated successfully',
-                        })
+                        });
                       }
                     });
                   }}

--- a/packages/web/app/pages/[organizationId]/[projectId]/view/policy.tsx
+++ b/packages/web/app/pages/[organizationId]/[projectId]/view/policy.tsx
@@ -11,6 +11,7 @@ import { graphql } from '@/gql';
 import { ProjectAccessScope, RegistryModel } from '@/gql/graphql';
 import { useProjectAccess } from '@/lib/access/project';
 import { useRouteSelector } from '@/lib/hooks';
+import { useToast } from '@/components/ui/use-toast';
 
 const ProjectPolicyPageQuery = graphql(`
   query ProjectPolicyPageQuery($organizationId: ID!, $projectId: ID!) {
@@ -106,6 +107,7 @@ function ProjectPolicyContent() {
   }
 
   const isLegacyProject = currentProject?.registryModel === RegistryModel.Legacy;
+  const { toast } = useToast();
 
   return (
     <ProjectLayout
@@ -161,7 +163,7 @@ function ProjectPolicyContent() {
             </CardHeader>
             <CardContent>
               {currentProject.parentSchemaPolicy === null ||
-              currentProject.parentSchemaPolicy?.allowOverrides ? (
+                currentProject.parentSchemaPolicy?.allowOverrides ? (
                 <PolicySettings
                   saving={mutation.fetching}
                   rulesInParent={currentProject.parentSchemaPolicy?.rules.map(r => r.rule.id)}
@@ -176,6 +178,20 @@ function ProjectPolicyContent() {
                         project: router.projectId,
                       },
                       policy: newPolicy,
+                    }).then(() => {
+                      if (mutation.error) {
+                        toast({
+                          variant: 'destructive',
+                          title: 'Error',
+                          description: mutation.error.message,
+                        });
+                      } else {
+                        toast({
+                          variant: 'default',
+                          title: 'Success',
+                          description: 'Policy updated successfully',
+                        })
+                      }
                     });
                   }}
                   currentState={currentProject.schemaPolicy}

--- a/packages/web/app/pages/[organizationId]/[projectId]/view/settings.tsx
+++ b/packages/web/app/pages/[organizationId]/[projectId]/view/settings.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/components/ui/card';
 import { Subtitle, Title } from '@/components/ui/page';
 import { QueryError } from '@/components/ui/query-error';
+import { useToast } from '@/components/ui/use-toast';
 import { DocsLink, Input, MetaTitle } from '@/components/v2';
 import { HiveLogo } from '@/components/v2/icon';
 import { DeleteProjectModal } from '@/components/v2/modals';
@@ -28,7 +29,6 @@ import { ProjectType } from '@/gql/graphql';
 import { canAccessProject, ProjectAccessScope, useProjectAccess } from '@/lib/access/project';
 import { getDocsUrl } from '@/lib/docs-url';
 import { useNotifications, useRouteSelector, useToggle } from '@/lib/hooks';
-import { useToast } from '@/components/ui/use-toast';
 
 const GithubIntegration_GithubIntegrationDetailsQuery = graphql(`
   query getGitHubIntegrationDetails($selector: OrganizationSelectorInput!) {
@@ -278,26 +278,28 @@ function ProjectSettingsContent() {
             project: router.projectId,
             name: values.name,
           },
-        }).then(result => {
-          if (result?.data?.updateProjectName?.ok) {
-            const newProjectId = result.data.updateProjectName.ok.updatedProject.cleanId;
-            void router.replace(`/${router.organizationId}/${newProjectId}/view/settings`);
-          }
-        }).then(() => {
-          if (mutation.error) {
-            toast({
-              variant: 'destructive',
-              title: 'Error',
-              description: mutation.error.message,
-            });
-          } else {
-            toast({
-              variant: 'default',
-              title: 'Success',
-              description: 'Project name updated successfully',
-            })
-          }
-        }),
+        })
+          .then(result => {
+            if (result?.data?.updateProjectName?.ok) {
+              const newProjectId = result.data.updateProjectName.ok.updatedProject.cleanId;
+              void router.replace(`/${router.organizationId}/${newProjectId}/view/settings`);
+            }
+          })
+          .then(() => {
+            if (mutation.error) {
+              toast({
+                variant: 'destructive',
+                title: 'Error',
+                description: mutation.error.message,
+              });
+            } else {
+              toast({
+                variant: 'default',
+                title: 'Success',
+                description: 'Project name updated successfully',
+              });
+            }
+          }),
     });
 
   if (query.error) {
@@ -372,7 +374,7 @@ function ProjectSettingsContent() {
                 </form>
 
                 {query.data?.isGitHubIntegrationFeatureEnabled &&
-                  !project.isProjectNameInGitHubCheckEnabled ? (
+                !project.isProjectNameInGitHubCheckEnabled ? (
                   <GitHubIntegration
                     organizationName={organization.name}
                     projectName={project.name}

--- a/packages/web/app/pages/[organizationId]/[projectId]/view/settings.tsx
+++ b/packages/web/app/pages/[organizationId]/[projectId]/view/settings.tsx
@@ -28,6 +28,7 @@ import { ProjectType } from '@/gql/graphql';
 import { canAccessProject, ProjectAccessScope, useProjectAccess } from '@/lib/access/project';
 import { getDocsUrl } from '@/lib/docs-url';
 import { useNotifications, useRouteSelector, useToggle } from '@/lib/hooks';
+import { useToast } from '@/components/ui/use-toast';
 
 const GithubIntegration_GithubIntegrationDetailsQuery = graphql(`
   query getGitHubIntegrationDetails($selector: OrganizationSelectorInput!) {
@@ -257,6 +258,7 @@ function ProjectSettingsContent() {
     member: organization?.me ?? null,
     redirect: true,
   });
+  const { toast } = useToast();
 
   const [mutation, mutate] = useMutation(ProjectSettingsPage_UpdateProjectNameMutation);
 
@@ -280,6 +282,20 @@ function ProjectSettingsContent() {
           if (result?.data?.updateProjectName?.ok) {
             const newProjectId = result.data.updateProjectName.ok.updatedProject.cleanId;
             void router.replace(`/${router.organizationId}/${newProjectId}/view/settings`);
+          }
+        }).then(() => {
+          if (mutation.error) {
+            toast({
+              variant: 'destructive',
+              title: 'Error',
+              description: mutation.error.message,
+            });
+          } else {
+            toast({
+              variant: 'default',
+              title: 'Success',
+              description: 'Project name updated successfully',
+            })
           }
         }),
     });
@@ -356,7 +372,7 @@ function ProjectSettingsContent() {
                 </form>
 
                 {query.data?.isGitHubIntegrationFeatureEnabled &&
-                !project.isProjectNameInGitHubCheckEnabled ? (
+                  !project.isProjectNameInGitHubCheckEnabled ? (
                   <GitHubIntegration
                     organizationName={organization.name}
                     projectName={project.name}

--- a/packages/web/app/pages/[organizationId]/view/policy.tsx
+++ b/packages/web/app/pages/[organizationId]/view/policy.tsx
@@ -12,6 +12,7 @@ import { graphql } from '@/gql';
 import { OrganizationAccessScope, RegistryModel } from '@/gql/graphql';
 import { useOrganizationAccess } from '@/lib/access/organization';
 import { useRouteSelector } from '@/lib/hooks';
+import { useToast } from '@/components/ui/use-toast';
 
 const OrganizationPolicyPageQuery = graphql(`
   query OrganizationPolicyPageQuery($selector: OrganizationSelectorInput!) {
@@ -108,6 +109,7 @@ function PolicyPageContent() {
   if (query.error) {
     return <QueryError error={query.error} />;
   }
+  const { toast } = useToast();
 
   return (
     <OrganizationLayout
@@ -183,6 +185,20 @@ function PolicyPageContent() {
                     },
                     policy: newPolicy,
                     allowOverrides,
+                  }).then(() => {
+                    if (mutation.error) {
+                      toast({
+                        variant: 'destructive',
+                        title: 'Error',
+                        description: mutation.error.message,
+                      });
+                    } else {
+                      toast({
+                        variant: 'default',
+                        title: 'Success',
+                        description: 'Policy updated successfully',
+                      })
+                    }
                   }).catch();
                 }}
                 currentState={currentOrganization.schemaPolicy}

--- a/packages/web/app/pages/[organizationId]/view/policy.tsx
+++ b/packages/web/app/pages/[organizationId]/view/policy.tsx
@@ -7,12 +7,12 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 import { Checkbox } from '@/components/ui/checkbox';
 import { Subtitle, Title } from '@/components/ui/page';
 import { QueryError } from '@/components/ui/query-error';
+import { useToast } from '@/components/ui/use-toast';
 import { DocsLink, DocsNote, MetaTitle } from '@/components/v2';
 import { graphql } from '@/gql';
 import { OrganizationAccessScope, RegistryModel } from '@/gql/graphql';
 import { useOrganizationAccess } from '@/lib/access/organization';
 import { useRouteSelector } from '@/lib/hooks';
-import { useToast } from '@/components/ui/use-toast';
 
 const OrganizationPolicyPageQuery = graphql(`
   query OrganizationPolicyPageQuery($selector: OrganizationSelectorInput!) {
@@ -185,21 +185,23 @@ function PolicyPageContent() {
                     },
                     policy: newPolicy,
                     allowOverrides,
-                  }).then(() => {
-                    if (mutation.error) {
-                      toast({
-                        variant: 'destructive',
-                        title: 'Error',
-                        description: mutation.error.message,
-                      });
-                    } else {
-                      toast({
-                        variant: 'default',
-                        title: 'Success',
-                        description: 'Policy updated successfully',
-                      })
-                    }
-                  }).catch();
+                  })
+                    .then(() => {
+                      if (mutation.error) {
+                        toast({
+                          variant: 'destructive',
+                          title: 'Error',
+                          description: mutation.error.message,
+                        });
+                      } else {
+                        toast({
+                          variant: 'default',
+                          title: 'Success',
+                          description: 'Policy updated successfully',
+                        });
+                      }
+                    })
+                    .catch();
                 }}
                 currentState={currentOrganization.schemaPolicy}
               >

--- a/packages/web/app/pages/[organizationId]/view/settings.tsx
+++ b/packages/web/app/pages/[organizationId]/view/settings.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/card';
 import { Subtitle, Title } from '@/components/ui/page';
 import { QueryError } from '@/components/ui/query-error';
+import { useToast } from '@/components/ui/use-toast';
 import { DocsLink, Input, MetaTitle, Tag } from '@/components/v2';
 import { GitHubIcon, SlackIcon } from '@/components/v2/icon';
 import {
@@ -31,7 +32,6 @@ import {
   useOrganizationAccess,
 } from '@/lib/access/organization';
 import { useRouteSelector, useToggle } from '@/lib/hooks';
-import { useToast } from '@/components/ui/use-toast';
 
 const Integrations_CheckIntegrationsQuery = graphql(`
   query Integrations_CheckIntegrationsQuery($selector: OrganizationSelectorInput!) {
@@ -257,28 +257,30 @@ const SettingsPageRenderer = (props: {
             organization: router.organizationId,
             name: values.name,
           },
-        }).then(result => {
-          if (result.data?.updateOrganizationName?.ok) {
-            const newOrgId =
-              result.data?.updateOrganizationName?.ok.updatedOrganizationPayload.selector
-                .organization;
-            void router.replace(`/${newOrgId}/view/settings`);
-          }
-        }).then(() => {
-          if (mutation.error) {
-            toast({
-              variant: 'destructive',
-              title: 'Error',
-              description: mutation.error.message,
-            });
-          } else {
-            toast({
-              variant: 'default',
-              title: 'Success',
-              description: 'Organization name updated',
-            })
-          }
-        }),
+        })
+          .then(result => {
+            if (result.data?.updateOrganizationName?.ok) {
+              const newOrgId =
+                result.data?.updateOrganizationName?.ok.updatedOrganizationPayload.selector
+                  .organization;
+              void router.replace(`/${newOrgId}/view/settings`);
+            }
+          })
+          .then(() => {
+            if (mutation.error) {
+              toast({
+                variant: 'destructive',
+                title: 'Error',
+                description: mutation.error.message,
+              });
+            } else {
+              toast({
+                variant: 'default',
+                title: 'Success',
+                description: 'Organization name updated',
+              });
+            }
+          }),
     });
 
   return (

--- a/packages/web/app/pages/[organizationId]/view/settings.tsx
+++ b/packages/web/app/pages/[organizationId]/view/settings.tsx
@@ -31,6 +31,7 @@ import {
   useOrganizationAccess,
 } from '@/lib/access/organization';
 import { useRouteSelector, useToggle } from '@/lib/hooks';
+import { useToast } from '@/components/ui/use-toast';
 
 const Integrations_CheckIntegrationsQuery = graphql(`
   query Integrations_CheckIntegrationsQuery($selector: OrganizationSelectorInput!) {
@@ -237,6 +238,7 @@ const SettingsPageRenderer = (props: {
   const router = useRouteSelector();
   const [isDeleteModalOpen, toggleDeleteModalOpen] = useToggle();
   const [isTransferModalOpen, toggleTransferModalOpen] = useToggle();
+  const { toast } = useToast();
 
   const [mutation, mutate] = useMutation(UpdateOrganizationNameMutation);
 
@@ -261,6 +263,20 @@ const SettingsPageRenderer = (props: {
               result.data?.updateOrganizationName?.ok.updatedOrganizationPayload.selector
                 .organization;
             void router.replace(`/${newOrgId}/view/settings`);
+          }
+        }).then(() => {
+          if (mutation.error) {
+            toast({
+              variant: 'destructive',
+              title: 'Error',
+              description: mutation.error.message,
+            });
+          } else {
+            toast({
+              variant: 'default',
+              title: 'Success',
+              description: 'Organization name updated',
+            })
           }
         }),
     });

--- a/packages/web/app/src/components/user/settings.tsx
+++ b/packages/web/app/src/components/user/settings.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery } from 'urql';
 import * as Yup from 'yup';
 import { Button, Heading, Input, Modal } from '@/components/v2';
 import { graphql } from '@/gql';
+import { useToast } from '../ui/use-toast';
 
 const UserSettings_MeQuery = graphql(`
   query UserSettings_MeQuery {
@@ -46,6 +47,7 @@ export function UserSettingsModal({
 }): ReactElement {
   const [meQuery] = useQuery({ query: UserSettings_MeQuery });
   const [mutation, mutate] = useMutation(UpdateMeMutation);
+  const { toast } = useToast();
 
   const me = meQuery.data?.me;
 
@@ -64,6 +66,18 @@ export function UserSettingsModal({
         const { data } = await mutate({ input: values });
         if (data?.updateMe.ok) {
           toggleModalOpen();
+          toast({
+            variant: 'default',
+            title: 'Profile updated',
+            description: 'Your profile has been updated successfully',
+          })
+        }
+        if (data?.updateMe.error) {
+          toast({
+            variant: 'destructive',
+            title: 'Error',
+            description: data.updateMe.error.message,
+          });
         }
       },
     });

--- a/packages/web/app/src/components/user/settings.tsx
+++ b/packages/web/app/src/components/user/settings.tsx
@@ -70,7 +70,7 @@ export function UserSettingsModal({
             variant: 'default',
             title: 'Profile updated',
             description: 'Your profile has been updated successfully',
-          })
+          });
         }
         if (data?.updateMe.error) {
           toast({


### PR DESCRIPTION
### Background
Related to #4651 

### Description
Better user experience after save - got toast feedback

### Overview
Added to:

- On save Profile settings
- On save Organization Schema Policy
- On save Organization Name
- On save Project Schema Policy
- On save Project Name
- On save Target Name
- On save GraphQL Endpoint URL
- On save Conditional Breaking Changes
- On save Extend Your Schema

### Video

https://github.com/kamilkisiela/graphql-hive/assets/37614975/e5a0767f-1eb5-4c4e-a22c-3dea069fe96b


