### PR TITLE
[laboratory] remove `Merge fragments into query`, `Copy query` toolbar buttons, move `Prettify query` to end

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
       "got@14.4.1": "patches/got@14.4.1.patch",
       "slonik@30.4.4": "patches/slonik@30.4.4.patch",
       "@oclif/core@3.26.6": "patches/@oclif__core@3.26.6.patch",
-      "oclif@4.13.6": "patches/oclif@4.13.6.patch"
+      "oclif@4.13.6": "patches/oclif@4.13.6.patch",
+      "graphiql@3.3.0": "patches/graphiql@3.3.0.patch"
     }
   }
 }

--- a/packages/web/app/src/components/layouts/target.tsx
+++ b/packages/web/app/src/components/layouts/target.tsx
@@ -269,10 +269,8 @@ export const TargetLayout = ({
           ) : null}
         </div>
       </div>
-      <div className="container h-full pb-7">
-        <div className={cn('flex h-full justify-between gap-12', className)}>
-          <div className="flex grow flex-col">{children}</div>
-        </div>
+      <div className={cn('container pb-7', className)}>
+        {children}
       </div>
     </>
   );

--- a/packages/web/app/src/components/layouts/target.tsx
+++ b/packages/web/app/src/components/layouts/target.tsx
@@ -269,9 +269,7 @@ export const TargetLayout = ({
           ) : null}
         </div>
       </div>
-      <div className={cn('container pb-7', className)}>
-        {children}
-      </div>
+      <div className={cn('container pb-7', className)}>{children}</div>
     </>
   );
 };

--- a/packages/web/app/src/components/ui/form.tsx
+++ b/packages/web/app/src/components/ui/form.tsx
@@ -98,7 +98,7 @@ FormLabel.displayName = 'FormLabel';
 const FormControl = React.forwardRef<
   React.ElementRef<typeof Slot>,
   React.ComponentPropsWithoutRef<typeof Slot>
