### PR TITLE
Fix constantly growing \200b backslash escaping

### DIFF
--- a/packages/web/app/src/components/target/settings/schema-contracts.tsx
+++ b/packages/web/app/src/components/target/settings/schema-contracts.tsx
@@ -447,7 +447,7 @@ function CreateContractDialogContent(props: {
                 disabled={form.isSubmitting}
                 autoComplete="off"
               />
-              <span className="text-sm text-red-500 after:hidden after:content-['.']">
+              <span className="text-sm text-red-500 after:invisible after:content-['.']">
                 {mutation.data?.createContract.error?.details?.contractName ??
                   form.errors.contractName}
               </span>
@@ -538,7 +538,7 @@ function CreateContractDialogContent(props: {
                       </Command>
                     </PopoverContent>
                   </Popover>
-                  <div className="mt-2 text-sm text-red-500 after:hidden after:content-['.']">
+                  <div className="mt-2 text-sm text-red-500 after:invisible after:content-['.']">
                     {mutation.data?.createContract.error?.details?.includeTags ??
                       form.errors.includeTags}
                   </div>
@@ -651,7 +651,7 @@ function CreateContractDialogContent(props: {
                       </Command>
                     </PopoverContent>
                   </Popover>
-                  <div className="mt-2 text-sm text-red-500 after:hidden after:content-['.']">
+                  <div className="mt-2 text-sm text-red-500 after:invisible after:content-['.']">
                     {mutation.data?.createContract.error?.details?.excludeTags ??
                       form.errors.excludeTags}
                   </div>

--- a/packages/web/app/src/components/target/settings/schema-contracts.tsx
+++ b/packages/web/app/src/components/target/settings/schema-contracts.tsx
@@ -447,7 +447,7 @@ function CreateContractDialogContent(props: {
                 disabled={form.isSubmitting}
                 autoComplete="off"
               />
-              <span className="text-sm text-red-500 after:content-['\\\\200b']">
+              <span className="text-sm text-red-500 after:hidden after:content-['.']">
                 {mutation.data?.createContract.error?.details?.contractName ??
                   form.errors.contractName}
               </span>
@@ -538,7 +538,7 @@ function CreateContractDialogContent(props: {
                       </Command>
                     </PopoverContent>
                   </Popover>
-                  <div className="mt-2 text-sm text-red-500 after:content-['\\\\200b']">
+                  <div className="mt-2 text-sm text-red-500 after:hidden after:content-['.']">
                     {mutation.data?.createContract.error?.details?.includeTags ??
                       form.errors.includeTags}
                   </div>
@@ -651,7 +651,7 @@ function CreateContractDialogContent(props: {
                       </Command>
                     </PopoverContent>
                   </Popover>
-                  <div className="mt-2 text-sm text-red-500 after:content-['\\\\200b']">
+                  <div className="mt-2 text-sm text-red-500 after:hidden after:content-['.']">
                     {mutation.data?.createContract.error?.details?.excludeTags ??
                       form.errors.excludeTags}
                   </div>


### PR DESCRIPTION
Every time prettier runs, the amount of \ doubles

```css
after:content-['\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\200b']
```