### PR TITLE
Perform local schema composition in the hive dev command

### DIFF
--- a/.changeset/bright-lobsters-smell.md
+++ b/.changeset/bright-lobsters-smell.md
@@ -2,7 +2,7 @@
 '@graphql-hive/cli': minor
 ---
 
-Changes the default behavior of `hive dev` command where schema composition is done locally, without substituting subgraphs available in the registry.
+Changes the default behavior of `hive dev` command. Now schema composition is done locally, without substituting subgraphs available in the registry.
 
 We added `--remote` flag to the `hive dev` command to mimic the previous behavior.
 

--- a/.changeset/bright-lobsters-smell.md
+++ b/.changeset/bright-lobsters-smell.md
@@ -1,0 +1,23 @@
+---
+'@graphql-hive/cli': minor
+---
+
+Changes the default behavior of `hive dev` command where schema composition is done locally, without substituting subgraphs available in the registry.
+
+We added `--remote` flag to the `hive dev` command to mimic the previous behavior.
+
+**Breaking Change**
+The `$ hive dev` command is still a work in progress (as stated in the command description).
+That's why we are not considering this a breaking change, but a minor change.
+
+**_Before:_**
+
+The `hive dev` command would substitute subgraphs available in the registry with their local counterparts, performing schema composition over the network according to your project's configuration.
+
+**_After:_**
+
+The `hive dev` command will now perform schema composition locally, without substituting subgraphs available in the registry. This is the default behavior.
+
+To mimic the previous behavior, you can apply the `--remote` flag and continue using the command as before.
+
+

--- a/integration-tests/testkit/cli.ts
+++ b/integration-tests/testkit/cli.ts
@@ -259,14 +259,20 @@ export function createCLI(tokens: { readwrite: string; readonly: string }) {
       url: string;
       sdl: string;
     }>;
