### PR TITLE
integration-tests: dynamic port handling for web app URL verification

### DIFF
--- a/scripts/serializers/cli-output.ts
+++ b/scripts/serializers/cli-output.ts
@@ -8,8 +8,8 @@ export function normalizeCliOutput(value: string) {
         // eslint-disable-next-line no-control-regex
         .replace(/\x1B[[(?);]{0,2}(;?\d)*./g, '')
         .replace(
-          /http:\/\/localhost:8080\/[$]*\w+\/[$]*\w+\/[$]*\w+/i,
-          'http://localhost:8080/$organization/$project/$target',
+          /(http:\/\/localhost:\d+)\/([^\/]+)\/([^\/]+)\/([^\/]+)/,
+          '$1/$organization/$project/$target',
         )
         .replace(/history\/[$]*\w+-\w+-\w+-\w+-\w+/i, 'history/$version')
         .trim(),


### PR DESCRIPTION
Our integration tests verify that the web app's URLs in the CLI output are correct. Previously, we used a hardcoded port number, but this PR makes it dynamic, allowing any port number to be accepted.