### PR TITLE
Shared HTTP client with retries

### DIFF
--- a/.changeset/good-hairs-deliver.md
+++ b/.changeset/good-hairs-deliver.md
@@ -1,0 +1,6 @@
+---
+'@graphql-hive/apollo': patch
+'@graphql-hive/yoga': patch
+---
+
+Use built-in retry of http client of the core package

--- a/.changeset/selfish-shoes-pump.md
+++ b/.changeset/selfish-shoes-pump.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': patch
+---
+
+Retry up to 3 times a GET request in the artifact:fetch command

--- a/.changeset/tidy-worms-add.md
+++ b/.changeset/tidy-worms-add.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/core': minor
+---
+
+Add retry mechanism to the http client

--- a/packages/libraries/cli/package.json
+++ b/packages/libraries/cli/package.json
@@ -57,7 +57,6 @@
     "@oclif/core": "^3.26.6",
     "@oclif/plugin-help": "6.0.22",
     "@oclif/plugin-update": "4.2.13",
-    "@whatwg-node/fetch": "0.9.18",
     "colors": "1.4.0",
     "env-ci": "7.3.0",
     "graphql": "^16.8.1",

--- a/packages/libraries/cli/src/base-command.ts
+++ b/packages/libraries/cli/src/base-command.ts
@@ -1,9 +1,9 @@
 import colors from 'colors';
 import { print, type GraphQLError } from 'graphql';
 import type { ExecutionResult } from 'graphql';
+import { http } from '@graphql-hive/core';
 import type { TypedDocumentNode } from '@graphql-typed-document-node/core';
 import { Command, Errors, Config as OclifConfig } from '@oclif/core';
-import { fetch } from '@whatwg-node/fetch';
 import { Config, GetConfigurationValueType, ValidConfigurationKeys } from './helpers/config';
 
 type OmitNever<T> = { [K in keyof T as T[K] extends never ? never : K]: T[K] };
