### PR TITLE
Create npm-409-issue.md

### DIFF
--- a/.changeset/npm-409-issue.md
+++ b/.changeset/npm-409-issue.md
@@ -1,0 +1,5 @@
+---
+"@graphql-hive/cli": patch
+---
+
+No changes


### PR DESCRIPTION
**CI**
https://github.com/kamilkisiela/graphql-hive/actions/runs/9205722573/job/25323489730

> error npm ERR! 409 Conflict - PUT https://registry.npmjs.org/@graphql-hive%2fcli - Failed to save packument. A common cause is if you try to publish a new package before the previous package has been fully processed.

**NPM**
https://www.npmjs.com/package/@graphql-hive/cli/v/0.38.0

**Result**
No binaries in R2.