+    remote: boolean;
     write?: string;
     useLatestVersion?: boolean;
   }) {
     return dev([
-      '--registry.accessToken',
-      tokens.readonly,
+      ...(input.remote
+        ? [
+            '--remote',
+            '--registry.accessToken',
+            tokens.readonly,
+            input.useLatestVersion ? '--unstable__forceLatest' : '',
+          ]
+        : []),
       input.write ? `--write ${input.write}` : '',
-      input.useLatestVersion ? '--unstable__forceLatest' : '',
       ...(await Promise.all(
         input.services.map(async ({ name, url, sdl }) => {
           return [

--- a/packages/libraries/cli/package.json
+++ b/packages/libraries/cli/package.json
@@ -57,6 +57,7 @@
     "@oclif/core": "^3.26.6",
     "@oclif/plugin-help": "6.0.22",
     "@oclif/plugin-update": "4.2.13",
+    "@theguild/federation-composition": "0.12.1",
     "colors": "1.4.0",
     "env-ci": "7.3.0",
     "graphql": "^16.8.1",

--- a/packages/libraries/cli/src/commands/dev.ts
+++ b/packages/libraries/cli/src/commands/dev.ts
@@ -101,7 +101,7 @@ export default class Dev extends Command {
     }),
     /** @deprecated */
     registry: Flags.string({
-      description: 'registry address',
+      description: 'registry address (deprecated in favor of --registry.endpoint)',
       deprecated: {
         message: 'use --registry.endpoint instead',
         version: '0.21.0',
@@ -114,7 +114,7 @@ export default class Dev extends Command {
     }),
     /** @deprecated */
     token: Flags.string({
-      description: 'api token',
+      description: 'api token (deprecated in favor of --registry.accessToken)',
       deprecated: {
         message: 'use --registry.accessToken instead',
         version: '0.21.0',

--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -16,6 +16,9 @@ export default gql`
     schemaDelete(input: SchemaDeleteInput!): SchemaDeleteResult!
     """
     Requires API Token
+
+    Publish a schema of a single or multiple services and compose a supergraph schema,
+    including the rest of the services in the project.
     """
     schemaCompose(input: SchemaComposeInput!): SchemaComposePayload!
 

--- a/packages/web/docs/src/pages/docs/api-reference/cli.mdx
+++ b/packages/web/docs/src/pages/docs/api-reference/cli.mdx
@@ -209,14 +209,21 @@ In case you want to confirm deletion of the service without typing anything in t
 
 ### Develop schema locally
 
-<Callout type="info" emoji="🔑">
-  This CLI command requires an active registry token with **Read** permissions to the target and the
-  project.
-</Callout>
+When developing subgraphs locally, you might want to compose a supergraph with your local subgraph
+changes. GraphQL Hive helps you to do that with the `hive dev` command.
 
 <Callout type="info">This action is only available for Apollo Federation projects.</Callout>
 
-This command enables you to replace the subgraph(s) available in the Registry with your local
+<details>
+
+<summary>Remote mode</summary>
+
+<Callout type="info" emoji="🔑">
+  This CLI command requires an active registry token with **Read** permissions to the target and the
+  project, to preform a composition according to your project configuration.
+</Callout>
+
+This mode enables you to replace the subgraph(s) available in the Registry with your local
 subgraph(s) and compose a Supergraph.
 
 ```mermaid
@@ -251,6 +258,59 @@ the gateway.
 
 ```bash
 # Introspect the SDL of the local service
+hive dev --remote --service reviews --url http://localhost:3001/graphql
+
+# Watch mode
+hive dev --remote --watch --service reviews --url http://localhost:3001/graphql
+
+# Provide the SDL of the local service
+hive dev --remote --service reviews --url http://localhost:3001/graphql --schema reviews.graphql
+
+# or with multiple services
+hive dev \
+  --remote \
+  --service reviews --url http://localhost:3001/graphql \
+  --service products --url http://localhost:3002/graphql --schema products.graphql
+
+# Custom output file (default: supergraph.graphql)
+hive dev --remote --service reviews --url http://localhost:3001/graphql --write local-supergraph.graphql
+```
+
+**Usage example**
+
+Let's say you have two subgraphs, `reviews` and `products`, and you want to test the `reviews`
+service.
+
+First, you need to start the `reviews` service locally and then run the following command:
+
+```bash
+hive dev --remote --watch --service reviews --url http://localhost:3001/graphql
+```
+
+This command will fetch subgraph's schema from the provided URL, replace the original `reviews`
+subgraph from the Registry with the local one, and compose a supergraph. The outcome will be saved
+in the `supergraph.graphql` file.
+
+The `products` subgraph will stay untoched, meaing that the gateway will route requests to its
+remote endpoint.
+
+> The `--watch` flag will keep the process running and update the supergraph whenever the local
+> schema changes.
+
+Now you're ready to use the `supergraph.graphql` file in your gateway and execute queries.
+
+</details>
+
+This mode enables you to compose a Supergraph with your local subgraph(s).
+
+Rather than uploading your local schema to the registry and retrieving the supergraph from the CDN,
+you can integrate your local modifications directly into the supergraph.
+
+The result of executing this command is a file containing the Supergraph SDL, which can be feed into
+the gateway.
+
+```bash
+# Introspect the SDL of the local service
 hive dev --service reviews --url http://localhost:3001/graphql
 
 # Watch mode
@@ -268,7 +328,7 @@ hive dev \
 hive dev --service reviews --url http://localhost:3001/graphql --write local-supergraph.graphql
 ```
 
-#### Usage example
+**Usage example**
 
 Let's say you have two subgraphs, `reviews` and `products`, and you want to test the `reviews`
 service.
@@ -279,12 +339,10 @@ First, you need to start the `reviews` service locally and then run the followin
 hive dev --watch --service reviews --url http://localhost:3001/graphql
 ```
 
-This command will fetch subgraph's schema from the provided URL, replace the original `reviews`
-subgraph from the Registry with the local one, and compose a supergraph. The outcome will be saved
-in the `supergraph.graphql` file.
+This command will fetch subgraph's schema from the provided URL and compose a supergraph. The
+outcome will be saved in the `supergraph.graphql` file.
 
-The `products` subgraph will stay untoched, meaing that the gateway will route requests to its
-remote endpoint.
+The `products` subgraph will be omitted from the supergraph.
 
 > The `--watch` flag will keep the process running and update the supergraph whenever the local
 > schema changes.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -409,6 +409,9 @@ importers:
       '@oclif/plugin-update':
         specifier: 4.2.13
         version: 4.2.13
+      '@theguild/federation-composition':
+        specifier: 0.12.1
+        version: 0.12.1(graphql@16.9.0)
       colors:
         specifier: 1.4.0
         version: 1.4.0


### PR DESCRIPTION
Closes #5113

Changes the default behavior of `hive dev` command. Now schema composition is done locally, without substituting subgraphs available in the registry.

I added `--remote` flag to the `hive dev` command to mimic the previous behavior.

The `$ hive dev` command was marked as "work in progress" (stated in the command description).
That's why I'm are not considering this a breaking change, but a minor change.

**_Before:_**

The `hive dev` command would substitute subgraphs available in the registry with their local counterparts, performing schema composition over the network according to your project's configuration.

**_After:_**

The `hive dev` command will now perform schema composition locally, without substituting subgraphs available in the registry. This is the default behavior.

To mimic the previous behavior, a user can apply the `--remote` flag and continue using the command as before.

---

- [ ] test `dependsOn` oclif options