### PR TITLE
fix lost whitespace in `<DocsLink />` component

### DIFF
--- a/packages/web/app/src/components/ui/docs-note.tsx
+++ b/packages/web/app/src/components/ui/docs-note.tsx
@@ -36,7 +36,15 @@ export const DocsLink = ({
   const fullUrl = href.startsWith('http') ? href : getDocsUrl(href);
 
   return (
-    <Button variant="link" className={cn('p-0 text-orange-500', className)} asChild>
+    <Button
+      asChild
+      variant="link"
+      className={cn(
+        'p-0 text-orange-500',
+        'whitespace-pre-wrap', // to not lose whitespace between tags due to `display: 'inline-flex'`
+        className,
+      )}
+    >
       <a href={fullUrl} target="_blank" rel="noreferrer">
         {icon ?? <Book className="mr-2 size-4" />}
         {children}


### PR DESCRIPTION
## before
<img width="677" alt="image" src="https://github.com/kamilkisiela/graphql-hive/assets/7361780/8c449834-5f4b-4d06-b39a-02a1db30ae6f">

## after

<img width="693" alt="image" src="https://github.com/kamilkisiela/graphql-hive/assets/7361780/8cf26efa-5099-4a57-8373-dde9413ade4a">
