### PR TITLE
[laboratory] hide `Share Operation` GraphiQL toolbar button if operation is not yet saved

### DIFF
--- a/packages/web/app/src/components/layouts/target.tsx
+++ b/packages/web/app/src/components/layouts/target.tsx
@@ -269,10 +269,8 @@ export const TargetLayout = ({
           ) : null}
         </div>
       </div>
-      <div className="container h-full pb-7">
-        <div className={cn('flex h-full justify-between gap-12', className)}>
-          <div className="flex grow flex-col">{children}</div>
-        </div>
+      <div className={cn('container pb-7', className)}>
+        {children}
       </div>
     </>
   );

--- a/packages/web/app/src/components/layouts/target.tsx
+++ b/packages/web/app/src/components/layouts/target.tsx
@@ -269,9 +269,7 @@ export const TargetLayout = ({
           ) : null}
         </div>
       </div>
-      <div className={cn('container pb-7', className)}>
-        {children}
-      </div>
+      <div className={cn('container pb-7', className)}>{children}</div>
     </>
   );
 };

--- a/packages/web/app/src/components/ui/form.tsx
+++ b/packages/web/app/src/components/ui/form.tsx
@@ -98,7 +98,7 @@ FormLabel.displayName = 'FormLabel';
 const FormControl = React.forwardRef<
   React.ElementRef<typeof Slot>,
   React.ComponentPropsWithoutRef<typeof Slot>
