### PR TITLE
Revert "[hive/app] fixes error `<button>` cannot appear as a descendant of `<button>` for `TabsTrigger` inside `TooltipTrigger"

### DIFF
--- a/packages/web/app/src/components/ui/tabs.tsx
+++ b/packages/web/app/src/components/ui/tabs.tsx
@@ -28,8 +28,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'ring-offset-background focus-visible:ring-ring data-[state=active]:bg-background data-[state=active]:text-foreground inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:opacity-50 data-[state=active]:shadow-sm',
-      'disabled:cursor-not-allowed active:disabled:pointer-events-none', // `:active` allows `:hover` state for using with `TooltipTrigger` with `asChild` prop
+      'ring-offset-background focus-visible:ring-ring data-[state=active]:bg-background data-[state=active]:text-foreground inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm',
       className,
     )}
     {...props}

--- a/packages/web/app/src/pages/target-history-version.tsx
+++ b/packages/web/app/src/pages/target-history-version.tsx
@@ -283,10 +283,7 @@ function DefaultSchemaVersionView(props: {
           <TabsList className="bg-background border-muted w-full justify-start rounded-none border-x border-b">
             {availableViews.map(item => (
               <Tooltip key={item.value}>
-                <TooltipTrigger
-                  // fixes <button> cannot appear as a descendant of <button>
-                  asChild
-                >
+                <TooltipTrigger>
                   <TabsTrigger value={item.value} disabled={!!item.disabledReason}>
                     {item.icon}
                     <span className="ml-2">{item.label}</span>


### PR DESCRIPTION
Reverts kamilkisiela/graphql-hive#4999