### PR TITLE
Fix /graphql-whatever matching /graphql route

### DIFF
--- a/deployment/services/proxy.ts
+++ b/deployment/services/proxy.ts
@@ -65,14 +65,6 @@ export function deployProxy({
         retriable: true,
       },
       {
-        name: 'graphql-api',
-        path: '/graphql',
-        customRewrite: '/graphql',
-        service: graphql.service,
-        requestTimeout: '60s',
-        retriable: true,
-      },
-      {
         name: 'graphql-api-subscriptions',
         path: '/graphql/stream',
         customRewrite: '/graphql',
@@ -80,6 +72,14 @@ export function deployProxy({
         requestTimeout: 'infinity',
         // we send a ping every 12 seconds
         idleTimeout: '30s',
+        retriable: true,
+      },
+      {
+        name: 'graphql-api',
+        path: '/graphql',
+        customRewrite: '/graphql',
+        service: graphql.service,
+        requestTimeout: '60s',
         retriable: true,
       },
       {

--- a/deployment/services/proxy.ts
+++ b/deployment/services/proxy.ts
@@ -41,24 +41,28 @@ export function deployProxy({
       {
         name: 'app',
         path: '/',
+        match: 'prefix',
         service: app.service,
         requestTimeout: '60s',
       },
       {
         name: 'server',
         path: '/server',
+        match: 'path_separated_prefix',
         service: graphql.service,
         requestTimeout: '60s',
       },
       {
         name: 'registry-api-health',
         path: '/registry/_health',
+        match: 'exact',
         customRewrite: '/_health',
         service: graphql.service,
       },
       {
         name: 'registry-api',
         path: '/registry',
+        match: 'exact',
         customRewrite: '/graphql',
         service: graphql.service,
         requestTimeout: '60s',
@@ -67,6 +71,7 @@ export function deployProxy({
       {
         name: 'graphql-api-subscriptions',
         path: '/graphql/stream',
+        match: 'path_separated_prefix',
         customRewrite: '/graphql',
         service: graphql.service,
         requestTimeout: 'infinity',
@@ -77,6 +82,7 @@ export function deployProxy({
       {
         name: 'graphql-api',
         path: '/graphql',
+        match: 'path_separated_prefix',
         customRewrite: '/graphql',
         service: graphql.service,
         requestTimeout: '60s',
@@ -85,6 +91,7 @@ export function deployProxy({
       {
         name: 'auth',
         path: '/auth-api',
+        match: 'path_separated_prefix',
         customRewrite: '/auth-api',
         service: graphql.service,
         requestTimeout: '60s',
@@ -93,6 +100,7 @@ export function deployProxy({
       {
         name: 'usage',
         path: '/usage',
+        match: 'exact',
         service: usage.service,
         retriable: true,
       },

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -113,7 +113,7 @@ export class Proxy {
                   port: route.service.spec.ports[0].port,
                 },
               ],
-              ...(route.path === '/'
+              ...(route.path === '/' || route.match === 'exact'
                 ? {}
                 : {
                     pathRewritePolicy: {

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -78,14 +78,14 @@ export class Proxy {
                       ...route,
                       // Accepts: /graphql
                       // Rejects: /graphql/ and /graphql-hive
-                      match: 'exact',
+                      match: 'exact' as const,
                     },
                     {
                       ...route,
                       path: route.path + '/',
                       // Accepts: /graphql/ and /graphql/anything
                       // Rejects: /graphql and /graphql-hive
-                      match: 'prefix',
+                      match: 'prefix' as const,
                     },
                   ]
                 : [route],
@@ -113,6 +113,7 @@ export class Proxy {
                     pathRewritePolicy: {
                       replacePrefix: [
                         {
+                          prefix: route.path,
                           replacement: route.customRewrite || '/',
                         },
                       ],

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -106,6 +106,9 @@ export class Proxy {
                       {
                         exact: route.path,
                       },
+                      {
+                        prefix: '/',
+                      },
                     ],
               services: [
                 {
@@ -113,7 +116,7 @@ export class Proxy {
                   port: route.service.spec.ports[0].port,
                 },
               ],
-              ...(route.path === '/' || route.match === 'exact'
+              ...(route.path === '/'
                 ? {}
                 : {
                     pathRewritePolicy: {

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -77,7 +77,7 @@ export class Proxy {
                   [
                     {
                       ...route,
-                      regex: `^${route.path}(/.*)?$`,
+                      regex: `${route.path}(/.*)?`,
                       match: 'regex' as const,
                     },
                   ]

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -69,9 +69,17 @@ export class Proxy {
           },
           routes: routes.map(route => ({
             conditions: [
-              {
-                prefix: route.path,
-              },
+              route.path === '/'
+                ? {
+                    prefix: route.path,
+                  }
+                : {
+                    // See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routematch-path-separated-prefix
+                    // If specified, the route is a path-separated prefix rule meaning that the :path header (without the query string) must either exactly match the path_separated_prefix or have it as a prefix, followed by /
+                    // For example, /api/dev would match /api/dev, /api/dev/, /api/dev/v1, and /api/dev?param=true but would not match /api/developer
+                    // Expect the value to not contain ? or # and not to end in /
+                    path_separated_prefix: route.path,
+                  },
             ],
             services: [
               {

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -100,9 +100,9 @@ export class Proxy {
                       },
                     ]
                   : [
-                      {
-                        prefix: route.path,
-                      },
+                      // {
+                      //   prefix: route.path,
+                      // },
                       {
                         exact: route.path,
                       },

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -4,7 +4,7 @@ import { ContourValues } from './contour.types';
 import { helmChart } from './helm';
 
 // prettier-ignore
-export const CONTOUR_CHART = helmChart('https://charts.bitnami.com/bitnami', 'contour', '17.0.12');
+export const CONTOUR_CHART = helmChart('https://charts.bitnami.com/bitnami', 'contour', '18.2.4');
 
 export class Proxy {
   private lbService: Output<k8s.core.v1.Service> | null = null;
@@ -77,17 +77,15 @@ export class Proxy {
                   [
                     {
                       ...route,
-                      regex: `${route.path}(/.*)?`,
-                      match: 'regex' as const,
+                      path: route.path,
+                      match: 'prefix' as const,
                     },
                   ]
                 : [route],
             )
             .flat(1)
             .map(route => ({
-              conditions: [
-                route.match === 'regex' ? { regex: route.regex } : { prefix: route.path },
-              ],
+              conditions: [{ prefix: route.path }],
               services: [
                 {
                   name: route.service.metadata.name,

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -68,19 +68,24 @@ export class Proxy {
             },
           },
           routes: routes.map(route => ({
-            conditions: [
+            conditions:
               route.path === '/'
-                ? {
-                    prefix: route.path,
-                  }
-                : {
+                ? [
+                    {
+                      prefix: route.path,
+                    },
+                  ]
+                : [
+                    // Contour does not support Envoy's path_separated_prefix
                     // See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routematch-path-separated-prefix
-                    // If specified, the route is a path-separated prefix rule meaning that the :path header (without the query string) must either exactly match the path_separated_prefix or have it as a prefix, followed by /
-                    // For example, /api/dev would match /api/dev, /api/dev/, /api/dev/v1, and /api/dev?param=true but would not match /api/developer
-                    // Expect the value to not contain ? or # and not to end in /
-                    path_separated_prefix: route.path,
-                  },
-            ],
+                    // This could help us to avoid the need of two conditions for the same route.
+                    {
+                      exact: route.path,
+                    },
+                    {
+                      prefix: route.path + '/',
+                    },
+                  ],
             services: [
               {
                 name: route.service.metadata.name,

--- a/deployment/utils/reverse-proxy.ts
+++ b/deployment/utils/reverse-proxy.ts
@@ -92,15 +92,21 @@ export class Proxy {
             )
             .flat(1)
             .map(route => ({
-              conditions: [
+              conditions:
                 route.match === 'prefix'
-                  ? {
-                      prefix: route.path,
-                    }
-                  : {
-                      exact: route.path,
-                    },
-              ],
+                  ? [
+                      {
+                        prefix: route.path,
+                      },
+                    ]
+                  : [
+                      {
+                        prefix: route.path,
+                      },
+                      {
+                        exact: route.path,
+                      },
+                    ],
               services: [
                 {
                   name: route.service.metadata.name,


### PR DESCRIPTION
We used `prefix: "/graphql"`, and because of that every path that starts with `/graphql` is routed by Envoy to `graphql-api` service.

For non `/` routes, I tried to move us to `path_separated_prefix`, so `/graphql` route could accept `/graphql`, `/graphql/whatever`, but not `/graphql-whatever`.
The problem is that `path_separated_prefix` is only available in Envoy, so I had to create two routes `exact /graphql` and `prefix /graphql/`, but I wish to solve it in a different way (to support `/graphql?` as well, and to not duplicate routes).

- [ ] check if `/graphql/stream` is affected