->(({ ...props }, ref) => {
+>((props, ref) => {
   const { error, formItemId, formDescriptionId, formMessageId } = useFormField();
 
   return (

--- a/packages/web/app/src/components/ui/page-content-layout.tsx
+++ b/packages/web/app/src/components/ui/page-content-layout.tsx
@@ -55,21 +55,19 @@ type SubPageLayoutHeaderProps = {
   description?: string | ReactNode;
 } & HTMLAttributes<HTMLDivElement>;
 
-const SubPageLayoutHeader = forwardRef<HTMLDivElement, SubPageLayoutHeaderProps>(
-  ({ ...props }, ref) => (
-    <div className="flex flex-row items-center justify-between" ref={ref}>
-      <div className="space-y-1.5">
-        <CardTitle>{props.title}</CardTitle>
-        {typeof props.description === 'string' ? (
-          <CardDescription>{props.description}</CardDescription>
-        ) : (
-          props.description
-        )}
-      </div>
-      <div>{props.children}</div>
+const SubPageLayoutHeader = forwardRef<HTMLDivElement, SubPageLayoutHeaderProps>((props, ref) => (
+  <div className="flex flex-row items-center justify-between" ref={ref}>
+    <div className="space-y-1.5">
+      <CardTitle>{props.title}</CardTitle>
+      {typeof props.description === 'string' ? (
+        <CardDescription>{props.description}</CardDescription>
+      ) : (
+        props.description
+      )}
     </div>
-  ),
-);
+    <div>{props.children}</div>
+  </div>
+));
 SubPageLayoutHeader.displayName = 'SubPageLayoutHeader';
 
 export { PageLayout, NavLayout, PageLayoutContent, SubPageLayout, SubPageLayoutHeader };

--- a/packages/web/app/src/components/ui/use-toast.ts
+++ b/packages/web/app/src/components/ui/use-toast.ts
@@ -134,7 +134,7 @@ function dispatch(action: Action) {
 
 type Toast = Omit<ToasterToast, 'id'>;
 
-function toast({ ...props }: Toast) {
+function toast(props: Toast) {
   const id = genId();
 
   const update = (props: ToasterToast) =>

--- a/packages/web/app/src/index.css
+++ b/packages/web/app/src/index.css
@@ -36,6 +36,8 @@
     --ring: 215 20.2% 65.1%;
 
     --radius: 0.5rem;
+    
+    --hive-content-height: calc(100vh - 84px - 47px);
   }
 
   .dark {

--- a/packages/web/app/src/index.css
+++ b/packages/web/app/src/index.css
@@ -36,7 +36,7 @@
     --ring: 215 20.2% 65.1%;
 
     --radius: 0.5rem;
-    
+
     --hive-content-height: calc(100vh - 84px - 47px);
   }
 

--- a/packages/web/app/src/pages/target-history.tsx
+++ b/packages/web/app/src/pages/target-history.tsx
@@ -212,7 +212,7 @@ function HistoryPageContent(props: {
       projectId={props.projectId}
       targetId={props.targetId}
       page={Page.History}
-      className="h-full"
+      className="h-[--hive-content-height] overflow-scroll"
     >
       {hasVersions ? (
         <div className="flex size-full flex-row gap-x-6">

--- a/packages/web/app/src/pages/target-laboratory.tsx
+++ b/packages/web/app/src/pages/target-laboratory.tsx
@@ -59,16 +59,17 @@ import { Repeater } from '@repeaterjs/repeater';
 import { Link as RouterLink, useRouter } from '@tanstack/react-router';
 import 'graphiql/graphiql.css';
 
-function Share(props: { operation: string | null }): ReactElement {
+function Share({ operation }: { operation: string | null }): ReactElement | null {
   const label = 'Share query';
   const copyToClipboard = useClipboard();
+
+  if (!operation) return null;
 
   return (
     <GraphiQLTooltip label={label}>
       <GraphiQLButton
         className="graphiql-toolbar-button"
         aria-label={label}
-        disabled={!props.operation}
         onClick={async () => {
           await copyToClipboard(window.location.href);
         }}

--- a/packages/web/app/src/pages/target-laboratory.tsx
+++ b/packages/web/app/src/pages/target-laboratory.tsx
@@ -1,6 +1,9 @@
 import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
+import { cx } from 'class-variance-authority';
+import clsx from 'clsx';
 import { GraphiQL } from 'graphiql';
 import { buildSchema } from 'graphql';
+import { Helmet } from 'react-helmet-async';
 import { useMutation, useQuery } from 'urql';
 import { Page, TargetLayout } from '@/components/layouts/target';
 import { ConnectLabModal } from '@/components/target/laboratory/connect-lab-modal';
@@ -8,32 +11,6 @@ import { CreateCollectionModal } from '@/components/target/laboratory/create-col
 import { CreateOperationModal } from '@/components/target/laboratory/create-operation-modal';
 import { DeleteCollectionModal } from '@/components/target/laboratory/delete-collection-modal';
 import { DeleteOperationModal } from '@/components/target/laboratory/delete-operation-modal';
-import { Button } from '@/components/ui/button';
-import { DocsLink } from '@/components/ui/docs-note';
-import { Link } from '@/components/ui/link';
-import { Subtitle, Title } from '@/components/ui/page';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { HiveLogo, PlusIcon, SaveIcon, ShareIcon } from '@/components/v2/icon';
-import { Spinner } from '@/components/v2/spinner';
-import { ToggleGroup, ToggleGroupItem } from '@/components/v2/toggle-group';
-import { Tooltip as LegacyTooltip } from '@/components/v2/tooltip';
-import { graphql } from '@/gql';
-import { TargetAccessScope } from '@/gql/graphql';
-import { canAccessTarget } from '@/lib/access/target';
-import { useClipboard, useNotifications, useToggle } from '@/lib/hooks';
-import { cn } from '@/lib/utils';
-import {
-  UnStyledButton as GraphiQLButton,
-  GraphiQLPlugin,
-  Tooltip as GraphiQLTooltip,
-  useEditorContext,
-} from '@graphiql/react';
-import { createGraphiQLFetcher, Fetcher, isAsyncIterable } from '@graphiql/toolkit';
-import { BookmarkIcon, DotsHorizontalIcon } from '@radix-ui/react-icons';
-import 'graphiql/graphiql.css';
-import { cx } from 'class-variance-authority';
-import clsx from 'clsx';
-import { Helmet } from 'react-helmet-async';
 import { EditOperationModal } from '@/components/target/laboratory/edit-operation-modal';
 import {
   Accordion,
@@ -42,6 +19,8 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@/components/ui/accordion';
+import { Button } from '@/components/ui/button';
+import { DocsLink } from '@/components/ui/docs-note';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -49,11 +28,36 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Link } from '@/components/ui/link';
 import { Meta } from '@/components/ui/meta';
+import { Subtitle, Title } from '@/components/ui/page';
 import { QueryError } from '@/components/ui/query-error';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { PlusIcon, SaveIcon, ShareIcon } from '@/components/v2/icon';
+import { Spinner } from '@/components/v2/spinner';
+import { ToggleGroup, ToggleGroupItem } from '@/components/v2/toggle-group';
+import { graphql } from '@/gql';
+import { TargetAccessScope } from '@/gql/graphql';
+import { canAccessTarget } from '@/lib/access/target';
+import { useClipboard, useNotifications, useToggle } from '@/lib/hooks';
 import { useResetState } from '@/lib/hooks/use-reset-state';
+import { cn } from '@/lib/utils';
+import {
+  UnStyledButton as GraphiQLButton,
+  GraphiQLPlugin,
+  Tooltip as GraphiQLTooltip,
+  useEditorContext,
+} from '@graphiql/react';
+import { createGraphiQLFetcher, Fetcher, isAsyncIterable } from '@graphiql/toolkit';
+import {
+  BookmarkIcon,
+  DotsHorizontalIcon,
+  EnterFullScreenIcon,
+  ExitFullScreenIcon,
+} from '@radix-ui/react-icons';
 import { Repeater } from '@repeaterjs/repeater';
 import { Link as RouterLink, useRouter } from '@tanstack/react-router';
+import 'graphiql/graphiql.css';
 
 function Share(props: { operation: string | null }): ReactElement {
   const label = 'Share query';

--- a/packages/web/app/src/pages/target-laboratory.tsx
+++ b/packages/web/app/src/pages/target-laboratory.tsx
@@ -943,6 +943,10 @@ function LaboratoryPageContent(props: {
       ? searchObj.operation
       : null;
 
+  const [isFullScreen, setIsFullScreen] = useState(false);
+
+  const FullScreenComponent = isFullScreen ? ExitFullScreenIcon : EnterFullScreenIcon;
+
   return (
     <TargetLayout
       organizationId={props.organizationId}
@@ -1031,7 +1035,6 @@ function LaboratoryPageContent(props: {
         .graphiql-container {
           --color-base: transparent !important;
           --color-primary: 40, 89%, 60% !important;
-          min-height: 600px;
         }
         .graphiql-container .graphiql-tab-add {
           display: none;
@@ -1074,57 +1077,46 @@ function LaboratoryPageContent(props: {
       `}</style>
       </Helmet>
 
-      {query.fetching ? null : (
-        <GraphiQL
-          fetcher={fetcher}
-          toolbar={{
-            additionalContent: (
-              <>
-                <Save
-                  organizationId={props.organizationId}
-                  projectId={props.projectId}
-                  targetId={props.targetId}
-                />
-                <Share operation={operation} />
-              </>
-            ),
-          }}
-          showPersistHeadersSettings={false}
-          shouldPersistHeaders={false}
-          plugins={[operationCollectionsPlugin]}
-          visiblePlugin={operationCollectionsPlugin}
-          schema={schema}
-          forcedTheme="dark"
-        >
-          <GraphiQL.Logo>
-            <EditorBreadcrumbs
-              organizationId={props.organizationId}
-              projectId={props.projectId}
-              targetId={props.targetId}
-            />
-            <div className="ml-auto">
-              <LegacyTooltip
-                content={
-                  actualSelectedApiEndpoint === 'linkedApi' ? (
-                    <>
-                      Operations are executed against{' '}
-                      <span>{query.data?.target?.graphqlEndpointUrl}</span>.
-                    </>
-                  ) : (
-                    <>Operations are executed against the mock endpoint.</>
-                  )
-                }
+      {!query.fetching && (
+        <div className={clsx('grow', isFullScreen && 'fixed inset-0 bg-[#030711]')}>
+          <GraphiQL
+            fetcher={fetcher}
+            toolbar={{
+              additionalContent: (
+                <>
+                  <Save
+                    organizationId={props.organizationId}
+                    projectId={props.projectId}
+                    targetId={props.targetId}
+                  />
+                  <Share operation={operation} />
+                </>
+              ),
+            }}
+            showPersistHeadersSettings={false}
+            shouldPersistHeaders={false}
+            plugins={[operationCollectionsPlugin]}
+            visiblePlugin={operationCollectionsPlugin}
+            schema={schema}
+            forcedTheme="dark"
+          >
+            <GraphiQL.Logo>
+              <EditorBreadcrumbs
+                organizationId={props.organizationId}
+                projectId={props.projectId}
+                targetId={props.targetId}
+              />
+              <Button
+                onClick={() => setIsFullScreen(prev => !prev)}
+                variant="outline"
+                className="h-auto gap-2 p-2"
               >
-                <span className="cursor-help pr-2 text-xs font-normal">
-                  {actualSelectedApiEndpoint === 'linkedApi'
-                    ? 'Querying GraphQL API'
-                    : 'Querying Mock API'}
-                </span>
-              </LegacyTooltip>
-              <HiveLogo className="h-6 w-auto" />
-            </div>
-          </GraphiQL.Logo>
-        </GraphiQL>
+                <FullScreenComponent className="size-4" />
+                {isFullScreen ? 'Exit' : 'Enter'} Full Screen
+              </Button>
+            </GraphiQL.Logo>
+          </GraphiQL>
+        </div>
       )}
       <ConnectLabModal
         endpoint={mockEndpoint}

--- a/packages/web/app/src/pages/target-laboratory.tsx
+++ b/packages/web/app/src/pages/target-laboratory.tsx
@@ -953,6 +953,7 @@ function LaboratoryPageContent(props: {
       projectId={props.projectId}
       targetId={props.targetId}
       page={Page.Laboratory}
+      className="flex h-[--hive-content-height] flex-col"
     >
       <div className="flex py-6">
         <div className="flex-1">
@@ -1109,7 +1110,7 @@ function LaboratoryPageContent(props: {
               <Button
                 onClick={() => setIsFullScreen(prev => !prev)}
                 variant="outline"
-                className="h-auto gap-2 p-2"
+                className="h-auto gap-2"
               >
                 <FullScreenComponent className="size-4" />
                 {isFullScreen ? 'Exit' : 'Enter'} Full Screen

--- a/packages/web/app/src/pages/target-laboratory.tsx
+++ b/packages/web/app/src/pages/target-laboratory.tsx
@@ -863,6 +863,7 @@ function LaboratoryPageContent(props: {
   });
   const router = useRouter();
   const [isConnectLabModalOpen, toggleConnectLabModal] = useToggle();
+  const [isFullScreen, setIsFullScreen] = useState(false);
 
   const currentOrganization = query.data?.organization?.organization;
 
@@ -942,8 +943,6 @@ function LaboratoryPageContent(props: {
     'operation' in searchObj && typeof searchObj.operation === 'string'
       ? searchObj.operation
       : null;
-
-  const [isFullScreen, setIsFullScreen] = useState(false);
 
   const FullScreenComponent = isFullScreen ? ExitFullScreenIcon : EnterFullScreenIcon;
 


### PR DESCRIPTION
nothing happens if an operation is not saved

previous experience is:



https://github.com/kamilkisiela/graphql-hive/assets/7361780/cb42498f-c343-464f-816a-0a0b8a57e70a

