### PR TITLE
feat: skip app publish if app is active

### DIFF
--- a/packages/services/api/src/modules/app-deployments/module.graphql.ts
+++ b/packages/services/api/src/modules/app-deployments/module.graphql.ts
@@ -196,6 +196,10 @@ export default gql`
 
   type ActivateAppDeploymentOk {
     activatedAppDeployment: AppDeployment!
+    """
+    Whether the app deployment activation was skipped because it is already activated.
+    """
+    isSkipped: Boolean!
   }
 
   type ActivateAppDeploymentResult {

--- a/packages/services/api/src/modules/app-deployments/providers/app-deployments.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/app-deployments.ts
@@ -365,13 +365,26 @@ export class AppDeployments {
       };
     }
 
-    if (appDeployment.activatedAt !== null) {
+    if (appDeployment.retiredAt !== null) {
       this.logger.debug(
-        'activate app deployment failed as it is already active. (targetId=%s, appName=%s, appVersion=%s)',
+        'app deployment is already retired. (targetId=%s, appName=%s, appVersion=%s)',
       );
+
       return {
         type: 'error' as const,
-        message: 'App deployment is already active',
+        message: 'App deployment is retired',
+      };
+    }
+
+    if (appDeployment.activatedAt !== null) {
+      this.logger.debug(
+        'app deployment is already active. (targetId=%s, appName=%s, appVersion=%s)',
+      );
+
+      return {
+        type: 'success' as const,
+        isSkipped: true,
+        appDeployment,
       };
     }
 
@@ -443,6 +456,7 @@ export class AppDeployments {
 
     return {
       type: 'success' as const,
+      isSkipped: false,
       appDeployment: updatedAppDeployment,
     };
   }

--- a/packages/services/api/src/modules/app-deployments/resolvers/Mutation/activateAppDeployment.ts
+++ b/packages/services/api/src/modules/app-deployments/resolvers/Mutation/activateAppDeployment.ts
@@ -23,6 +23,7 @@ export const activateAppDeployment: NonNullable<
   return {
     error: null,
     ok: {
+      isSkipped: result.isSkipped,
       activatedAppDeployment: result.appDeployment,
     },
   };


### PR DESCRIPTION
### Background

Publishing an app deployment that is already active should not fail by default for unblocking rollbacks within CD pipelines.

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
