### PR TITLE
chore: publish graphql schema as pulumni action

### DIFF
--- a/.github/workflows/build-and-dockerize.yaml
+++ b/.github/workflows/build-and-dockerize.yaml
@@ -89,6 +89,16 @@ jobs:
           file: ${{ github.workspace }}/packages/web/app/src/gql/persisted-documents.json
           destination: ${{ inputs.imageTag }}.app.documents.json
 
+      - name: upload graphql schema
+        uses: randomairborne/r2-release@v1.0.2
+        with:
+          endpoint: https://6d5bc18cd8d13babe7ed321adba3d8ae.r2.cloudflarestorage.com
+          accesskeyid: ${{ secrets.R2_ACCESS_KEY_ID }}
+          secretaccesskey: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          bucket: hive-js-build-artifacts
+          file: ${{ github.workspace }}/schema.graphql
+          destination: ${{ inputs.imageTag }}.schema.graphqls
+
       - name: configure eqemu
         if: ${{ inputs.dockerize }}
         uses: docker/setup-qemu-action@v3

--- a/deployment/index.ts
+++ b/deployment/index.ts
@@ -41,6 +41,14 @@ const imagesTag = process.env.DOCKER_IMAGE_TAG as string;
 if (!imagesTag) {
   throw new Error(`DOCKER_IMAGE_TAG env variable is not set.`);
 }
+
+// eslint-disable-next-line no-process-env
+const graphqlSchemaAbsolutePath = process.env.GRAPHQL_SCHEMA_ABSOLUTE_PATH as string;
+
+if (!graphqlSchemaAbsolutePath) {
+  throw new Error(`GRAPHQL_SCHEMA_ABSOLUTE_PATH env variable is not set.`);
+}
+
 // eslint-disable-next-line no-process-env
 let HIVE_APP_USE_PERSISTED_DOCUMENTS = process.env.HIVE_APP_USE_PERSISTED_DOCUMENTS;
 