@@ -166,14 +166,16 @@ export default abstract class extends Command {
         operation: TypedDocumentNode<TResult, TVariables>,
         ...[variables]: TVariables extends Record<string, never> ? [] : [TVariables]
       ): Promise<TResult> {
-        const response = await fetch(endpoint, {
-          headers: requestHeaders,
-          method: 'POST',
-          body: JSON.stringify({
+        const response = await http.post(
+          endpoint,
+          JSON.stringify({
             query: typeof operation === 'string' ? operation : print(operation),
             variables,
           }),
-        });
+          {
+            headers: requestHeaders,
+          },
+        );
 
         if (!response.ok) {
           throw new Error(`Invalid status code for HTTP call: ${response.status}`);

--- a/packages/libraries/cli/src/commands/artifact/fetch.ts
+++ b/packages/libraries/cli/src/commands/artifact/fetch.ts
@@ -1,5 +1,5 @@
+import { http, URL } from '@graphql-hive/core';
 import { Flags } from '@oclif/core';
-import { fetch, URL } from '@whatwg-node/fetch';
 import Command from '../../base-command';
 
 export default class ArtifactsFetch extends Command {
@@ -40,10 +40,16 @@ export default class ArtifactsFetch extends Command {
 
     const url = new URL(`${cdnEndpoint}/${artifactType}`);
 
-    const response = await fetch(url.toString(), {
+    const response = await http.get(url.toString(), {
       headers: {
         'x-hive-cdn-key': token,
         'User-Agent': `hive-cli/${this.config.version}`,
+      },
+      retry: {
+        retries: 3,
+        retryWhen(response) {
+          return response.status >= 500;
+        },
       },
     });
 

--- a/packages/libraries/core/package.json
+++ b/packages/libraries/core/package.json
@@ -54,6 +54,7 @@
   "devDependencies": {
     "@apollo/federation": "0.38.1",
     "@apollo/subgraph": "2.8.1",
+    "@types/async-retry": "1.4.8",
     "@types/lodash.sortby": "4.7.9",
     "graphql": "16.9.0",
     "nock": "14.0.0-beta.7",

--- a/packages/libraries/core/src/client/http-client.ts
+++ b/packages/libraries/core/src/client/http-client.ts
@@ -1,4 +1,10 @@
-import { fetch } from '@whatwg-node/fetch';
+import asyncRetry from 'async-retry';
+import { fetch, URL } from '@whatwg-node/fetch';
+
+type RetryOptions = Parameters<typeof asyncRetry>[1] & {
+  retryWhen(response: Response): boolean;
+  okWhen?(response: Response): boolean;
+};
 
 function get(
   endpoint: string,
@@ -6,12 +12,14 @@ function get(
     headers: Record<string, string>;
     timeout?: number;
     fetchImplementation?: typeof fetch;
+    retry?: RetryOptions;
   },
 ) {
   return makeFetchCall(endpoint, {
     method: 'GET',
     headers: config.headers,
     timeout: config.timeout,
+    retry: config.retry,
     fetchImplementation: config.fetchImplementation,
   });
 }
@@ -22,6 +30,7 @@ function post(
   config: {
     headers: Record<string, string>;
     timeout?: number;
+    retry?: RetryOptions;
     fetchImplementation?: typeof fetch;
   },
 ) {
@@ -30,6 +39,7 @@ function post(
     method: 'POST',
     headers: config.headers,
     timeout: config.timeout,
+    retry: config.retry,
     fetchImplementation: config.fetchImplementation,
   });
 }
@@ -46,24 +56,68 @@ async function makeFetchCall(
     method: 'GET' | 'POST';
     headers: Record<string, string>;
     timeout?: number;
+    retry?: RetryOptions;
     fetchImplementation?: typeof fetch;
   },
 ) {
   const controller = new AbortController();
   let timeoutId: ReturnType<typeof setTimeout> | undefined = undefined;
-  const responsePromise = (config.fetchImplementation ?? fetch)(endpoint, {
-    method: config.method,
-    body: config.body,
-    headers: config.headers,
-    signal: controller.signal,
-  });
 
   if (config.timeout) {
     timeoutId = setTimeout(() => controller.abort(), config.timeout);
   }
 
   try {
-    return await responsePromise;
+    const retryOptions = config.retry;
+    if (!retryOptions) {
+      return await (config.fetchImplementation ?? fetch)(endpoint, {
+        method: config.method,
+        body: config.body,
+        headers: config.headers,
+        signal: controller.signal,
+      });
+    }
+
+    const result = await asyncRetry(
+      async bail => {
+        const res = await (config.fetchImplementation ?? fetch)(endpoint, {
+          method: config.method,
+          body: config.body,
+          headers: config.headers,
+          signal: controller.signal,
+        });
+
+        if (res.ok || retryOptions.okWhen?.(res)) {
+          return res;
+        }
+
+        if (!retryOptions.retryWhen(res)) {
+          bail(
+            new Error(
+              `Failed to fetch ${endpoint}, received: ${res.status} ${res.statusText ?? 'Internal Server Error'}`,
+            ),
+          );
+          return;
+        }
+
+        throw new Error(
+          `Failed to fetch ${endpoint}, received: ${res.status} ${res.statusText ?? 'Internal Server Error'}`,
+        );
+      },
+      {
+        ...retryOptions,
+        retries: retryOptions?.retries ?? 5,
+        minTimeout: retryOptions?.minTimeout ?? 200,
+        maxTimeout: retryOptions?.maxTimeout ?? 2000,
+        factor: retryOptions?.factor ?? 1.2,
+      },
+    );
+
+    if (result === undefined) {
+      throw new Error('Failed to bail out of retry.');
+    }
+
+    return result;
   } catch (error) {
     if (isAggregateError(error)) {
       throw new Error(error.errors.map(e => e.message).join(', '), {
@@ -85,3 +139,5 @@ interface AggregateError extends Error {
 function isAggregateError(error: unknown): error is AggregateError {
   return !!error && typeof error === 'object' && 'errors' in error && Array.isArray(error.errors);
 }
+
+export { URL };

--- a/packages/libraries/core/src/index.ts
+++ b/packages/libraries/core/src/index.ts
@@ -4,4 +4,4 @@ export { createSchemaFetcher, createServicesFetcher } from './client/gateways.js
 export { createHive, autoDisposeSymbol } from './client/client.js';
 export { atLeastOnceSampler } from './client/samplers.js';
 export { isHiveClient, isAsyncIterable, createHash, joinUrl } from './client/utils.js';
-export { http } from './client/http-client.js';
+export { http, URL } from './client/http-client.js';

--- a/packages/libraries/core/src/version.ts
+++ b/packages/libraries/core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.3.0';
+export const version = '0.3.1';

--- a/packages/libraries/core/tests/gateways.spec.ts
+++ b/packages/libraries/core/tests/gateways.spec.ts
@@ -289,6 +289,8 @@ test('fail in case of unexpected CDN status code (nRetryCount=11)', async () => 
   try {
     await fetcher();
   } catch (e) {
-    expect(e).toMatchInlineSnapshot(`[Error: Failed to fetch [500]]`);
+    expect(e).toMatchInlineSnapshot(
+      `[Error: Failed to fetch http://localhost/services, received: 500 Internal Server Error]`,
+    );
   }
 });

--- a/packages/libraries/yoga/package.json
+++ b/packages/libraries/yoga/package.json
@@ -56,7 +56,6 @@
     "@graphql-yoga/plugin-disable-introspection": "2.4.0",
     "@graphql-yoga/plugin-graphql-sse": "3.4.0",
     "@graphql-yoga/plugin-response-cache": "3.6.0",
-    "@whatwg-node/fetch": "0.9.18",
     "graphql-ws": "5.16.0",
     "graphql-yoga": "5.4.0",
     "nock": "14.0.0-beta.7",

--- a/packages/libraries/yoga/package.json
+++ b/packages/libraries/yoga/package.json
@@ -56,6 +56,7 @@
     "@graphql-yoga/plugin-disable-introspection": "2.4.0",
     "@graphql-yoga/plugin-graphql-sse": "3.4.0",
     "@graphql-yoga/plugin-response-cache": "3.6.0",
+    "@whatwg-node/fetch": "0.9.18",
     "graphql-ws": "5.16.0",
     "graphql-yoga": "5.4.0",
     "nock": "14.0.0-beta.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -551,6 +551,9 @@ importers:
       '@graphql-yoga/plugin-response-cache':
         specifier: 3.6.0
         version: 3.6.0(@envelop/core@5.0.1)(graphql-yoga@5.4.0(graphql@16.9.0))(graphql@16.9.0)
+      '@whatwg-node/fetch':
+        specifier: 0.9.18
+        version: 0.9.18
       graphql-ws:
         specifier: 5.16.0
         version: 5.16.0(graphql@16.9.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,9 +412,6 @@ importers:
       '@oclif/plugin-update':
         specifier: 4.2.13
         version: 4.2.13
-      '@whatwg-node/fetch':
-        specifier: 0.9.18
-        version: 0.9.18
       colors:
         specifier: 1.4.0
         version: 1.4.0
@@ -477,6 +474,9 @@ importers:
       '@apollo/subgraph':
         specifier: 2.8.1
         version: 2.8.1(graphql@16.9.0)
+      '@types/async-retry':
+        specifier: 1.4.8
+        version: 1.4.8
       '@types/lodash.sortby':
         specifier: 4.7.9
         version: 4.7.9
@@ -551,9 +551,6 @@ importers:
       '@graphql-yoga/plugin-response-cache':
         specifier: 3.6.0
         version: 3.6.0(@envelop/core@5.0.1)(graphql-yoga@5.4.0(graphql@16.9.0))(graphql@16.9.0)
-      '@whatwg-node/fetch':
-        specifier: 0.9.18
-        version: 0.9.18
       graphql-ws:
         specifier: 5.16.0
         version: 5.16.0(graphql@16.9.0)
@@ -4148,6 +4145,7 @@ packages:
 
   '@fastify/vite@6.0.6':
     resolution: {integrity: sha512-FsWJC92murm5tjeTezTTvMLyZido/ZWy0wYWpVkh/bDe1gAUAabYLB7Vp8hokXGsRE/mOpqYVsRDAKENY2qPUQ==}
+    bundledDependencies: []
 
   '@floating-ui/core@1.2.6':
     resolution: {integrity: sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==}
@@ -17507,10 +17505,10 @@ snapshots:
       '@aws-crypto/sha1-browser': 5.2.0
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
-      '@aws-sdk/client-sts': 3.600.0
+      '@aws-sdk/client-sso-oidc': 3.600.0
+      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
       '@aws-sdk/core': 3.598.0
-      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0))
       '@aws-sdk/middleware-bucket-endpoint': 3.598.0
       '@aws-sdk/middleware-expect-continue': 3.598.0
       '@aws-sdk/middleware-flexible-checksums': 3.598.0
@@ -17610,13 +17608,13 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@aws-sdk/client-sso-oidc@3.600.0(@aws-sdk/client-sts@3.600.0)':
+  '@aws-sdk/client-sso-oidc@3.600.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sts': 3.600.0
+      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
       '@aws-sdk/core': 3.598.0
-      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0))
       '@aws-sdk/middleware-host-header': 3.598.0
       '@aws-sdk/middleware-logger': 3.598.0
       '@aws-sdk/middleware-recursion-detection': 3.598.0
@@ -17653,7 +17651,6 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.6.3
     transitivePeerDependencies:
-      - '@aws-sdk/client-sts'
       - aws-crt
 
   '@aws-sdk/client-sso@3.592.0':
@@ -17788,13 +17785,13 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/client-sts@3.600.0':
+  '@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
       '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/client-sso-oidc': 3.600.0
       '@aws-sdk/core': 3.598.0
-      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-node': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0))
       '@aws-sdk/middleware-host-header': 3.598.0
       '@aws-sdk/middleware-logger': 3.598.0
       '@aws-sdk/middleware-recursion-detection': 3.598.0
@@ -17831,6 +17828,7 @@ snapshots:
       '@smithy/util-utf8': 3.0.0
       tslib: 2.6.3
     transitivePeerDependencies:
+      - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
   '@aws-sdk/core@3.592.0':
@@ -17909,9 +17907,9 @@ snapshots:
       - '@aws-sdk/client-sso-oidc'
       - aws-crt
 
-  '@aws-sdk/credential-provider-ini@3.598.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)':
+  '@aws-sdk/credential-provider-ini@3.598.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0))':
     dependencies:
-      '@aws-sdk/client-sts': 3.600.0
+      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
       '@aws-sdk/credential-provider-env': 3.598.0
       '@aws-sdk/credential-provider-http': 3.598.0
       '@aws-sdk/credential-provider-process': 3.598.0
@@ -17946,11 +17944,11 @@ snapshots:
       - '@aws-sdk/client-sts'
       - aws-crt
 
-  '@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)':
+  '@aws-sdk/credential-provider-node@3.600.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0))':
     dependencies:
       '@aws-sdk/credential-provider-env': 3.598.0
       '@aws-sdk/credential-provider-http': 3.598.0
-      '@aws-sdk/credential-provider-ini': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/credential-provider-ini': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0)(@aws-sdk/client-sts@3.600.0(@aws-sdk/client-sso-oidc@3.600.0))
       '@aws-sdk/credential-provider-process': 3.598.0
       '@aws-sdk/credential-provider-sso': 3.598.0(@aws-sdk/client-sso-oidc@3.600.0)
       '@aws-sdk/credential-provider-web-identity': 3.598.0(@aws-sdk/client-sts@3.600.0)
@@ -18017,7 +18015,7 @@ snapshots:
 
   '@aws-sdk/credential-provider-web-identity@3.598.0(@aws-sdk/client-sts@3.600.0)':
     dependencies:
-      '@aws-sdk/client-sts': 3.600.0
+      '@aws-sdk/client-sts': 3.600.0(@aws-sdk/client-sso-oidc@3.600.0)
       '@aws-sdk/types': 3.598.0
       '@smithy/property-provider': 3.1.2
       '@smithy/types': 3.2.0
@@ -18190,7 +18188,7 @@ snapshots:
 
   '@aws-sdk/token-providers@3.598.0(@aws-sdk/client-sso-oidc@3.600.0)':
     dependencies:
-      '@aws-sdk/client-sso-oidc': 3.600.0(@aws-sdk/client-sts@3.600.0)
+      '@aws-sdk/client-sso-oidc': 3.600.0
       '@aws-sdk/types': 3.598.0
       '@smithy/property-provider': 3.1.2
       '@smithy/shared-ini-file-loader': 3.1.2


### PR DESCRIPTION
- Adds retry logic to http client of `@graphql-hive/core`.
- Reuse the retry logic of core's http client in `@graphql-hive/apollo` and `@graphql-hive/yoga`
- Adds a retry to a GET request done by the `artifact:fetch` CLI command