### PR TITLE
feat: upload persisted documents from app to R2

### DIFF
--- a/.github/workflows/build-and-dockerize.yaml
+++ b/.github/workflows/build-and-dockerize.yaml
@@ -79,6 +79,16 @@ jobs:
           file: ${{ github.workspace }}/${{ inputs.imageTag }}.zip
           destination: ${{ inputs.imageTag }}.zip
 
+      - name: upload app persisted documents artifact
+        uses: randomairborne/r2-release@v1.0.2
+        with:
+          endpoint: https://6d5bc18cd8d13babe7ed321adba3d8ae.r2.cloudflarestorage.com
+          accesskeyid: ${{ secrets.R2_ACCESS_KEY_ID }}
+          secretaccesskey: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          bucket: hive-js-build-artifacts
+          file: ${{ github.workspace }}/packages/web/app/src/gql/persisted-documents.json
+          destination: ${{ inputs.imageTag }}.app.documents.json
+
       - name: configure eqemu
         if: ${{ inputs.dockerize }}
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
### Background

Let's start uploading the persisted documents to r2, so we can access them from within our deployment pipeline for publishing them to Hive. This is a pre-requisite for https://github.com/kamilkisiela/graphql-hive/pull/4866

### Description

−

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