->(({ ...props }, ref) => {
+>((props, ref) => {
   const { error, formItemId, formDescriptionId, formMessageId } = useFormField();
 
   return (

--- a/packages/web/app/src/components/ui/page-content-layout.tsx
+++ b/packages/web/app/src/components/ui/page-content-layout.tsx
@@ -55,21 +55,19 @@ type SubPageLayoutHeaderProps = {
   description?: string | ReactNode;
 } & HTMLAttributes<HTMLDivElement>;
 
-const SubPageLayoutHeader = forwardRef<HTMLDivElement, SubPageLayoutHeaderProps>(
-  ({ ...props }, ref) => (
-    <div className="flex flex-row items-center justify-between" ref={ref}>
-      <div className="space-y-1.5">
-        <CardTitle>{props.title}</CardTitle>
-        {typeof props.description === 'string' ? (
-          <CardDescription>{props.description}</CardDescription>
-        ) : (
-          props.description
-        )}
-      </div>
-      <div>{props.children}</div>
+const SubPageLayoutHeader = forwardRef<HTMLDivElement, SubPageLayoutHeaderProps>((props, ref) => (
+  <div className="flex flex-row items-center justify-between" ref={ref}>
+    <div className="space-y-1.5">
+      <CardTitle>{props.title}</CardTitle>
+      {typeof props.description === 'string' ? (
+        <CardDescription>{props.description}</CardDescription>
+      ) : (
+        props.description
+      )}
     </div>
-  ),
-);
+    <div>{props.children}</div>
+  </div>
+));
 SubPageLayoutHeader.displayName = 'SubPageLayoutHeader';
 
 export { PageLayout, NavLayout, PageLayoutContent, SubPageLayout, SubPageLayoutHeader };

--- a/packages/web/app/src/components/ui/use-toast.ts
+++ b/packages/web/app/src/components/ui/use-toast.ts
@@ -134,7 +134,7 @@ function dispatch(action: Action) {
 
 type Toast = Omit<ToasterToast, 'id'>;
 
-function toast({ ...props }: Toast) {
+function toast(props: Toast) {
   const id = genId();
 
   const update = (props: ToasterToast) =>

--- a/packages/web/app/src/index.css
+++ b/packages/web/app/src/index.css
@@ -36,6 +36,8 @@
     --ring: 215 20.2% 65.1%;
 
     --radius: 0.5rem;
+    
+    --hive-content-height: calc(100vh - 84px - 47px);
   }
 
   .dark {

--- a/packages/web/app/src/index.css
+++ b/packages/web/app/src/index.css
@@ -36,7 +36,7 @@
     --ring: 215 20.2% 65.1%;
 
     --radius: 0.5rem;
-    
+
     --hive-content-height: calc(100vh - 84px - 47px);
   }
 

--- a/packages/web/app/src/pages/target-history.tsx
+++ b/packages/web/app/src/pages/target-history.tsx
@@ -212,7 +212,7 @@ function HistoryPageContent(props: {
       projectId={props.projectId}
       targetId={props.targetId}
       page={Page.History}
-      className="h-full"
+      className="h-[--hive-content-height] overflow-scroll"
     >
       {hasVersions ? (
         <div className="flex size-full flex-row gap-x-6">

--- a/packages/web/app/src/pages/target-laboratory.tsx
+++ b/packages/web/app/src/pages/target-laboratory.tsx
@@ -59,16 +59,17 @@ import { Repeater } from '@repeaterjs/repeater';
 import { Link as RouterLink, useRouter } from '@tanstack/react-router';
 import 'graphiql/graphiql.css';
 
-function Share(props: { operation: string | null }): ReactElement {
+function Share({ operation }: { operation: string | null }): ReactElement | null {
   const label = 'Share query';
   const copyToClipboard = useClipboard();
+
+  if (!operation) return null;
 
   return (
     <GraphiQLTooltip label={label}>
       <GraphiQLButton
         className="graphiql-toolbar-button"
         aria-label={label}
-        disabled={!props.operation}
         onClick={async () => {
           await copyToClipboard(window.location.href);
         }}

--- a/packages/web/app/src/pages/target-laboratory.tsx
+++ b/packages/web/app/src/pages/target-laboratory.tsx
@@ -207,7 +207,7 @@ const CollectionItem = (props: {
         )}
       </Link>
       <DropdownMenu>
-        <DropdownMenuTrigger className="graphiql-toolbar-button text-white">
+        <DropdownMenuTrigger className="graphiql-toolbar-button text-white opacity-0 transition-opacity [div:hover>&]:opacity-100">
           <DotsHorizontalIcon />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
@@ -1183,10 +1183,15 @@ function EditorBreadcrumbs(props: { organizationId: string; projectId: string; t
   }
 
   return (
-    <div className="text-xs font-normal italic">
-      {currentOperation?.id
-        ? `${currentOperation.collection.name} > ${currentOperation.name}`
-        : 'New Operation'}
+    <div className="text-sm font-normal italic">
+      {currentOperation?.id ? (
+        <>
+          {currentOperation.collection.name} <span className="not-italic">{'>'}</span>{' '}
+          {currentOperation.name}
+        </>
+      ) : (
+        'New Operation'
+      )}
     </div>
   );
 }

--- a/packages/web/app/src/pages/target-laboratory.tsx
+++ b/packages/web/app/src/pages/target-laboratory.tsx
@@ -1,6 +1,9 @@
 import { ReactElement, useCallback, useEffect, useMemo, useState } from 'react';
+import { cx } from 'class-variance-authority';
+import clsx from 'clsx';
 import { GraphiQL } from 'graphiql';
 import { buildSchema } from 'graphql';
+import { Helmet } from 'react-helmet-async';
 import { useMutation, useQuery } from 'urql';
 import { Page, TargetLayout } from '@/components/layouts/target';
 import { ConnectLabModal } from '@/components/target/laboratory/connect-lab-modal';
@@ -8,32 +11,6 @@ import { CreateCollectionModal } from '@/components/target/laboratory/create-col
 import { CreateOperationModal } from '@/components/target/laboratory/create-operation-modal';
 import { DeleteCollectionModal } from '@/components/target/laboratory/delete-collection-modal';
 import { DeleteOperationModal } from '@/components/target/laboratory/delete-operation-modal';
-import { Button } from '@/components/ui/button';
-import { DocsLink } from '@/components/ui/docs-note';
-import { Link } from '@/components/ui/link';
-import { Subtitle, Title } from '@/components/ui/page';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
-import { HiveLogo, PlusIcon, SaveIcon, ShareIcon } from '@/components/v2/icon';
-import { Spinner } from '@/components/v2/spinner';
-import { ToggleGroup, ToggleGroupItem } from '@/components/v2/toggle-group';
-import { Tooltip as LegacyTooltip } from '@/components/v2/tooltip';
-import { graphql } from '@/gql';
-import { TargetAccessScope } from '@/gql/graphql';
-import { canAccessTarget } from '@/lib/access/target';
-import { useClipboard, useNotifications, useToggle } from '@/lib/hooks';
-import { cn } from '@/lib/utils';
-import {
-  UnStyledButton as GraphiQLButton,
-  GraphiQLPlugin,
-  Tooltip as GraphiQLTooltip,
-  useEditorContext,
-} from '@graphiql/react';
-import { createGraphiQLFetcher, Fetcher, isAsyncIterable } from '@graphiql/toolkit';
-import { BookmarkIcon, DotsHorizontalIcon } from '@radix-ui/react-icons';
-import 'graphiql/graphiql.css';
-import { cx } from 'class-variance-authority';
-import clsx from 'clsx';
-import { Helmet } from 'react-helmet-async';
 import { EditOperationModal } from '@/components/target/laboratory/edit-operation-modal';
 import {
   Accordion,
@@ -42,6 +19,8 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@/components/ui/accordion';
+import { Button } from '@/components/ui/button';
+import { DocsLink } from '@/components/ui/docs-note';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -49,11 +28,36 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Link } from '@/components/ui/link';
 import { Meta } from '@/components/ui/meta';
+import { Subtitle, Title } from '@/components/ui/page';
 import { QueryError } from '@/components/ui/query-error';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { PlusIcon, SaveIcon, ShareIcon } from '@/components/v2/icon';
+import { Spinner } from '@/components/v2/spinner';
+import { ToggleGroup, ToggleGroupItem } from '@/components/v2/toggle-group';
+import { graphql } from '@/gql';
+import { TargetAccessScope } from '@/gql/graphql';
+import { canAccessTarget } from '@/lib/access/target';
+import { useClipboard, useNotifications, useToggle } from '@/lib/hooks';
 import { useResetState } from '@/lib/hooks/use-reset-state';
+import { cn } from '@/lib/utils';
+import {
+  UnStyledButton as GraphiQLButton,
+  GraphiQLPlugin,
+  Tooltip as GraphiQLTooltip,
+  useEditorContext,
+} from '@graphiql/react';
+import { createGraphiQLFetcher, Fetcher, isAsyncIterable } from '@graphiql/toolkit';
+import {
+  BookmarkIcon,
+  DotsHorizontalIcon,
+  EnterFullScreenIcon,
+  ExitFullScreenIcon,
+} from '@radix-ui/react-icons';
 import { Repeater } from '@repeaterjs/repeater';
 import { Link as RouterLink, useRouter } from '@tanstack/react-router';
+import 'graphiql/graphiql.css';
 
 function Share(props: { operation: string | null }): ReactElement {
   const label = 'Share query';

--- a/packages/web/app/src/pages/target-laboratory.tsx
+++ b/packages/web/app/src/pages/target-laboratory.tsx
@@ -943,6 +943,10 @@ function LaboratoryPageContent(props: {
       ? searchObj.operation
       : null;
 
+  const [isFullScreen, setIsFullScreen] = useState(false);
+
+  const FullScreenComponent = isFullScreen ? ExitFullScreenIcon : EnterFullScreenIcon;
+
   return (
     <TargetLayout
       organizationId={props.organizationId}
@@ -1031,7 +1035,6 @@ function LaboratoryPageContent(props: {
         .graphiql-container {
           --color-base: transparent !important;
           --color-primary: 40, 89%, 60% !important;
-          min-height: 600px;
         }
         .graphiql-container .graphiql-tab-add {
           display: none;
@@ -1074,57 +1077,46 @@ function LaboratoryPageContent(props: {
       `}</style>
       </Helmet>
 
-      {query.fetching ? null : (
-        <GraphiQL
-          fetcher={fetcher}
-          toolbar={{
-            additionalContent: (
-              <>
-                <Save
-                  organizationId={props.organizationId}
-                  projectId={props.projectId}
-                  targetId={props.targetId}
-                />
-                <Share operation={operation} />
-              </>
-            ),
-          }}
-          showPersistHeadersSettings={false}
-          shouldPersistHeaders={false}
-          plugins={[operationCollectionsPlugin]}
-          visiblePlugin={operationCollectionsPlugin}
-          schema={schema}
-          forcedTheme="dark"
-        >
-          <GraphiQL.Logo>
-            <EditorBreadcrumbs
-              organizationId={props.organizationId}
-              projectId={props.projectId}
-              targetId={props.targetId}
-            />
-            <div className="ml-auto">
-              <LegacyTooltip
-                content={
-                  actualSelectedApiEndpoint === 'linkedApi' ? (
-                    <>
-                      Operations are executed against{' '}
-                      <span>{query.data?.target?.graphqlEndpointUrl}</span>.
-                    </>
-                  ) : (
-                    <>Operations are executed against the mock endpoint.</>
-                  )
-                }
+      {!query.fetching && (
+        <div className={clsx('grow', isFullScreen && 'fixed inset-0 bg-[#030711]')}>
+          <GraphiQL
+            fetcher={fetcher}
+            toolbar={{
+              additionalContent: (
+                <>
+                  <Save
+                    organizationId={props.organizationId}
+                    projectId={props.projectId}
+                    targetId={props.targetId}
+                  />
+                  <Share operation={operation} />
+                </>
+              ),
+            }}
+            showPersistHeadersSettings={false}
+            shouldPersistHeaders={false}
+            plugins={[operationCollectionsPlugin]}
+            visiblePlugin={operationCollectionsPlugin}
+            schema={schema}
+            forcedTheme="dark"
+          >
+            <GraphiQL.Logo>
+              <EditorBreadcrumbs
+                organizationId={props.organizationId}
+                projectId={props.projectId}
+                targetId={props.targetId}
+              />
+              <Button
+                onClick={() => setIsFullScreen(prev => !prev)}
+                variant="outline"
+                className="h-auto gap-2 p-2"
               >
-                <span className="cursor-help pr-2 text-xs font-normal">
-                  {actualSelectedApiEndpoint === 'linkedApi'
-                    ? 'Querying GraphQL API'
-                    : 'Querying Mock API'}
-                </span>
-              </LegacyTooltip>
-              <HiveLogo className="h-6 w-auto" />
-            </div>
-          </GraphiQL.Logo>
-        </GraphiQL>
+                <FullScreenComponent className="size-4" />
+                {isFullScreen ? 'Exit' : 'Enter'} Full Screen
+              </Button>
+            </GraphiQL.Logo>
+          </GraphiQL>
+        </div>
       )}
       <ConnectLabModal
         endpoint={mockEndpoint}

--- a/packages/web/app/src/pages/target-laboratory.tsx
+++ b/packages/web/app/src/pages/target-laboratory.tsx
@@ -953,6 +953,7 @@ function LaboratoryPageContent(props: {
       projectId={props.projectId}
       targetId={props.targetId}
       page={Page.Laboratory}
+      className="flex h-[--hive-content-height] flex-col"
     >
       <div className="flex py-6">
         <div className="flex-1">
@@ -1109,7 +1110,7 @@ function LaboratoryPageContent(props: {
               <Button
                 onClick={() => setIsFullScreen(prev => !prev)}
                 variant="outline"
-                className="h-auto gap-2 p-2"
+                className="h-auto gap-2"
               >
                 <FullScreenComponent className="size-4" />
                 {isFullScreen ? 'Exit' : 'Enter'} Full Screen

--- a/packages/web/app/src/pages/target-laboratory.tsx
+++ b/packages/web/app/src/pages/target-laboratory.tsx
@@ -863,6 +863,7 @@ function LaboratoryPageContent(props: {
   });
   const router = useRouter();
   const [isConnectLabModalOpen, toggleConnectLabModal] = useToggle();
+  const [isFullScreen, setIsFullScreen] = useState(false);
 
   const currentOrganization = query.data?.organization?.organization;
 
@@ -942,8 +943,6 @@ function LaboratoryPageContent(props: {
     'operation' in searchObj && typeof searchObj.operation === 'string'
       ? searchObj.operation
       : null;
-
-  const [isFullScreen, setIsFullScreen] = useState(false);
 
   const FullScreenComponent = isFullScreen ? ExitFullScreenIcon : EnterFullScreenIcon;
 

--- a/patches/graphiql@3.3.0.patch
+++ b/patches/graphiql@3.3.0.patch
@@ -1,0 +1,25 @@
+# move prettify button to the end, we can't use `<GraphiQL.Toolbar />` because `usePrettifyEditors` needs to access `EditorContextProvider`
+#
+diff --git a/esm/components/GraphiQL.js b/esm/components/GraphiQL.js
+index adf5b7dfc4d292391c5f3c20d7082984529062d9..e8d32614459dd0e9ee484ce278b8ce4f3a9e7d35 100644
+--- a/esm/components/GraphiQL.js
++++ b/esm/components/GraphiQL.js
+@@ -139,14 +139,10 @@ export function GraphiQLInterface(props) {
+     var toolbar = children.find(function (child) {
+         return isChildComponentType(child, GraphiQL.Toolbar);
+     }) || (React.createElement(React.Fragment, null,
+-        React.createElement(ToolbarButton, { onClick: prettify, label: "Prettify query (Shift-Ctrl-P)" },
+-            React.createElement(PrettifyIcon, { className: "graphiql-toolbar-icon", "aria-hidden": "true" })),
+-        React.createElement(ToolbarButton, { onClick: merge, label: "Merge fragments into query (Shift-Ctrl-M)" },
+-            React.createElement(MergeIcon, { className: "graphiql-toolbar-icon", "aria-hidden": "true" })),
+-        React.createElement(ToolbarButton, { onClick: copy, label: "Copy query (Shift-Ctrl-C)" },
+-            React.createElement(CopyIcon, { className: "graphiql-toolbar-icon", "aria-hidden": "true" })), (_c = props.toolbar) === null || _c === void 0 ? void 0 :
+-        _c.additionalContent,
+-        ((_d = props.toolbar) === null || _d === void 0 ? void 0 : _d.additionalComponent) && (React.createElement(props.toolbar.additionalComponent, null))));
++        (_c = props.toolbar) === null || _c === void 0 ? void 0 : _c.additionalContent,
++        ((_d = props.toolbar) === null || _d === void 0 ? void 0 : _d.additionalComponent) && (React.createElement(props.toolbar.additionalComponent, null)),
++        React.createElement(ToolbarButton, { onClick: prettify, label: "Prettify query (Shift-Ctrl-P)" }, React.createElement(PrettifyIcon, { className: "graphiql-toolbar-icon", "aria-hidden": "true" }))
++    ));
+     var footer = children.find(function (child) {
+         return isChildComponentType(child, GraphiQL.Footer);
+     });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ patchedDependencies:
     hash: b6pwqmrs3qqykctltsasvrfwti
     path: patches/got@14.4.1.patch
   graphiql@3.3.0:
-    hash: jdjooxzccays7ahdvnzoneb4ie
+    hash: p4mc7pxwsatzeupmv5hnqi5t6q
     path: patches/graphiql@3.3.0.patch
   mjml-core@4.14.0:
     hash: zxxsxbqejjmcwuzpigutzzq6wa
@@ -1825,7 +1825,7 @@ importers:
         version: 11.2.10(@emotion/is-prop-valid@0.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       graphiql:
         specifier: 3.3.0
-        version: 3.3.0(patch_hash=jdjooxzccays7ahdvnzoneb4ie)(@codemirror/language@6.0.0)(@types/node@20.14.2)(@types/react-dom@18.3.0)(@types/react@18.3.3)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.3.0(patch_hash=p4mc7pxwsatzeupmv5hnqi5t6q)(@codemirror/language@6.0.0)(@types/node@20.14.2)(@types/react-dom@18.3.0)(@types/react@18.3.3)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       graphql:
         specifier: 16.8.1
         version: 16.8.1
@@ -28976,7 +28976,7 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphiql@3.3.0(patch_hash=jdjooxzccays7ahdvnzoneb4ie)(@codemirror/language@6.0.0)(@types/node@20.14.2)(@types/react-dom@18.3.0)(@types/react@18.3.3)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  graphiql@3.3.0(patch_hash=p4mc7pxwsatzeupmv5hnqi5t6q)(@codemirror/language@6.0.0)(@types/node@20.14.2)(@types/react-dom@18.3.0)(@types/react@18.3.3)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@graphiql/react': 0.22.3(@codemirror/language@6.0.0)(@types/node@20.14.2)(@types/react-dom@18.3.0)(@types/react@18.3.3)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@graphiql/toolkit': 0.9.1(@types/node@20.14.2)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ patchedDependencies:
   got@14.4.1:
     hash: b6pwqmrs3qqykctltsasvrfwti
     path: patches/got@14.4.1.patch
+  graphiql@3.3.0:
+    hash: jdjooxzccays7ahdvnzoneb4ie
+    path: patches/graphiql@3.3.0.patch
   mjml-core@4.14.0:
     hash: zxxsxbqejjmcwuzpigutzzq6wa
     path: patches/mjml-core@4.14.0.patch
@@ -1822,7 +1825,7 @@ importers:
         version: 11.2.10(@emotion/is-prop-valid@0.8.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       graphiql:
         specifier: 3.3.0
-        version: 3.3.0(@codemirror/language@6.0.0)(@types/node@20.14.2)(@types/react-dom@18.3.0)(@types/react@18.3.3)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 3.3.0(patch_hash=jdjooxzccays7ahdvnzoneb4ie)(@codemirror/language@6.0.0)(@types/node@20.14.2)(@types/react-dom@18.3.0)(@types/react@18.3.3)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       graphql:
         specifier: 16.8.1
         version: 16.8.1
@@ -28973,7 +28976,7 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphiql@3.3.0(@codemirror/language@6.0.0)(@types/node@20.14.2)(@types/react-dom@18.3.0)(@types/react@18.3.3)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  graphiql@3.3.0(patch_hash=jdjooxzccays7ahdvnzoneb4ie)(@codemirror/language@6.0.0)(@types/node@20.14.2)(@types/react-dom@18.3.0)(@types/react@18.3.3)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@graphiql/react': 0.22.3(@codemirror/language@6.0.0)(@types/node@20.14.2)(@types/react-dom@18.3.0)(@types/react@18.3.3)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@graphiql/toolkit': 0.9.1(@types/node@20.14.2)(graphql-ws@5.16.0(graphql@16.8.1))(graphql@16.8.1)


### PR DESCRIPTION
- [x] remove `Merge fragments into query`, `Copy query` toolbar buttons, move `Prettify query` to end
<img width="568" alt="image" src="https://github.com/kamilkisiela/graphql-hive/assets/7361780/2787282d-7b4e-4128-8ea5-268e84495d3c">

- [x] increase text

<img width="287" alt="image" src="https://github.com/kamilkisiela/graphql-hive/assets/7361780/428edeb0-def3-45d3-af0a-0105ead00138">


- [x] show 3 dots on hover

https://github.com/kamilkisiela/graphql-hive/assets/7361780/a42a25f8-014d-46d3-9bc6-2a1a3b9bb885



