### PR TITLE
chore: app operation check command

### DIFF
--- a/.github/workflows/graphql-app-document-check.yaml
+++ b/.github/workflows/graphql-app-document-check.yaml
@@ -1,0 +1,19 @@
+on:
+  workflow_call:
+    secrets:
+      hiveToken:
+jobs:
+  graphql-app-deployment-check:
+    name: GraphQL App Deployment Check
+    runs-on: ubuntu-22.04
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+      - name: install Hive CLI
+        run: |
+          curl -sSL https://graphql-hive.com/install.sh | sh
+      - name: check documents
+        env:
+          HIVE_TOKEN: ${{ secrets.hiveToken }}
+        run: |
+          hive operations:check "./packages/web/app/src/(components|lib|pages)/**/*.ts(x)?" --globalGraphqlTag graphql

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -69,6 +69,12 @@ jobs:
   static-analysis:
     uses: ./.github/workflows/codeql-analysis.yml
 
+  # GraphQL App Document Check
+  graphql-app-document-check:
+    uses: ./.github/workflows/graphql-app-document-check.yaml
+    secrets:
+      hiveToken: ${{ secrets.HIVE_TOKEN }}
+
   # TypeScript Typecheck and compiler checks
   typescript:
     uses: ./.github/workflows/typescript-typecheck.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -129,7 +129,6 @@ packages/web/app/next.config.mjs
 packages/web/app/environment-*.mjs
 packages/web/app/src/gql/*.ts
 packages/web/app/src/gql/*.json
-packages/web/app/src/graphql/*.ts
 packages/web/docs/public/feed.xml
 # Changelog
 packages/web/app/src/components/ui/changelog/generated-changelog.ts

--- a/codegen.mts
+++ b/codegen.mts
@@ -200,7 +200,6 @@ const config: CodegenConfig = {
     './packages/web/app/src/gql/': {
       documents: [
         './packages/web/app/src/(components|lib|pages)/**/*.ts(x)?',
-        './packages/web/app/src/graphql',
         '!./packages/web/app/src/server/**/*.ts',
       ],
       preset: 'client',


### PR DESCRIPTION
### Background

Prerequisite for using app deployments on Hive app in a safe way.

### Description

App deployments require that the documents that will be published to an app deployment are valid against the latest valid schema version within Hive.

This also affects our Hive app. If we try publishing a GraphQL document during the deployment that uses a field not yet available in the Hive schema, the deployment process would fail.

A PR branch should use the `hive operations:check` command to ensure that merging a PR would not break the persisted document upload.

For contributors to Hive, this will now require people to split up changes that alter both the GraphQL API schema and app documents into separate pull requests.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
