### PR TITLE
Capture a logic path that leads to default TTL

### DIFF
--- a/packages/services/rate-limit/src/limiter.ts
+++ b/packages/services/rate-limit/src/limiter.ts
@@ -224,6 +224,13 @@ export function createRateLimiter(config: {
       if (!orgData) {
         // This is a safety measure to prevent setting the retention to a lower value then expected,
         // in case of an organization data not being available yet in the cache.
+        const error = new Error(
+          `Failed to resolve/find retention information for targetId=${targetId}`,
+        );
+        Sentry.captureException(error, {
+          level: 'error',
+        });
+        logger.error(error);
         return RETENTION_IN_DAYS_FALLBACK;
       }
 
@@ -234,9 +241,13 @@ export function createRateLimiter(config: {
         input.entityType === 'organization' ? input.id : targetIdToOrgLookup.get(input.id);
 
       if (!orgId) {
-        logger.warn(
-          `Failed to resolve/find rate limit information for entityId=${input.id} (type=${input.entityType})`,
+        const error = new Error(
+          `Failed to resolve/find rate limit information for entityId=${input.id} type=${input.entityType}`,
         );
+        Sentry.captureException(error, {
+          level: 'error',
+        });
+        logger.error(error);
 
         return UNKNOWN_RATE_LIMIT_OBJ;
       }

--- a/packages/services/usage/src/index.ts
+++ b/packages/services/usage/src/index.ts
@@ -174,6 +174,15 @@ async function main() {
         const retentionInfo =
           (await rateLimit?.getRetentionForTargetId?.(tokenInfo.target)) || null;
 
+        if (typeof retentionInfo !== 'number') {
+          req.log.error(
+            'Failed to get retention info (token=%s, target=%s, organization=%s)',
+            maskedToken,
+            tokenInfo.target,
+            tokenInfo.organization,
+          );
+        }
+
         const stopTimer = collectDuration.startTimer();
         try {
           if (readiness() === false) {


### PR DESCRIPTION
Log errors whenever we hit a scenario when default data retention period is used for a usage report.