@@ -248,6 +256,7 @@ publishGraphQLSchema({
   version: {
     commit: imagesTag,
   },
+  schemaPath: graphqlSchemaAbsolutePath,
 });
 
 const app = deployApp({

--- a/deployment/index.ts
+++ b/deployment/index.ts
@@ -33,6 +33,7 @@ import { deployWebhooks } from './services/webhooks';
 import { configureZendesk } from './services/zendesk';
 import { optimizeAzureCluster } from './utils/azure-helpers';
 import { isDefined } from './utils/helpers';
+import { publishGraphQLSchema } from './utils/publish-graphql-schema';
 
 // eslint-disable-next-line no-process-env
 const imagesTag = process.env.DOCKER_IMAGE_TAG as string;
@@ -233,6 +234,20 @@ const graphql = deployGraphQL({
   githubApp,
   sentry,
   observability,
+});
+
+const apiConfig = new pulumi.Config('api');
+const apiEnv = apiConfig.requireObject<Record<string, string>>('env');
+
+publishGraphQLSchema({
+  graphql,
+  registry: {
+    endpoint: `https://${environment.appDns}/registry`,
+    accessToken: apiEnv.HIVE_API_TOKEN,
+  },
+  version: {
+    commit: imagesTag,
+  },
 });
 
 const app = deployApp({

--- a/deployment/package.json
+++ b/deployment/package.json
@@ -9,6 +9,7 @@
     "@lbrlabs/pulumi-grafana": "0.1.0",
     "@manypkg/get-packages": "2.2.2",
     "@pulumi/cloudflare": "4.16.0",
+    "@pulumi/command": "1.0.1",
     "@pulumi/kubernetes": "4.14.0",
     "@pulumi/kubernetesx": "0.1.6",
     "@pulumi/pulumi": "3.122.0",

--- a/deployment/services/app.ts
+++ b/deployment/services/app.ts
@@ -1,5 +1,4 @@
 import * as pulumi from '@pulumi/pulumi';
-import { Observability } from '../services/observability';
 import { serviceLocalEndpoint } from '../utils/local-endpoint';
 import { ServiceDeployment } from '../utils/service-deployment';
 import { StripeBilling } from './billing';

--- a/deployment/utils/publish-graphql-schema.ts
+++ b/deployment/utils/publish-graphql-schema.ts
@@ -12,13 +12,13 @@ export function publishGraphQLSchema(args: {
   const command =
     `schema:publish` +
     ` --registry.endpoint ${args.registry.endpoint} --registry.accessToken ${args.registry.accessToken}` +
-    ` --commit ${args.version.commit} --author "Hive CD" /schema.graphqls`;
+    ` --commit ${args.version.commit} --author "Hive CD" ./schema.graphqls`;
 
   return new local.Command(
     'publish-graphql-schema',
     {
       create:
-        `docker run --name "publish-graphql-schema" -v ./schema.graphqls:/schema.graphqls ghcr.io/kamilkisiela/graphql-hive/cli:0.36.0 ` +
+        `docker run --name "publish-graphql-schema" -v ./schema.graphqls:/usr/src/app/schema.graphqls ghcr.io/kamilkisiela/graphql-hive/cli:0.36.0 ` +
         command,
     },
     {

--- a/deployment/utils/publish-graphql-schema.ts
+++ b/deployment/utils/publish-graphql-schema.ts
@@ -10,14 +10,15 @@ export function publishGraphQLSchema(args: {
   };
 }) {
   const command =
+    `schema:publish` +
     ` --registry.endpoint ${args.registry.endpoint} --registry.accessToken ${args.registry.accessToken}` +
-    ` schema:publish --commit ${args.version.commit} --author "Hive CD" ./schema.graphql`;
+    ` --commit ${args.version.commit} --author "Hive CD" /schema.graphqls`;
 
   return new local.Command(
     'publish-graphql-schema',
     {
       create:
-        `docker run --name "publish-graphql-schema" ghcr.io/kamilkisiela/graphql-hive/cli:0.36.0 ` +
+        `docker run --name "publish-graphql-schema" -v ./schema.graphqls:/schema.graphqls ghcr.io/kamilkisiela/graphql-hive/cli:0.36.0 ` +
         command,
     },
     {

--- a/deployment/utils/publish-graphql-schema.ts
+++ b/deployment/utils/publish-graphql-schema.ts
@@ -1,0 +1,27 @@
+import { local } from '@pulumi/command';
+import type { GraphQL } from '../services/graphql';
+
+/** Publish API GraphQL schema to Hive schema registry. */
+export function publishGraphQLSchema(args: {
+  graphql: GraphQL;
+  registry: { accessToken: string; endpoint: string };
+  version: {
+    commit: string;
+  };
+}) {
+  const command =
+    ` --registry.endpoint ${args.registry.endpoint} --registry.accessToken ${args.registry.accessToken}` +
+    ` schema:publish --commit ${args.version.commit} --author "Hive CD" ./schema.graphql`;
+
+  return new local.Command(
+    'publish-graphql-schema',
+    {
+      create:
+        `docker run --name "publish-graphql-schema" ghcr.io/kamilkisiela/graphql-hive/cli:0.36.0 ` +
+        command,
+    },
+    {
+      dependsOn: [args.graphql.deployment, args.graphql.service],
+    },
+  );
+}

--- a/deployment/utils/publish-graphql-schema.ts
+++ b/deployment/utils/publish-graphql-schema.ts
@@ -8,6 +8,7 @@ export function publishGraphQLSchema(args: {
   version: {
     commit: string;
   };
+  schemaPath: string;
 }) {
   const command =
     `schema:publish` +
@@ -18,7 +19,7 @@ export function publishGraphQLSchema(args: {
     'publish-graphql-schema',
     {
       create:
-        `docker run --name "publish-graphql-schema" -v ./schema.graphqls:/usr/src/app/schema.graphqls ghcr.io/kamilkisiela/graphql-hive/cli:0.36.0 ` +
+        `docker run --name "publish-graphql-schema" -v ${args.schemaPath}:/usr/src/app/schema.graphqls ghcr.io/kamilkisiela/graphql-hive/cli:0.36.0 ` +
         command,
     },
     {

--- a/packages/services/server/src/graphql-handler.ts
+++ b/packages/services/server/src/graphql-handler.ts
@@ -181,11 +181,6 @@ export const graphqlHandler = (options: GraphQLHandlerOptions): RouteHandlerMeth
           },
           exclude: ['readiness'],
         },
-        reporting: {
-          endpoint: options.hiveConfig?.reporting?.endpoint ?? undefined,
-          author: 'Hive API',
-          commit: options.release,
-        },
         experimental__persistedDocuments: options.hivePersistedDocumentsConfig
           ? {
               cdn: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,9 @@ importers:
       '@pulumi/cloudflare':
         specifier: 4.16.0
         version: 4.16.0(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.11))(@types/node@20.14.10)(typescript@5.5.3))(typescript@5.5.3)
+      '@pulumi/command':
+        specifier: 1.0.1
+        version: 1.0.1(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.11))(@types/node@20.14.10)(typescript@5.5.3))(typescript@5.5.3)
       '@pulumi/kubernetes':
         specifier: 4.14.0
         version: 4.14.0(encoding@0.1.13)(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.11))(@types/node@20.14.10)(typescript@5.5.3))(typescript@5.5.3)
@@ -4015,6 +4018,7 @@ packages:
 
   '@fastify/vite@6.0.7':
     resolution: {integrity: sha512-+dRo9KUkvmbqdmBskG02SwigWl06Mwkw8SBDK1zTNH6vd4DyXbRvI7RmJEmBkLouSU81KTzy1+OzwHSffqSD6w==}
+    bundledDependencies: []
 
   '@floating-ui/core@1.2.6':
     resolution: {integrity: sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==}
@@ -5911,6 +5915,9 @@ packages:
 
   '@pulumi/cloudflare@4.16.0':
     resolution: {integrity: sha512-cwdB70bLeKL/VNIqqOD5fpHQcocVmpHuiHH589eR+QUfbLa4f+M8yA/TTCcxx2AFFctTqO5wgVuC+faL8xZmWQ==}
+
+  '@pulumi/command@1.0.1':
+    resolution: {integrity: sha512-PqqcMp80Y9dc7Lt0epXqvqha76S4XF08NB8lpMA0zJ9zWvkkssQ8lq8XdHuZOrAGHXj7gKBs6JBrhhltoovUTQ==}
 
   '@pulumi/kubernetes@4.14.0':
     resolution: {integrity: sha512-q3xwRJYx4hJpvpLboCZeyncqfzGtTVZ6zGEk4aZQ3jmbUUkIP8hYi1EkUedjtyjw9xtWch5Zb1s+PZgqXz9l3w==}
@@ -22508,6 +22515,15 @@ snapshots:
   '@protobufjs/utf8@1.1.0': {}
 
   '@pulumi/cloudflare@4.16.0(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.11))(@types/node@20.14.10)(typescript@5.5.3))(typescript@5.5.3)':
+    dependencies:
+      '@pulumi/pulumi': 3.122.0(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.11))(@types/node@20.14.10)(typescript@5.5.3))(typescript@5.5.3)
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+      - ts-node
+      - typescript
+
+  '@pulumi/command@1.0.1(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.11))(@types/node@20.14.10)(typescript@5.5.3))(typescript@5.5.3)':
     dependencies:
       '@pulumi/pulumi': 3.122.0(ts-node@10.9.2(@swc/core@1.6.13(@swc/helpers@0.5.11))(@types/node@20.14.10)(typescript@5.5.3))(typescript@5.5.3)
     transitivePeerDependencies:


### PR DESCRIPTION
### Background

It is not recommended that the GraphQL schema be published from the actual service. Instead, we want to do it within the CD pipeline.

### Description

- Upload schema.graphql to R2
- Use CLI docker container for publishing schema after API has been deployed
- Stop publishing schema from within the service

Internal deployment counter-part: https://github.com/the-guild-org/graphql-hive-deployment/pull/1413

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
