### PR TITLE
chore: publish CLI docker images for alpha versions 

### DIFF
--- a/.github/workflows/dockerize-cli.yaml
+++ b/.github/workflows/dockerize-cli.yaml
@@ -1,0 +1,74 @@
+on:
+  workflow_call:
+    inputs:
+      registry:
+        default: ghcr.io
+        type: string
+      imageName:
+        default: ${{ github.repository }}
+        type: string
+      cliVersion:
+        required: true
+        type: string
+
+jobs:
+  build-cli-docker-image:
+    name: Build CLI Docker Image
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: write
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: configure eqemu
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: 'linux/arm64,linux/amd64'
+      - name: configure docker buildx
+        uses: docker/setup-buildx-action@v3
+      - name: login to docker registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ inputs.registry }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Prepare Bake inputs
+        id: docker-bake-inputs
+        run: |
+          targets=$(docker buildx bake -f docker/docker.hcl --print build | jq -r '.group.build.targets[]')
+          input_set=""
+          first=0
+
+          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
+
+          echo "set<<$EOF" >> "$GITHUB_ENV"
+          for target in $targets
+          do
+              echo "$target.cache-from=type=gha,ignore-error=true,scope=$GITHUB_REF-$target" >> "$GITHUB_ENV"
+              echo "$target.cache-to=type=gha,ignore-error=true,mode=max,scope=$GITHUB_REF-$target" >> "$GITHUB_ENV"
+          done
+          echo "$EOF" >> "$GITHUB_ENV"
+
+      - name: build docker images
+        timeout-minutes: 360
+        id: docker-bake
+        uses: docker/bake-action@v5
+        env:
+          DOCKER_REGISTRY: ${{ inputs.registry }}/${{ inputs.imageName }}/
+          COMMIT_SHA: ${{ inputs.cliVersion }}
+          RELEASE: ${{ inputs.cliVersion }}
+          BUILD_TYPE: 'publish'
+          PWD: ${{ github.workspace }}
+        with:
+          # See https://github.com/docker/buildx/issues/1533
+          provenance: false
+          push: true
+          files: docker/docker.hcl
+          targets: cli
+          set: |
+            ${{ steps.docker-bake-inputs.outputs.set }}

--- a/.github/workflows/release-alpha.yaml
+++ b/.github/workflows/release-alpha.yaml
@@ -108,3 +108,30 @@ jobs:
           tar -xzf *.tar.gz
           # Expect the command to succeed
           ./hive/bin/hive --version || exit 1
+
+  extract-cli-version:
+    needs: [npm]
+    runs-on: ubuntu-22.04
+    name: Extract CLI version
+    outputs:
+      published: ${{ steps.cli.outputs.published }}
+      version: ${{ steps.cli.outputs.version }}
+    steps:
+      - name: Extract published version
+        if:
+          needs.npm.outputs.published && contains(needs.npm.outputs.publishedPackages,
+          '"@graphql-hive/cli"')
+        id: cli
+        run: |
+          echo '${{needs.npm.outputs.publishedPackages}}' > cli-ver.json
+          VERSION=`echo $(jq -r '.[] | select(.name | endswith("@graphql-hive/cli")).version' cli-ver.json)`
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "published=true" >> "$GITHUB_OUTPUT"
+
+  publish_docker:
+    needs: [extract-cli-version]
+    uses: ./.github/workflows/dockerize-cli.yaml
+    if: ${{ needs.extract-cli-version.outputs.published == 'true' }}
+    with:
+      cliVersion: ${{ needs.extract-cli-version.outputs.version }}
+    secrets: inherit

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -80,14 +80,9 @@ jobs:
         run: pnpm oclif promote --no-xz --sha ${GITHUB_SHA:0:7} --version $VERSION
 
   publish_docker:
-    needs: publish
-    uses: ./.github/workflows/build-and-dockerize.yaml
-    if: needs.publish.outputs.publish == 'true'
+    needs: [publish]
+    uses: ./.github/workflows/dockerize-cli.yaml
+    if: ${{ needs.publish.outputs.publish == 'true' }}
     with:
-      imageTag: ${{ needs.publish.outputs.version }}
-      publishSourceMaps: false
-      publishLatest: true
-      publishPrComment: false
-      targets: cli
-      uploadJavaScriptArtifacts: false
+      cliVersion: ${{ needs.publish.outputs.version }}
     secrets: inherit

--- a/docker/cli.dockerfile
+++ b/docker/cli.dockerfile
@@ -2,13 +2,11 @@ FROM node:22.4.1-slim
 
 RUN apt-get update && apt-get install -y ca-certificates
 
+ARG CLI_VERSION
+
 WORKDIR /usr/src/app
 
-COPY package.json /usr/src/app
-
-RUN npm install --omit=dev
-
-COPY . /usr/src/app/
+RUN npm install --global @graphql-hive/cli@${CLI_VERSION}
 
 LABEL org.opencontainers.image.title=$IMAGE_TITLE
 LABEL org.opencontainers.image.version=$RELEASE
@@ -20,6 +18,6 @@ LABEL org.opencontainers.image.source="https://github.com/kamilkisiela/graphql-h
 
 ENV ENVIRONMENT production
 ENV RELEASE $RELEASE
-RUN npx . --version
+RUN hive --version
 
-ENTRYPOINT ["npx", "."]
+ENTRYPOINT ["hive"]

--- a/docker/docker.hcl
+++ b/docker/docker.hcl
@@ -405,6 +405,8 @@ target "cli" {
   args = {
     IMAGE_TITLE = "graphql-hive/cli"
     IMAGE_DESCRIPTION = "GraphQL Hive CLI"
+    # note that for CLI we always pass the npm version ! ! !
+    CLI_VERSION = "${COMMIT_SHA}"
   }
   tags = [
     local_image_tag("cli"),


### PR DESCRIPTION
### Background

Having docker images for alpha releases is nice and we want to use them within our pulumi deployment script for pending features.

### Description

This publishes a docker image with the same tag as the snapshot release listed version.

```
docker run ghcr.io/kamilkisiela/graphql-hive/cli:0.39.0-alpha-20240724164620-5e8722409ceed454769143c20c0b52bbd2fa50b4 \
  --version
@graphql-hive/cli/0.39.0-alpha-20240724164620-5e8722409ceed454769143c20c0b52bbd2fa50b4 linux-arm64 node-v22.4.1
```

~~Problem here is that `--version` shows the wrong version. I think we should change the docker step to use `npm install --global @graphql-hive/cli@version`.~~ Fixed since we now `npm install` the version within the image.


### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
