### PR TITLE
Move `schema` mappers to `schema` module

### DIFF
--- a/codegen.mts
+++ b/codegen.mts
@@ -43,15 +43,15 @@ const config: CodegenConfig = {
           ID: 'string',
         },
         mappers: {
-          SchemaChange: '../shared/mappers#SchemaChange as SchemaChangeMapper',
+          SchemaChange: '../modules/schema/module.graphql.mappers#SchemaChangeMapper',
           SchemaChangeApproval:
-            '../shared/mappers#SchemaChangeApproval as SchemaChangeApprovalMapper',
+            '../modules/schema/module.graphql.mappers#SchemaChangeApprovalMapper',
           SchemaChangeConnection:
-            '../shared/mappers#SchemaChangeConnection as SchemaChangeConnectionMapper',
+            '../modules/schema/module.graphql.mappers#SchemaChangeConnectionMapper',
           SchemaErrorConnection:
-            '../shared/mappers#SchemaErrorConnection as SchemaErrorConnectionMapper',
+            '../modules/schema/module.graphql.mappers#SchemaErrorConnectionMapper',
           SchemaWarningConnection:
-            '../shared/mappers#SchemaWarningConnection as SchemaWarningConnectionMapper',
+            '../modules/schema/module.graphql.mappers#SchemaWarningConnectionMapper',
           OrganizationConnection:
             '../shared/mappers#OrganizationConnection as OrganizationConnectionMapper',
           UserConnection: '../shared/mappers#UserConnection as UserConnectionMapper',

--- a/packages/services/api/src/modules/schema/module.graphql.mappers.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.mappers.ts
@@ -1,0 +1,9 @@
+import type { SchemaChangeType, SchemaCheckApprovalMetadata } from '@hive/storage';
+import type { SchemaError } from '../../__generated__/types';
+import type { SchemaCheckWarning } from './providers/models/shared';
+
+export type SchemaChangeConnectionMapper = ReadonlyArray<SchemaChangeType>;
+export type SchemaChangeMapper = SchemaChangeType;
+export type SchemaChangeApprovalMapper = SchemaCheckApprovalMetadata;
+export type SchemaErrorConnectionMapper = readonly SchemaError[];
+export type SchemaWarningConnectionMapper = readonly SchemaCheckWarning[];

--- a/packages/services/api/src/shared/mappers.ts
+++ b/packages/services/api/src/shared/mappers.ts
@@ -2,10 +2,9 @@ import type { DocumentNode, GraphQLSchema, Kind } from 'graphql';
 import type {
   SchemaChangeType,
   SchemaCheck,
-  SchemaCheckApprovalMetadata,
   SchemaVersion as SchemaVersionEntity,
 } from '@hive/storage';
-import type { ClientStatsValues, OperationStatsValues, SchemaError } from '../__generated__/types';
+import type { ClientStatsValues, OperationStatsValues } from '../__generated__/types';
 import type { SuperGraphInformation } from '../modules/schema/lib/federation-super-graph';
 import type { SchemaCheckWarning } from '../modules/schema/providers/models/shared';
 import type { SchemaBuildError } from '../modules/schema/providers/orchestrators/errors';
@@ -250,11 +249,6 @@ export type GraphQLScalarTypeMapper = WithSchemaCoordinatesUsage<{
   };
 }>;
 
-export type SchemaChangeConnection = ReadonlyArray<SchemaChangeType>;
-export type SchemaChange = SchemaChangeType;
-export type SchemaChangeApproval = SchemaCheckApprovalMetadata;
-export type SchemaErrorConnection = readonly SchemaError[];
-export type SchemaWarningConnection = readonly SchemaCheckWarning[];
 export type UserConnection = readonly User[];
 export type MemberConnection = readonly Member[];
 export type ActivityConnection = readonly ActivityObject[];


### PR DESCRIPTION
### Background

Relates to https://github.com/kamilkisiela/graphql-hive/issues/4741

This PR moves `schema` module related mappers to live next to `module.graphql.ts` file. This move follows the convention of Server Preset, making it easier to make the switch

### Description

This PR only affects types so it doesn't have any runtime impact. This first PR is intentionally small to help me understand the process end-to-end and detect issues quicker. Future PRs may be bigger.
