### PR TITLE
chore: allow more memory for clickhouse

### DIFF
--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -74,7 +74,7 @@ services:
 
   clickhouse:
     image: clickhouse/clickhouse-server:24.4-alpine
-    mem_limit: 500m
+    mem_limit: 2048m
     environment:
       CLICKHOUSE_USER: test
       CLICKHOUSE_PASSWORD: test


### PR DESCRIPTION
### Background

After applying the constraints from https://github.com/kamilkisiela/graphql-hive/pull/5177 I constantly see ClickHouse crashing and running OOM locally.

### Description

Just bumps the constraints to a value that works for me. 1gb seems to be not enough. I still encountered a lot of crashes.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
