### PR TITLE
chore: allow multiple entrypoints for both runify and the dev config

### DIFF
--- a/configs/tsup/dev.config.node.ts
+++ b/configs/tsup/dev.config.node.ts
@@ -1,3 +1,4 @@
+import { parseArgs } from 'node:util';
 import { defineConfig } from 'tsup';
 import {
   commonWatchList,
@@ -6,7 +7,13 @@ import {
   watchEntryPlugin,
 } from './utils';
 
+const entryPoints = parseArgs({
+  allowPositionals: true,
+  strict: false,
+}).positionals;
+
 export default defineConfig({
+  entryPoints: entryPoints.length ? entryPoints : ['src/index.ts'],
   splitting: false,
   sourcemap: true,
   clean: true,


### PR DESCRIPTION
### Background

Prerequisite for building worker thread js files.

### Description

Uses `import { parseArgs } from 'node:util'`, to make things a bit more predictable and future proof.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
