### PR TITLE
Reduce the number of presets in date range picker

### DIFF
--- a/packages/web/app/src/components/ui/date-range-picker.tsx
+++ b/packages/web/app/src/components/ui/date-range-picker.tsx
@@ -88,21 +88,11 @@ export const presetLast1Day: Preset = {
 
 // Define presets
 export const availablePresets: Preset[] = [
-  { name: 'last5min', label: 'Last 5 minutes', range: { from: 'now-5m', to: 'now' } },
-  { name: 'last10min', label: 'Last 10 minutes', range: { from: 'now-10m', to: 'now' } },
-  { name: 'last15min', label: 'Last 15 minutes', range: { from: 'now-15m', to: 'now' } },
-  { name: 'last30min', label: 'Last 30 minutes', range: { from: 'now-30m', to: 'now' } },
   { name: 'last1h', label: 'Last 1 hour', range: { from: 'now-1h', to: 'now' } },
-  { name: 'last3h', label: 'Last 3 hours', range: { from: 'now-3h', to: 'now' } },
-  { name: 'last6h', label: 'Last 6 hours', range: { from: 'now-6h', to: 'now' } },
-  { name: 'last12h', label: 'Last 12 hours', range: { from: 'now-12h', to: 'now' } },
   presetLast1Day,
-  { name: 'last2d', label: 'Last 2 days', range: { from: 'now-2d', to: 'now' } },
-  { name: 'last3d', label: 'Last 3 days', range: { from: 'now-3d', to: 'now' } },
   presetLast7Days,
   { name: 'last14d', label: 'Last 14 days', range: { from: 'now-14d', to: 'now' } },
   { name: 'last30d', label: 'Last 30 days', range: { from: 'now-30d', to: 'now' } },
-  { name: 'last60d', label: 'Last 60 days', range: { from: 'now-60d', to: 'now' } },
   { name: 'last90d', label: 'Last 90 days', range: { from: 'now-90d', to: 'now' } },
   { name: 'last6M', label: 'Last 6 months', range: { from: 'now-6M', to: 'now' } },
   { name: 'last1y', label: 'Last 1 year', range: { from: 'now-364d', to: 'now' } },

--- a/packages/web/app/src/components/ui/date-range-picker.tsx
+++ b/packages/web/app/src/components/ui/date-range-picker.tsx
@@ -88,6 +88,7 @@ export const presetLast1Day: Preset = {
 
 // Define presets
 export const availablePresets: Preset[] = [
+  { name: 'last30m', label: 'Last 30 minutes', range: { from: 'now-30m', to: 'now' } },
   { name: 'last1h', label: 'Last 1 hour', range: { from: 'now-1h', to: 'now' } },
   presetLast1Day,
   presetLast7Days,


### PR DESCRIPTION
Problem: I want to quickly pick "Last 30 days", but because the list is super long I need to scroll and find it.

Reducing the number of options helps to quickly switch between date ranges, without scrolling.
Having `last 5 minutes` next to `last 10 minutes` and to `last 15 minutes` is too granular and in my opinion really not needed.

I feel like showing:
```
Last 5 minutes
Last 10 minutes
Last 15 minutes
Last 30 minutes
Last 1 hour
Last 3 hours
Last 6 hours
Last 12 hours
Last 24 hours
Last 2 days
Last 3 days
Last 7 days
Last 14 days
Last 30 days
Last 60 days
Last 90 days
Last 6 months
Last 1 year
```
is A BIT too much :D

The PR displays only:

```
Last 30 minutes
Last 1 hour
Last 1 day
Last 7 days
Last 14 days
Last 30 days
Last 90 days
Last 6 months
Last 1 year
```

![Screenshot 2024-05-09 at 14 43 45](https://github.com/kamilkisiela/graphql-hive/assets/8167190/2c26e13e-6e0c-48ef-b0d7-a5e847964a1c)

![Screenshot 2024-05-09 at 14 53 45](https://github.com/kamilkisiela/graphql-hive/assets/8167190/ca2b38fb-09f1-43b3-82c2-22f5559534f3)

