### PR TITLE
Double precision traffic percentage in Conditional Breaking Changes

### DIFF
--- a/packages/services/api/src/modules/target/validation.ts
+++ b/packages/services/api/src/modules/target/validation.ts
@@ -2,4 +2,4 @@ import { z } from 'zod';
 import { NameModel } from '../../shared/entities';
 
 export const TargetNameModel = NameModel.min(2).max(30);
-export const PercentageModel = z.number().min(0).max(100);
+export const PercentageModel = z.number().min(0).max(100).step(0.01);

--- a/packages/web/app/src/pages/target-settings.tsx
+++ b/packages/web/app/src/pages/target-settings.tsx
@@ -505,6 +505,15 @@ const ConditionalBreakingChanges = (props: {
       period: Yup.number()
         .min(1)
         .max(targetSettings.data?.organization?.organization?.rateLimit.retentionInDays ?? 30)
+        .test('double-precision', 'Invalid precision', num => {
+          if (typeof num !== 'number') {
+            return false;
+          }
+
+          // Round the number to two decimal places
+          // and check if it is equal to the original number
+          return Number(num.toFixed(2)) === num;
+        })
         .required(),
       targets: Yup.array().of(Yup.string()).min(1),
       excludedClients: Yup.array().of(Yup.string()),
@@ -591,6 +600,7 @@ const ConditionalBreakingChanges = (props: {
               type="number"
               min="0"
               max="100"
+              step={0.01}
               className="mx-2 !inline-flex !w-16"
             />
             % of traffic in the past


### PR DESCRIPTION
In some cases 1% of not enough, this PR enables 0.01% precision.

- [ ] add an integration test