### PR TITLE
fix: breaking change day retention picker

### DIFF
--- a/packages/web/app/src/pages/target-settings.tsx
+++ b/packages/web/app/src/pages/target-settings.tsx
@@ -603,7 +603,7 @@ const ConditionalBreakingChanges = (props: {
               size="small"
               type="number"
               min="1"
-              max="30"
+              max={targetSettings.data?.organization?.organization?.rateLimit.retentionInDays ?? 30}
               className="mx-2 !inline-flex !w-16"
             />
             days.


### PR DESCRIPTION
### Background

The value was hardcoded and selecting a day range higher than 30 days was impossible.

### Description

This uses the remote value instead.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
