### PR TITLE
Pin node to v22.4 in release-alpha.yaml

### DIFF
--- a/.github/workflows/release-alpha.yaml
+++ b/.github/workflows/release-alpha.yaml
@@ -8,7 +8,7 @@ jobs:
     with:
       npmTag: alpha
       buildScript: build:libraries
-      nodeVersion: 22
+      nodeVersion: '22.4'
       packageManager: pnpm
     secrets:
       githubToken: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Same reason as in #5246

The snapshot release pipeline is broken.