### PR TITLE
configures the Access-Control-Allow-Credentials CORS header

### DIFF
--- a/packages/web/app/src/server/index.ts
+++ b/packages/web/app/src/server/index.ts
@@ -59,7 +59,9 @@ async function main() {
     });
   }
 
-  await server.register(cors, {});
+  await server.register(cors, {
+    credentials: true
+  });
 
   server.get('/api/health', (_req, res) => {
     return res.status(200).send('OK');


### PR DESCRIPTION
### Background

Configures the Access-Control-Allow-Credentials CORS header

### Description
allows credentials to be used in requests

We ran into an issue after updating Hive, our cors preflight request got redirected to our SSO page due to missing cookies. This should fix that and allow us to update