### PR TITLE
Allow to limit organization access to OIDC accounts only

### DIFF
--- a/cypress/e2e/app.cy.ts
+++ b/cypress/e2e/app.cy.ts
@@ -99,6 +99,31 @@ describe('oidc', () => {
     });
   });
 
+  it('first time oidc login of non-admin user', () => {
+    const organizationAdminUser = getUser();
+    cy.visit('/');
+    cy.signup(organizationAdminUser);
+
+    cy.createOIDCIntegration('Bubatzbieber').then(({ organizationSlug }) => {
+      cy.visit('/logout');
+
+      cy.clearAllCookies();
+      cy.clearAllLocalStorage();
+      cy.clearAllSessionStorage();
+      cy.get('a[href^="/auth/sso"]').click();
+
+      // Select organization
+      cy.get('input[name="slug"]').type(organizationSlug);
+      cy.get('button[type="submit"]').click();
+
+      cy.get('input[id="Input_Username"]').type('test-user-2');
+      cy.get('input[id="Input_Password"]').type('password');
+      cy.get('button[value="login"]').click();
+
+      cy.get('[data-cy="organization-picker-current"]').contains('Bubatzbieber');
+    });
+  });
+
   it('oidc login for invalid url shows correct error message', () => {
     cy.clearAllCookies();
     cy.clearAllLocalStorage();

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -42,7 +42,7 @@ Cypress.Commands.add('createOIDCIntegration', (organizationName: string) => {
 
   return cy
     .get('div[role="dialog"]')
-    .find('code')
+    .find('[id="sign-in-uri"]')
     .last()
     .then($elem => $elem.text())
     .then(loginUrl => {

--- a/cypress/support/commands.ts
+++ b/cypress/support/commands.ts
@@ -42,9 +42,20 @@ Cypress.Commands.add('createOIDCIntegration', (organizationName: string) => {
 
   return cy
     .get('div[role="dialog"]')
-    .find('[id="sign-in-uri"]')
-    .last()
-    .then($elem => $elem.text())
+    .find('input[id="sign-in-uri"]')
+    .then(async $elem => {
+      const url = $elem.val();
+
+      if (!url) {
+        throw new Error('Failed to resolve OIDC integration URL');
+      }
+
+      if (typeof url !== 'string') {
+        throw new Error('OIDC integration URL is not a string');
+      }
+
+      return url;
+    })
     .then(loginUrl => {
       return cy.url().then(url => {
         const organizationSlug = new URL(url).pathname.split('/')[1];

--- a/docker/configs/oidc-server-mock/users-config.json
+++ b/docker/configs/oidc-server-mock/users-config.json
@@ -15,5 +15,22 @@
         "ValueType": "string"
       }
     ]
+  },
+  {
+    "SubjectId": "2",
+    "Username": "test-user-2",
+    "Password": "password",
+    "Claims": [
+      {
+        "Type": "name",
+        "Value": "Tom Sailor",
+        "ValueType": "string"
+      },
+      {
+        "Type": "email",
+        "Value": "tom.sailor@gmail.com",
+        "ValueType": "string"
+      }
+    ]
   }
 ]

--- a/integration-tests/tests/api/oidc-integrations/crud.spec.ts
+++ b/integration-tests/tests/api/oidc-integrations/crud.spec.ts
@@ -877,7 +877,7 @@ describe('restrictions', () => {
     expect(
       orgAfterDisablingOidcRestrictions.organization?.organization.oidcIntegration
         ?.oidcUserAccessOnly,
-    ).toEqual(true);
+    ).toEqual(false);
 
     const invitation = await inviteMember('example@example.com');
     const invitationCode = invitation.ok?.code;

--- a/integration-tests/tests/api/oidc-integrations/crud.spec.ts
+++ b/integration-tests/tests/api/oidc-integrations/crud.spec.ts
@@ -1,3 +1,4 @@
+import { userEmail } from 'testkit/auth';
 import { graphql } from '../../../testkit/gql';
 import { execute } from '../../../testkit/graphql';
 import { initSeed } from '../../../testkit/seed';
@@ -9,7 +10,18 @@ const OrganizationWithOIDCIntegration = graphql(`
         id
         oidcIntegration {
           id
+          oidcUserAccessOnly
         }
+      }
+    }
+  }
+`);
+
+const OrganizationReadTest = graphql(`
+  query OrganizationReadTest($organizationId: ID!) {
+    organization(selector: { organization: $organizationId }) {
+      organization {
+        id
       }
     }
   }
@@ -26,6 +38,7 @@ const CreateOIDCIntegrationMutation = graphql(`
           tokenEndpoint
           userinfoEndpoint
           authorizationEndpoint
+          oidcUserAccessOnly
         }
       }
       error {
@@ -37,6 +50,22 @@ const CreateOIDCIntegrationMutation = graphql(`
           userinfoEndpoint
           authorizationEndpoint
         }
+      }
+    }
+  }
+`);
+
+const UpdateOIDCRestrictionsMutation = graphql(`
+  mutation UpdateOIDCRestrictionsMutation($input: UpdateOIDCRestrictionsInput!) {
+    updateOIDCRestrictions(input: $input) {
+      ok {
+        updatedOIDCIntegration {
+          id
+          oidcUserAccessOnly
+        }
+      }
+      error {
+        message
       }
     }
   }
@@ -74,6 +103,7 @@ describe('create', () => {
               tokenEndpoint: 'http://localhost:8888/oauth/token',
               userinfoEndpoint: 'http://localhost:8888/oauth/userinfo',
               authorizationEndpoint: 'http://localhost:8888/oauth/authorize',
+              oidcUserAccessOnly: true,
             },
           },
         },
@@ -93,6 +123,7 @@ describe('create', () => {
             id: organization.id,
             oidcIntegration: {
               id: result.createOIDCIntegration.ok!.createdOIDCIntegration.id,
+              oidcUserAccessOnly: true,
             },
           },
         },
@@ -345,6 +376,7 @@ describe('create', () => {
               tokenEndpoint: 'http://localhost:8888/oauth/token',
               userinfoEndpoint: 'http://localhost:8888/oauth/userinfo',
               authorizationEndpoint: 'http://localhost:8888/oauth/authorize',
+              oidcUserAccessOnly: true,
             },
           },
         },
@@ -434,6 +466,7 @@ describe('delete', () => {
             id: organization.id,
             oidcIntegration: {
               id: oidcIntegrationId,
+              oidcUserAccessOnly: true,
             },
           },
         },
@@ -715,4 +748,188 @@ describe('update', () => {
       );
     });
   });
+});
+
+describe('restrictions', () => {
+  async function configureOIDC(args: { ownerToken: string; organizationId: string }) {
+    const result = await execute({
+      document: CreateOIDCIntegrationMutation,
+      variables: {
+        input: {
+          organizationId: args.organizationId,
+          clientId: 'foo',
+          clientSecret: 'foofoofoofoo',
+          tokenEndpoint: 'http://localhost:8888/oauth/token',
+          userinfoEndpoint: 'http://localhost:8888/oauth/userinfo',
+          authorizationEndpoint: 'http://localhost:8888/oauth/authorize',
+        },
+      },
+      authToken: args.ownerToken,
+    }).then(r => r.expectNoGraphQLErrors());
+
+    expect(result).toEqual({
+      createOIDCIntegration: {
+        error: null,
+        ok: {
+          createdOIDCIntegration: {
+            id: expect.any(String),
+            oidcUserAccessOnly: true,
+            clientId: 'foo',
+            clientSecretPreview: 'ofoo',
+            tokenEndpoint: 'http://localhost:8888/oauth/token',
+            userinfoEndpoint: 'http://localhost:8888/oauth/userinfo',
+            authorizationEndpoint: 'http://localhost:8888/oauth/authorize',
+          },
+        },
+      },
+    });
+
+    return result.createOIDCIntegration.ok!.createdOIDCIntegration.id;
+  }
+
+  test.concurrent('non-oidc users cannot join an organization (default)', async ({ expect }) => {
+    const seed = initSeed();
+    const { ownerToken, createOrg } = await seed.createOwner();
+    const { organization, inviteMember, joinMemberUsingCode } = await createOrg();
+
+    await configureOIDC({
+      ownerToken,
+      organizationId: organization.id,
+    });
+
+    const refetchedOrg = await execute({
+      document: OrganizationWithOIDCIntegration,
+      variables: {
+        organizationId: organization.cleanId,
+      },
+      authToken: ownerToken,
+    }).then(r => r.expectNoGraphQLErrors());
+
+    expect(refetchedOrg.organization?.organization.oidcIntegration?.oidcUserAccessOnly).toEqual(
+      true,
+    );
+
+    const invitation = await inviteMember('example@example.com');
+    const invitationCode = invitation.ok?.code;
+
+    if (!invitationCode) {
+      throw new Error('No invitation code');
+    }
+
+    const nonOidcAccount = await seed.authenticate(userEmail('non-oidc-user'));
+    const joinResult = await joinMemberUsingCode(invitationCode, nonOidcAccount.access_token).then(
+      r => r.expectNoGraphQLErrors(),
+    );
+
+    expect(joinResult.joinOrganization).toEqual(
+      expect.objectContaining({
+        __typename: 'OrganizationInvitationError',
+        message: 'Non-OIDC users are not allowed to join this organization.',
+      }),
+    );
+  });
+
+  test.concurrent('non-oidc users can join an organization (opt-in)', async ({ expect }) => {
+    const seed = initSeed();
+    const { ownerToken, createOrg } = await seed.createOwner();
+    const { organization, inviteMember, joinMemberUsingCode } = await createOrg();
+
+    const oidcIntegrationId = await configureOIDC({
+      ownerToken,
+      organizationId: organization.id,
+    });
+
+    const orgAfterOidc = await execute({
+      document: OrganizationWithOIDCIntegration,
+      variables: {
+        organizationId: organization.cleanId,
+      },
+      authToken: ownerToken,
+    }).then(r => r.expectNoGraphQLErrors());
+
+    expect(orgAfterOidc.organization?.organization.oidcIntegration?.oidcUserAccessOnly).toEqual(
+      true,
+    );
+
+    const restrictionsUpdateResult = await execute({
+      document: UpdateOIDCRestrictionsMutation,
+      variables: {
+        input: {
+          oidcIntegrationId,
+          oidcUserAccessOnly: false,
+        },
+      },
+      authToken: ownerToken,
+    }).then(r => r.expectNoGraphQLErrors());
+
+    expect(
+      restrictionsUpdateResult.updateOIDCRestrictions.ok?.updatedOIDCIntegration.oidcUserAccessOnly,
+    ).toEqual(false);
+
+    const orgAfterDisablingOidcRestrictions = await execute({
+      document: OrganizationWithOIDCIntegration,
+      variables: {
+        organizationId: organization.cleanId,
+      },
+      authToken: ownerToken,
+    }).then(r => r.expectNoGraphQLErrors());
+
+    expect(
+      orgAfterDisablingOidcRestrictions.organization?.organization.oidcIntegration
+        ?.oidcUserAccessOnly,
+    ).toEqual(true);
+
+    const invitation = await inviteMember('example@example.com');
+    const invitationCode = invitation.ok?.code;
+
+    if (!invitationCode) {
+      throw new Error('No invitation code');
+    }
+
+    const nonOidcAccount = await seed.authenticate(userEmail('non-oidc-user'));
+    const joinResult = await joinMemberUsingCode(invitationCode, nonOidcAccount.access_token).then(
+      r => r.expectNoGraphQLErrors(),
+    );
+
+    expect(joinResult.joinOrganization.__typename).toEqual('OrganizationPayload');
+  });
+
+  test.concurrent(
+    'existing non-oidc users can always access the organization',
+    async ({ expect }) => {
+      const seed = initSeed();
+      const { ownerToken, createOrg } = await seed.createOwner();
+      const { organization, inviteMember, joinMemberUsingCode } = await createOrg();
+
+      const invitation = await inviteMember('example@example.com');
+      const invitationCode = invitation.ok?.code;
+
+      if (!invitationCode) {
+        throw new Error('No invitation code');
+      }
+
+      const nonOidcAccount = await seed.authenticate(userEmail('non-oidc-user'));
+      const joinResult = await joinMemberUsingCode(
+        invitationCode,
+        nonOidcAccount.access_token,
+      ).then(r => r.expectNoGraphQLErrors());
+
+      expect(joinResult.joinOrganization.__typename).toEqual('OrganizationPayload');
+
+      await configureOIDC({
+        ownerToken,
+        organizationId: organization.id,
+      });
+
+      const readAccessCheck = await execute({
+        document: OrganizationReadTest,
+        variables: {
+          organizationId: organization.cleanId,
+        },
+        authToken: ownerToken,
+      }).then(r => r.expectNoGraphQLErrors());
+
+      expect(readAccessCheck.organization?.organization.id).toEqual(organization.id);
+    },
+  );
 });

--- a/packages/migrations/src/actions/2024.07.16T13-44-00.oidc-only-access.ts
+++ b/packages/migrations/src/actions/2024.07.16T13-44-00.oidc-only-access.ts
@@ -1,0 +1,9 @@
+import { type MigrationExecutor } from '../pg-migrator';
+
+export default {
+  name: '2024.07.16T13-44-00.oidc-only-access.ts',
+  run: ({ sql }) => sql`
+    ALTER TABLE "oidc_integrations"
+    ADD COLUMN "oidc_user_access_only" BOOLEAN NOT NULL DEFAULT TRUE;
+  `,
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -64,6 +64,7 @@ import migration_2024_01_12_01T00_00_00_schema_check_pagination_index_update fro
 import migration_2024_02_19_01T00_00_00_schema_check_store_breaking_change_metadata from './actions/2024.02.19T00.00.01.schema-check-store-breaking-change-metadata';
 import migration_2024_04_09T10_10_00_check_approval_comment from './actions/2024.04.09T10-10-00.check-approval-comment';
 import migration_2024_06_11T10_10_00_ms_teams_webhook from './actions/2024.06.11T10-10-00.ms-teams-webhook';
+import migration_2024_07_16T13_44_00_oidc_only_access from './actions/2024.07.16T13-44-00.oidc-only-access';
 import { runMigrations } from './pg-migrator';
 
 export const runPGMigrations = (args: { slonik: DatabasePool; runTo?: string }) =>
@@ -136,5 +137,6 @@ export const runPGMigrations = (args: { slonik: DatabasePool; runTo?: string }) 
       migration_2024_02_19_01T00_00_00_schema_check_store_breaking_change_metadata,
       migration_2024_04_09T10_10_00_check_approval_comment,
       migration_2024_06_11T10_10_00_ms_teams_webhook,
+      migration_2024_07_16T13_44_00_oidc_only_access,
     ],
   });

--- a/packages/services/api/src/modules/oidc-integrations/module.graphql.ts
+++ b/packages/services/api/src/modules/oidc-integrations/module.graphql.ts
@@ -18,12 +18,14 @@ export default gql`
     userinfoEndpoint: String!
     authorizationEndpoint: String!
     organization: Organization!
+    oidcUserAccessOnly: Boolean!
   }
 
   extend type Mutation {
     createOIDCIntegration(input: CreateOIDCIntegrationInput!): CreateOIDCIntegrationResult!
     updateOIDCIntegration(input: UpdateOIDCIntegrationInput!): UpdateOIDCIntegrationResult!
     deleteOIDCIntegration(input: DeleteOIDCIntegrationInput!): DeleteOIDCIntegrationResult!
+    updateOIDCRestrictions(input: UpdateOIDCRestrictionsInput!): UpdateOIDCRestrictionsResult!
   }
 
   type Subscription {
@@ -120,6 +122,31 @@ export default gql`
   }
 
   type DeleteOIDCIntegrationError implements Error {
+    message: String!
+  }
+
+  input UpdateOIDCRestrictionsInput {
+    oidcIntegrationId: ID!
+    """
+    Applies only to newly invited members.
+    Existing members are not affected.
+    """
+    oidcUserAccessOnly: Boolean!
+  }
+
+  """
+  @oneOf
+  """
+  type UpdateOIDCRestrictionsResult {
+    ok: UpdateOIDCRestrictionsOk
+    error: UpdateOIDCRestrictionsError
+  }
+
+  type UpdateOIDCRestrictionsOk {
+    updatedOIDCIntegration: OIDCIntegration!
+  }
+
+  type UpdateOIDCRestrictionsError implements Error {
     message: String!
   }
 `;

--- a/packages/services/api/src/modules/oidc-integrations/providers/oidc-integrations.provider.ts
+++ b/packages/services/api/src/modules/oidc-integrations/providers/oidc-integrations.provider.ts
@@ -282,6 +282,36 @@ export class OIDCIntegrationsProvider {
     } as const;
   }
 
+  async updateOIDCRestrictions(args: { oidcIntegrationId: string; oidcUserAccessOnly: boolean }) {
+    if (this.isEnabled() === false) {
+      return {
+        type: 'error',
+        message: 'OIDC integrations are disabled.',
+      } as const;
+    }
+
+    const oidcIntegration = await this.storage.getOIDCIntegrationById({
+      oidcIntegrationId: args.oidcIntegrationId,
+    });
+
+    if (oidcIntegration === null) {
+      return {
+        type: 'error',
+        message: 'Integration not found.',
+      } as const;
+    }
+
+    await this.authManager.ensureOrganizationAccess({
+      organization: oidcIntegration.linkedOrganizationId,
+      scope: OrganizationAccessScope.INTEGRATIONS,
+    });
+
+    return {
+      type: 'ok',
+      oidcIntegration: await this.storage.updateOIDCRestrictions(args),
+    } as const;
+  }
+
   async getOIDCIntegrationById(args: { oidcIntegrationId: string }) {
     if (this.isEnabled() === false) {
       return {

--- a/packages/services/api/src/modules/oidc-integrations/resolvers.ts
+++ b/packages/services/api/src/modules/oidc-integrations/resolvers.ts
@@ -95,6 +95,26 @@ export const resolvers: OidcIntegrationsModule.Resolvers = {
         },
       };
     },
+    async updateOIDCRestrictions(_, { input }, { injector }) {
+      const result = await injector.get(OIDCIntegrationsProvider).updateOIDCRestrictions({
+        oidcIntegrationId: input.oidcIntegrationId,
+        oidcUserAccessOnly: input.oidcUserAccessOnly,
+      });
+
+      if (result.type === 'ok') {
+        return {
+          ok: {
+            updatedOIDCIntegration: result.oidcIntegration,
+          },
+        };
+      }
+
+      return {
+        error: {
+          message: result.message,
+        },
+      };
+    },
   },
   Subscription: {
     oidcIntegrationLog: {

--- a/packages/services/api/src/modules/organization/providers/organization-manager.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-manager.ts
@@ -10,6 +10,7 @@ import { OrganizationAccessScope } from '../../auth/providers/organization-acces
 import { ProjectAccessScope } from '../../auth/providers/project-access';
 import { TargetAccessScope } from '../../auth/providers/target-access';
 import { BillingProvider } from '../../billing/providers/billing.provider';
+import { OIDCIntegrationsProvider } from '../../oidc-integrations/providers/oidc-integrations.provider';
 import { Emails, mjml } from '../../shared/providers/emails';
 import { Logger } from '../../shared/providers/logger';
 import type { OrganizationSelector } from '../../shared/providers/storage';
@@ -21,7 +22,6 @@ import {
   organizationViewerScopes,
   reservedOrganizationNames,
 } from './organization-config';
-import { OIDCIntegrationsProvider } from '../../oidc-integrations/providers/oidc-integrations.provider';
 
 function ensureReadAccess(
   scopes: readonly (OrganizationAccessScope | ProjectAccessScope | TargetAccessScope)[],

--- a/packages/services/api/src/modules/organization/providers/organization-manager.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-manager.ts
@@ -21,6 +21,7 @@ import {
   organizationViewerScopes,
   reservedOrganizationNames,
 } from './organization-config';
+import { OIDCIntegrationsProvider } from '../../oidc-integrations/providers/oidc-integrations.provider';
 
 function ensureReadAccess(
   scopes: readonly (OrganizationAccessScope | ProjectAccessScope | TargetAccessScope)[],
@@ -63,6 +64,7 @@ export class OrganizationManager {
     private tokenStorage: TokenStorage,
     private activityManager: ActivityManager,
     private billingProvider: BillingProvider,
+    private oidcIntegrationProvider: OIDCIntegrationsProvider,
     private emails: Emails,
     @Inject(WEB_APP_URL) private appBaseUrl: string,
   ) {
@@ -614,8 +616,9 @@ export class OrganizationManager {
     this.logger.info('Joining an organization (code=%s)', code);
 
     const user = await this.authManager.getCurrentUser();
+    const isOIDCUser = user.oidcIntegrationId !== null;
 
-    if (user.oidcIntegrationId !== null) {
+    if (isOIDCUser) {
       return {
         message: `You cannot join an organization with an OIDC account.`,
       };
@@ -627,6 +630,18 @@ export class OrganizationManager {
 
     if ('message' in organization) {
       return organization;
+    }
+
+    if (this.oidcIntegrationProvider.isEnabled()) {
+      const oidcIntegration = await this.storage.getOIDCIntegrationForOrganization({
+        organizationId: organization.id,
+      });
+
+      if (oidcIntegration?.oidcUserAccessOnly && !isOIDCUser) {
+        return {
+          message: 'Non-OIDC users are not allowed to join this organization.',
+        };
+      }
     }
 
     this.logger.debug('Adding member (organization=%s, code=%s)', organization.id, code);

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -639,6 +639,11 @@ export interface Storage {
 
   deleteOIDCIntegration(_: { oidcIntegrationId: string }): Promise<void>;
 
+  updateOIDCRestrictions(_: {
+    oidcIntegrationId: string;
+    oidcUserAccessOnly: boolean;
+  }): Promise<OIDCIntegration>;
+
   createCDNAccessToken(_: {
     id: string;
     targetId: string;

--- a/packages/services/api/src/shared/entities.ts
+++ b/packages/services/api/src/shared/entities.ts
@@ -216,6 +216,7 @@ export interface OIDCIntegration {
   tokenEndpoint: string;
   userinfoEndpoint: string;
   authorizationEndpoint: string;
+  oidcUserAccessOnly: boolean;
 }
 
 export interface CDNAccessToken {

--- a/packages/services/storage/src/db/types.ts
+++ b/packages/services/storage/src/db/types.ts
@@ -407,7 +407,6 @@ export interface DBTables {
   projects: projects;
   schema_change_approvals: schema_change_approvals;
   schema_checks: schema_checks;
-  schema_cleanup_tracker: schema_cleanup_tracker;
   schema_log: schema_log;
   schema_policy_config: schema_policy_config;
   schema_version_changes: schema_version_changes;

--- a/packages/services/storage/src/db/types.ts
+++ b/packages/services/storage/src/db/types.ts
@@ -140,6 +140,7 @@ export interface oidc_integrations {
   id: string;
   linked_organization_id: string;
   oauth_api_url: string | null;
+  oidc_user_access_only: boolean;
   token_endpoint: string | null;
   updated_at: Date;
   userinfo_endpoint: string | null;
@@ -258,6 +259,15 @@ export interface schema_checks {
   supergraph_sdl_store_id: string | null;
   target_id: string;
   updated_at: Date;
+}
+
+export interface schema_cleanup_tracker {
+  coordinate: string;
+  created_at: Date;
+  created_in_version_id: string;
+  deprecated_at: Date | null;
+  deprecated_in_version_id: string | null;
+  target_id: string;
 }
 
 export interface schema_log {
@@ -406,6 +416,7 @@ export interface DBTables {
   projects: projects;
   schema_change_approvals: schema_change_approvals;
   schema_checks: schema_checks;
+  schema_cleanup_tracker: schema_cleanup_tracker;
   schema_log: schema_log;
   schema_policy_config: schema_policy_config;
   schema_version_changes: schema_version_changes;

--- a/packages/services/storage/src/db/types.ts
+++ b/packages/services/storage/src/db/types.ts
@@ -261,15 +261,6 @@ export interface schema_checks {
   updated_at: Date;
 }
 
-export interface schema_cleanup_tracker {
-  coordinate: string;
-  created_at: Date;
-  created_in_version_id: string;
-  deprecated_at: Date | null;
-  deprecated_in_version_id: string | null;
-  target_id: string;
-}
-
 export interface schema_log {
   action: string;
   author: string;

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -3521,8 +3521,6 @@ export async function createStorage(
     },
 
     async updateOIDCRestrictions(args) {
-      // args.oidcIntegrationId
-      // args.oidcUserAccessOnly
       const result = await pool.one(sql`/* updateOIDCRestrictions */
           UPDATE "oidc_integrations"
           SET

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -3371,6 +3371,7 @@ export async function createStorage(
           , "token_endpoint"
           , "userinfo_endpoint"
           , "authorization_endpoint"
+          , "oidc_user_access_only"
         FROM
           "oidc_integrations"
         WHERE
@@ -3396,6 +3397,7 @@ export async function createStorage(
           , "token_endpoint"
           , "userinfo_endpoint"
           , "authorization_endpoint"
+          , "oidc_user_access_only"
         FROM
           "oidc_integrations"
         WHERE
@@ -3458,6 +3460,7 @@ export async function createStorage(
             , "token_endpoint"
             , "userinfo_endpoint"
             , "authorization_endpoint"
+            , "oidc_user_access_only"
         `);
 
         return {
@@ -3511,6 +3514,31 @@ export async function createStorage(
           , "token_endpoint"
           , "userinfo_endpoint"
           , "authorization_endpoint"
+          , "oidc_user_access_only"
+      `);
+
+      return decodeOktaIntegrationRecord(result);
+    },
+
+    async updateOIDCRestrictions(args) {
+      // args.oidcIntegrationId
+      // args.oidcUserAccessOnly
+      const result = await pool.one(sql`/* updateOIDCRestrictions */
+          UPDATE "oidc_integrations"
+          SET
+            "oidc_user_access_only" = ${args.oidcUserAccessOnly}
+          WHERE
+            "id" = ${args.oidcIntegrationId}
+          RETURNING
+          "id"
+          , "linked_organization_id"
+          , "client_id"
+          , "client_secret"
+          , "oauth_api_url"
+          , "token_endpoint"
+          , "userinfo_endpoint"
+          , "authorization_endpoint"
+          , "oidc_user_access_only"
       `);
 
       return decodeOktaIntegrationRecord(result);
@@ -4880,6 +4908,7 @@ const OktaIntegrationBaseModel = zod.object({
   linked_organization_id: zod.string(),
   client_id: zod.string(),
   client_secret: zod.string(),
+  oidc_user_access_only: zod.boolean(),
 });
 
 const OktaIntegrationLegacyModel = zod.intersection(
@@ -4913,6 +4942,7 @@ const decodeOktaIntegrationRecord = (result: unknown): OIDCIntegration => {
       tokenEndpoint: `${rawRecord.oauth_api_url}/token`,
       userinfoEndpoint: `${rawRecord.oauth_api_url}/userinfo`,
       authorizationEndpoint: `${rawRecord.oauth_api_url}/authorize`,
+      oidcUserAccessOnly: rawRecord.oidc_user_access_only,
     };
   }
 
@@ -4924,6 +4954,7 @@ const decodeOktaIntegrationRecord = (result: unknown): OIDCIntegration => {
     tokenEndpoint: rawRecord.token_endpoint,
     userinfoEndpoint: rawRecord.userinfo_endpoint,
     authorizationEndpoint: rawRecord.authorization_endpoint,
+    oidcUserAccessOnly: rawRecord.oidc_user_access_only,
   };
 };
 

--- a/packages/web/app/package.json
+++ b/packages/web/app/package.json
@@ -39,6 +39,7 @@
     "@radix-ui/react-radio-group": "1.2.0",
     "@radix-ui/react-scroll-area": "1.1.0",
     "@radix-ui/react-select": "2.1.1",
+    "@radix-ui/react-separator": "1.1.0",
     "@radix-ui/react-slider": "1.2.0",
     "@radix-ui/react-slot": "1.1.0",
     "@radix-ui/react-switch": "1.1.0",

--- a/packages/web/app/src/components/organization/settings/oidc-integration-section.tsx
+++ b/packages/web/app/src/components/organization/settings/oidc-integration-section.tsx
@@ -26,12 +26,12 @@ import { cn } from '@/lib/utils';
 import { Link, useRouter } from '@tanstack/react-router';
 import { useClipboard } from '@/lib/hooks';
 
-function CopyInput(props: { value: string }) {
+function CopyInput(props: { value: string; id?: string }) {
   const copy = useClipboard();
 
   return (
     <div className="flex space-x-2">
-      <Input value={props.value} readOnly />
+      <Input id={props.id} value={props.value} readOnly />
       <Button
         variant="secondary"
         className="shrink-0"
@@ -563,15 +563,19 @@ function UpdateOIDCIntegrationForm(props: {
                   <div className="space-y-2">
                     <div className="space-y-2">
                       <Label>Sign-in redirect URI</Label>
-                      <CopyInput value={`${env.appBaseUrl}/auth/callback/oidc`} />
+                      <CopyInput
+                        id="sing-in-redirect-uri"
+                        value={`${env.appBaseUrl}/auth/callback/oidc`}
+                      />
                     </div>
                     <div className="space-y-2">
                       <Label>Sign-out redirect URI</Label>
-                      <CopyInput value={`${env.appBaseUrl}/logout`} />
+                      <CopyInput id="sign-put-redirect-uri" value={`${env.appBaseUrl}/logout`} />
                     </div>
                     <div className="space-y-2">
                       <Label>Your users can login to the organization via </Label>
                       <CopyInput
+                        id="sign-in-uri"
                         value={`${env.appBaseUrl}/auth/oidc?id=${props.oidcIntegration.id}`}
                       />
                     </div>

--- a/packages/web/app/src/components/organization/settings/oidc-integration-section.tsx
+++ b/packages/web/app/src/components/organization/settings/oidc-integration-section.tsx
@@ -12,19 +12,19 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { Switch } from '@/components/ui/switch';
 import { useToast } from '@/components/ui/use-toast';
 import { Tag } from '@/components/v2';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
 import { AlertTriangleIcon, KeyIcon } from '@/components/v2/icon';
 import { env } from '@/env/frontend';
 import { DocumentType, FragmentType, graphql, useFragment } from '@/gql';
+import { useClipboard } from '@/lib/hooks';
 import { useResetState } from '@/lib/hooks/use-reset-state';
 import { cn } from '@/lib/utils';
 import { Link, useRouter } from '@tanstack/react-router';
-import { useClipboard } from '@/lib/hooks';
 
 function CopyInput(props: { value: string; id?: string }) {
   const copy = useClipboard();

--- a/packages/web/app/src/components/organization/settings/oidc-integration-section.tsx
+++ b/packages/web/app/src/components/organization/settings/oidc-integration-section.tsx
@@ -19,7 +19,6 @@ import { Tag } from '@/components/v2';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { AlertTriangleIcon, KeyIcon } from '@/components/v2/icon';
-import { InlineCode } from '@/components/v2/inline-code';
 import { env } from '@/env/frontend';
 import { DocumentType, FragmentType, graphql, useFragment } from '@/gql';
 import { useResetState } from '@/lib/hooks/use-reset-state';
@@ -38,7 +37,7 @@ function CopyInput(props: { value: string }) {
         className="shrink-0"
         onClick={ev => {
           ev.preventDefault();
-          copy(props.value);
+          void copy(props.value);
         }}
       >
         Copy
@@ -550,12 +549,7 @@ function UpdateOIDCIntegrationForm(props: {
   return (
     <Dialog open={props.isOpen} onOpenChange={props.close}>
       <DialogContent className="flex min-h-[600px] w-[960px] max-w-none">
-        <form className={cn(classes.container, 'flex-1')} onSubmit={formik.handleSubmit}>
-          {/* <DialogHeader>
-            <DialogTitle>OpenID Connect</DialogTitle>
-            <DialogDescription>Manage OpenID Connect Integration</DialogDescription>
-          </DialogHeader> */}
-
+        <div className={cn(classes.container, 'flex-1')}>
           <div className="flex gap-x-5">
             <div className="flex-1">
               <div className="flex flex-col gap-y-5">
@@ -613,7 +607,10 @@ function UpdateOIDCIntegrationForm(props: {
 
             <Separator orientation="vertical" />
 
-            <div className={cn(classes.container, 'flex flex-1 flex-col gap-y-4')}>
+            <form
+              className={cn(classes.container, 'flex flex-1 flex-col gap-y-4')}
+              onSubmit={formik.handleSubmit}
+            >
               <div>
                 <div className="text-lg font-medium">Properties</div>
                 <p className="text-muted-foreground text-sm">
@@ -700,18 +697,26 @@ function UpdateOIDCIntegrationForm(props: {
                     {oidcUpdateMutation.data?.updateOIDCIntegration.error?.details.clientSecret}
                   </FormError>
                 </div>
+                <div className="space-x-2 text-right">
+                  <Button
+                    variant="outline"
+                    onClick={ev => {
+                      ev.preventDefault();
+                      formik.resetForm();
+                      props.close();
+                    }}
+                    tabIndex={0}
+                  >
+                    Close
+                  </Button>
+                  <Button type="submit" disabled={oidcUpdateMutation.fetching}>
+                    Save
+                  </Button>
+                </div>
               </div>
-            </div>
+            </form>
           </div>
-          <DialogFooter className="space-x-2 text-right">
-            <Button variant="outline" onClick={props.close} tabIndex={0}>
-              Close
-            </Button>
-            <Button type="submit" disabled={oidcUpdateMutation.fetching || !formik.dirty}>
-              Save
-            </Button>
-          </DialogFooter>
-        </form>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/packages/web/app/src/components/organization/settings/oidc-integration-section.tsx
+++ b/packages/web/app/src/components/organization/settings/oidc-integration-section.tsx
@@ -4,7 +4,6 @@ import { useFormik } from 'formik';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 import { useClient, useMutation } from 'urql';
 import { Button, buttonVariants } from '@/components/ui/button';
-import { Separator } from '@/components/ui/separator';
 import {
   Dialog,
   DialogContent,
@@ -13,6 +12,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import { Separator } from '@/components/ui/separator';
+import { Switch } from '@/components/ui/switch';
+import { useToast } from '@/components/ui/use-toast';
 import { Input, Tag } from '@/components/v2';
 import { AlertTriangleIcon, KeyIcon } from '@/components/v2/icon';
 import { InlineCode } from '@/components/v2/inline-code';
@@ -21,8 +23,6 @@ import { DocumentType, FragmentType, graphql, useFragment } from '@/gql';
 import { useResetState } from '@/lib/hooks/use-reset-state';
 import { cn } from '@/lib/utils';
 import { Link, useRouter } from '@tanstack/react-router';
-import { Switch } from '@/components/ui/switch';
-import { useToast } from '@/components/ui/use-toast';
 
 const classes = {
   container: cn('flex flex-col items-stretch gap-2'),

--- a/packages/web/app/src/components/ui/separator.tsx
+++ b/packages/web/app/src/components/ui/separator.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as React from 'react';
 import * as SeparatorPrimitive from '@radix-ui/react-separator';
 import { cn } from '@/lib/utils';

--- a/packages/web/app/src/components/ui/separator.tsx
+++ b/packages/web/app/src/components/ui/separator.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
 import * as React from 'react';
-import * as SeparatorPrimitive from '@radix-ui/react-separator';
 import { cn } from '@/lib/utils';
+import * as SeparatorPrimitive from '@radix-ui/react-separator';
 
 const Separator = React.forwardRef<
   React.ElementRef<typeof SeparatorPrimitive.Root>,

--- a/packages/web/app/src/components/ui/separator.tsx
+++ b/packages/web/app/src/components/ui/separator.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react';
+import * as SeparatorPrimitive from '@radix-ui/react-separator';
+import { cn } from '@/lib/utils';
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(({ className, orientation = 'horizontal', decorative = true, ...props }, ref) => (
+  <SeparatorPrimitive.Root
+    ref={ref}
+    decorative={decorative}
+    orientation={orientation}
+    className={cn(
+      'bg-border shrink-0',
+      orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
+      className,
+    )}
+    {...props}
+  />
+));
+Separator.displayName = SeparatorPrimitive.Root.displayName;
+
+export { Separator };

--- a/packages/web/app/src/lib/hooks/use-clipboard.ts
+++ b/packages/web/app/src/lib/hooks/use-clipboard.ts
@@ -1,22 +1,31 @@
 import { useCallback } from 'react';
-import { useNotifications } from './use-notifications';
+import { useToast } from '@/components/ui/use-toast';
 
 export function useClipboard() {
-  const notify = useNotifications();
+  const { toast } = useToast();
 
   return useCallback(
     async (text: string): Promise<void> => {
       if (!navigator?.clipboard) {
-        notify('Access to clipboard rejected!', 'error');
+        toast({
+          title: 'Clipboard not supported',
+          description: 'Your browser does not support clipboard operations.',
+          variant: 'destructive',
+        });
         return;
       }
       try {
         await navigator.clipboard.writeText(text);
-        notify('Copied to clipboard!', 'success');
+        toast({
+          title: 'Copied to clipboard',
+        });
       } catch {
-        notify('Failed to copy!', 'error');
+        toast({
+          title: 'Failed to copy',
+          variant: 'destructive',
+        });
       }
     },
-    [notify],
+    [toast],
   );
 }

--- a/packages/web/app/src/pages/organization-join.tsx
+++ b/packages/web/app/src/pages/organization-join.tsx
@@ -8,8 +8,8 @@ import { Meta } from '@/components/ui/meta';
 import { DataWrapper } from '@/components/v2/data-wrapper';
 import { HiveLogo } from '@/components/v2/icon';
 import { graphql } from '@/gql';
-import { useNotifications } from '@/lib/hooks/use-notifications';
 import { Link, useRouter } from '@tanstack/react-router';
+import { useToast } from '@/components/ui/use-toast';
 
 const JoinOrganizationPage_JoinOrganizationMutation = graphql(`
   mutation JoinOrganizationPage_JoinOrganizationMutation($code: String!) {
@@ -48,7 +48,8 @@ const JoinOrganizationPage_OrganizationInvitationQuery = graphql(`
 
 export function JoinOrganizationPage(props: { inviteCode: string }) {
   const router = useRouter();
-  const notify = useNotifications();
+  const { toast } = useToast();
+  // const notify = useNotifications();
   const code = props.inviteCode;
   const [query] = useQuery({
     query: JoinOrganizationPage_OrganizationInvitationQuery,
@@ -59,17 +60,24 @@ export function JoinOrganizationPage(props: { inviteCode: string }) {
     const result = await mutate({ code });
     if (result.data) {
       if (result.data.joinOrganization.__typename === 'OrganizationInvitationError') {
-        notify(result.data.joinOrganization.message, 'error');
+        toast({
+          title: 'Failed to join organization',
+          description: result.data.joinOrganization.message,
+          variant: 'destructive',
+        });
       } else {
         const org = result.data.joinOrganization.organization;
-        notify(`You joined "${org.name}" organization`, 'success');
+        toast({
+          title: 'Joined organization',
+          description: `You are now a member of ${org.name}`,
+        });
         void router.navigate({
           to: '/$organizationId',
           params: { organizationId: org.cleanId },
         });
       }
     }
-  }, [mutate, code, router, notify]);
+  }, [mutate, code, router, toast]);
 
   const goBack = useCallback(() => {
     void router.navigate({

--- a/packages/web/app/src/pages/organization-join.tsx
+++ b/packages/web/app/src/pages/organization-join.tsx
@@ -5,11 +5,11 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card';
 import { DottedBackground } from '@/components/ui/dotted-background';
 import { Meta } from '@/components/ui/meta';
+import { useToast } from '@/components/ui/use-toast';
 import { DataWrapper } from '@/components/v2/data-wrapper';
 import { HiveLogo } from '@/components/v2/icon';
 import { graphql } from '@/gql';
 import { Link, useRouter } from '@tanstack/react-router';
-import { useToast } from '@/components/ui/use-toast';
 
 const JoinOrganizationPage_JoinOrganizationMutation = graphql(`
   mutation JoinOrganizationPage_JoinOrganizationMutation($code: String!) {

--- a/packages/web/app/src/pages/organization-join.tsx
+++ b/packages/web/app/src/pages/organization-join.tsx
@@ -49,7 +49,6 @@ const JoinOrganizationPage_OrganizationInvitationQuery = graphql(`
 export function JoinOrganizationPage(props: { inviteCode: string }) {
   const router = useRouter();
   const { toast } = useToast();
-  // const notify = useNotifications();
   const code = props.inviteCode;
   const [query] = useQuery({
     query: JoinOrganizationPage_OrganizationInvitationQuery,

--- a/packages/web/docs/src/pages/docs/management/organizations.mdx
+++ b/packages/web/docs/src/pages/docs/management/organizations.mdx
@@ -191,7 +191,7 @@ organization.
 To do this, go to the **Settings** tab of your organization, and use the **Organization Name** form
 to rename your organization.
 
-## Change slug of organization
+### Change slug of organization
 
 Slug is a unique identifier for your organization, and a URL namespace on GraphQL Hive.
 

--- a/packages/web/docs/src/pages/docs/management/sso-oidc-provider.mdx
+++ b/packages/web/docs/src/pages/docs/management/sso-oidc-provider.mdx
@@ -101,6 +101,16 @@ Your login URL will look like this:
 https://app.graphql-hive.com/auth/oidc?id=xxxxxxxx-1234-1234-1234-xxxxxxxxxxxx
 ```
 
+You can also sign in by clicking the "Login with SSO" button on the login screen. Simply enter your
+organization's slug, and you will then be redirected to your OIDC provider.
+
+<Callout type="info">
+  **Access to the organization is restricted to the OIDC accounts by default.** If you want to allow
+  users to sign in with email and password, or any other auth provider, visit your organization
+  **Settings** page and in the **OpenID Connect** configuration disable the **OIDC-Only Access**
+  option.
+</Callout>
+
 </Steps>
 
 ## Integration Guides

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1685,6 +1685,9 @@ importers:
       '@radix-ui/react-select':
         specifier: 2.1.1
         version: 2.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-separator':
+        specifier: 1.1.0
+        version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slider':
         specifier: 1.2.0
         version: 1.2.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -6327,6 +6330,19 @@ packages:
 
   '@radix-ui/react-select@2.1.1':
     resolution: {integrity: sha512-8iRDfyLtzxlprOo9IicnzvpsO1wNCkuwzzCM+Z5Rb5tNOpCdMvcc2AkzX0Fz+Tz9v6NJ5B/7EEgyZveo4FBRfQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.0':
+    resolution: {integrity: sha512-3uBAs+egzvJBDZAzvb/n4NxxOYpnspmWxO2u5NbZ8Y6FM/NdrGSF9bop3Cf6F6C71z1rTSn8KV0Fo2ZVd79lGA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -23041,6 +23057,15 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.5.7(@types/react@18.3.3)(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-separator@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.3
       '@types/react-dom': 18.3.0


### PR DESCRIPTION
When enabled (default):
- existing non-OIDC members keep their access (non-OIDC members can be removed)
- non-OIDC members can't join an organization

![Screenshot 2024-07-16 at 17 32 46](https://github.com/user-attachments/assets/44326365-e780-475c-9368-d5e4a7483541)


I will write a product update in a separate PR, otherwise it would be deployed before the feature lands in prod.