### PR TITLE
feat: app deployments CLI

### DIFF
--- a/.changeset/chilly-donkeys-pay.md
+++ b/.changeset/chilly-donkeys-pay.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': minor
+---
+
+add support for app deployments

--- a/packages/libraries/cli/README.md
+++ b/packages/libraries/cli/README.md
@@ -34,6 +34,8 @@ curl -sSL https://graphql-hive.com/install.sh | sh
 
 <!-- commands -->
 
+- [`hive app:create FILE`](#hive-appcreate-file)
+- [`hive app:publish`](#hive-apppublish)
 - [`hive artifact:fetch`](#hive-artifactfetch)
 - [`hive config:delete KEY`](#hive-configdelete-key)
 - [`hive config:get KEY`](#hive-configget-key)
@@ -49,6 +51,53 @@ curl -sSL https://graphql-hive.com/install.sh | sh
 - [`hive schema:publish FILE`](#hive-schemapublish-file)
 - [`hive update [CHANNEL]`](#hive-update-channel)
 - [`hive whoami`](#hive-whoami)
+
+## `hive app:create FILE`
+
+create an app deployment
+
+```
+USAGE
+  $ hive app:create FILE --name <value> --version <value> [--registry.endpoint <value>] [--registry.accessToken
+    <value>]
+
+ARGUMENTS
+  FILE  Path to the persisted operations mapping.
+
+FLAGS
+  --name=<value>                  (required) app name
+  --registry.accessToken=<value>  registry access token
+  --registry.endpoint=<value>     registry endpoint
+  --version=<value>               (required) app version
+
+DESCRIPTION
+  create an app deployment
+```
+
+_See code:
+[dist/commands/app/create.js](https://github.com/kamilkisiela/graphql-hive/blob/v0.37.0/dist/commands/app/create.js)_
+
+## `hive app:publish`
+
+publish an app deployment
+
+```
+USAGE
+  $ hive app:publish --name <value> --version <value> [--registry.endpoint <value>] [--registry.accessToken
+    <value>]
+
+FLAGS
+  --name=<value>                  (required) app name
+  --registry.accessToken=<value>  registry access token
+  --registry.endpoint=<value>     registry endpoint
+  --version=<value>               (required) app version
+
+DESCRIPTION
+  publish an app deployment
+```
+
+_See code:
+[dist/commands/app/publish.js](https://github.com/kamilkisiela/graphql-hive/blob/v0.37.0/dist/commands/app/publish.js)_
 
 ## `hive artifact:fetch`
 

--- a/packages/libraries/cli/src/commands/app/create.ts
+++ b/packages/libraries/cli/src/commands/app/create.ts
@@ -1,0 +1,163 @@
+import { z } from 'zod';
+import { Args, Flags } from '@oclif/core';
+import Command from '../../base-command';
+import { graphql } from '../../gql';
+import { AppDeploymentStatus } from '../../gql/graphql';
+import { graphqlEndpoint } from '../../helpers/config';
+
+export default class AppCreate extends Command {
+  static description = 'create an app deployment';
+  static flags = {
+    'registry.endpoint': Flags.string({
+      description: 'registry endpoint',
+    }),
+    'registry.accessToken': Flags.string({
+      description: 'registry access token',
+    }),
+    name: Flags.string({
+      description: 'app name',
+      required: true,
+    }),
+    version: Flags.string({
+      description: 'app version',
+      required: true,
+    }),
+  };
+
+  static args = {
+    file: Args.string({
+      name: 'file',
+      required: true,
+      description: 'Path to the persisted operations mapping.',
+      hidden: false,
+    }),
+  };
+
+  async run() {
+    const { flags, args } = await this.parse(AppCreate);
+
+    const endpoint = this.ensure({
+      key: 'registry.endpoint',
+      args: flags,
+      defaultValue: graphqlEndpoint,
+      env: 'HIVE_REGISTRY',
+    });
+    const accessToken = this.ensure({
+      key: 'registry.accessToken',
+      args: flags,
+      env: 'HIVE_TOKEN',
+    });
+
+    const file: string = args.file;
+    const fs = await import('fs/promises');
+    const contents = await fs.readFile(file, 'utf-8');
+    const operations: unknown = JSON.parse(contents);
+    const validationResult = ManifestModel.safeParse(operations);
+
+    if (validationResult.success === false) {
+      // TODO: better error message :)
+      throw new Error('Invalid manifest');
+    }
+
+    const result = await this.registryApi(endpoint, accessToken).request(
+      CreateAppDeploymentMutation,
+      {
+        input: {
+          appName: flags['name'],
+          appVersion: flags['version'],
+        },
+      },
+    );
+
+    if (result.createAppDeployment.error) {
+      // TODO: better error message formatting :)
+      throw new Error(result.createAppDeployment.error.message);
+    }
+
+    if (!result.createAppDeployment.ok) {
+      throw new Error('Unknown error');
+    }
+
+    if (result.createAppDeployment.ok.createdAppDeployment.status !== AppDeploymentStatus.Pending) {
+      this.log(
+        `App deployment "${flags['name']}@${flags['version']}" is "${result.createAppDeployment.ok.createdAppDeployment.status}". Skip publishing documents.`,
+      );
+      return;
+    }
+
+    let buffer: Array<{ hash: string; body: string }> = [];
+
+    const flush = async (force = false) => {
+      if (buffer.length >= 100 || force) {
+        const result = await this.registryApi(endpoint, accessToken).request(
+          AddDocumentsToAppDeploymentMutation,
+          {
+            input: {
+              appName: flags['name'],
+              appVersion: flags['version'],
+              documents: buffer,
+            },
+          },
+        );
+
+        if (result.addDocumentsToAppDeployment.error) {
+          // TODO: better error message formatting :)
+          throw new Error(result.addDocumentsToAppDeployment.error.message);
+        }
+        buffer = [];
+      }
+    };
+
+    let counter = 0;
+
+    for (const [hash, body] of Object.entries(validationResult.data)) {
+      buffer.push({ hash, body });
+      await flush();
+      counter++;
+    }
+
+    await flush(true);
+
+    this.log(
+      `\nApp deployment "${flags['name']}@${flags['version']}" (${counter} operations) created.\nActive it with the "hive app:publish" command.`,
+    );
+  }
+}
+
+const ManifestModel = z.record(z.string());
+
+const CreateAppDeploymentMutation = graphql(/* GraphQL */ `
+  mutation CreateAppDeployment($input: CreateAppDeploymentInput!) {
+    createAppDeployment(input: $input) {
+      ok {
+        createdAppDeployment {
+          id
+          name
+          version
+          status
+        }
+      }
+      error {
+        message
+      }
+    }
+  }
+`);
+
+const AddDocumentsToAppDeploymentMutation = graphql(/* GraphQL */ `
+  mutation AddDocumentsToAppDeployment($input: AddDocumentsToAppDeploymentInput!) {
+    addDocumentsToAppDeployment(input: $input) {
+      ok {
+        appDeployment {
+          id
+          name
+          version
+          status
+        }
+      }
+      error {
+        message
+      }
+    }
+  }
+`);

--- a/packages/libraries/cli/src/commands/app/create.ts
+++ b/packages/libraries/cli/src/commands/app/create.ts
@@ -80,7 +80,7 @@ export default class AppCreate extends Command {
 
     if (result.createAppDeployment.ok.createdAppDeployment.status !== AppDeploymentStatus.Pending) {
       this.log(
-        `App deployment "${flags['name']}@${flags['version']}" is "${result.createAppDeployment.ok.createdAppDeployment.status}". Skip publishing documents.`,
+        `App deployment "${flags['name']}@${flags['version']}" is "${result.createAppDeployment.ok.createdAppDeployment.status}". Skip uploading documents...`,
       );
       return;
     }

--- a/packages/libraries/cli/src/commands/app/publish.ts
+++ b/packages/libraries/cli/src/commands/app/publish.ts
@@ -1,0 +1,76 @@
+import { Flags } from '@oclif/core';
+import Command from '../../base-command';
+import { graphql } from '../../gql';
+import { graphqlEndpoint } from '../../helpers/config';
+
+export default class AppPublish extends Command {
+  static description = 'publish an app deployment';
+  static flags = {
+    'registry.endpoint': Flags.string({
+      description: 'registry endpoint',
+    }),
+    'registry.accessToken': Flags.string({
+      description: 'registry access token',
+    }),
+    name: Flags.string({
+      description: 'app name',
+      required: true,
+    }),
+    version: Flags.string({
+      description: 'app version',
+      required: true,
+    }),
+  };
+
+  async run() {
+    const { flags } = await this.parse(AppPublish);
+
+    const endpoint = this.ensure({
+      key: 'registry.endpoint',
+      args: flags,
+      defaultValue: graphqlEndpoint,
+      env: 'HIVE_REGISTRY',
+    });
+    const accessToken = this.ensure({
+      key: 'registry.accessToken',
+      args: flags,
+      env: 'HIVE_TOKEN',
+    });
+
+    const result = await this.registryApi(endpoint, accessToken).request(
+      ActivateAppDeploymentMutation,
+      {
+        input: {
+          appName: flags['name'],
+          appVersion: flags['version'],
+        },
+      },
+    );
+
+    if (result.activateAppDeployment.error) {
+      throw new Error(result.activateAppDeployment.error.message);
+    }
+
+    if (result.activateAppDeployment.ok) {
+      console.log('App deployment published successfully.');
+    }
+  }
+}
+
+const ActivateAppDeploymentMutation = graphql(/* GraphQL */ `
+  mutation ActivateAppDeployment($input: ActivateAppDeploymentInput!) {
+    activateAppDeployment(input: $input) {
+      ok {
+        activatedAppDeployment {
+          id
+          name
+          version
+          status
+        }
+      }
+      error {
+        message
+      }
+    }
+  }
+`);

--- a/packages/libraries/cli/src/commands/app/publish.ts
+++ b/packages/libraries/cli/src/commands/app/publish.ts
@@ -56,6 +56,7 @@ export default class AppPublish extends Command {
 
       if (result.activateAppDeployment.ok.isSkipped) {
         this.warn(`App deployment "${name}" is already published. Skipping...`);
+        return;
       }
       this.log(`App deployment "${name}" published successfully.`);
     }

--- a/packages/libraries/cli/src/commands/app/publish.ts
+++ b/packages/libraries/cli/src/commands/app/publish.ts
@@ -52,7 +52,12 @@ export default class AppPublish extends Command {
     }
 
     if (result.activateAppDeployment.ok) {
-      console.log('App deployment published successfully.');
+      const name = `${result.activateAppDeployment.ok.activatedAppDeployment.name}@${result.activateAppDeployment.ok.activatedAppDeployment.version}`;
+
+      if (result.activateAppDeployment.ok.isSkipped) {
+        this.warn(`App deployment "${name}" is already published. Skipping...`);
+      }
+      this.log(`App deployment "${name}" published successfully.`);
     }
   }
 }
@@ -67,6 +72,7 @@ const ActivateAppDeploymentMutation = graphql(/* GraphQL */ `
           version
           status
         }
+        isSkipped
       }
       error {
         message


### PR DESCRIPTION
CLI implementation for app deployments. Split out to avoid cluttering `main` with these changes once we merge the PR that introduces the API changes.

See https://github.com/kamilkisiela/graphql-hive/pull/4746