### PR TITLE
Hide punycode deprecation warning in CLI

### DIFF
--- a/packages/libraries/cli/bin/dev
+++ b/packages/libraries/cli/bin/dev
@@ -1,4 +1,7 @@
-#!/usr/bin/env tsx --no-deprecation
+#!/usr/bin/env tsx
+
+// Suppress warnings from the CLI
+process.removeAllListeners('warning');
 
 const oclif = require('@oclif/core');
 

--- a/packages/libraries/cli/bin/dev
+++ b/packages/libraries/cli/bin/dev
@@ -1,4 +1,4 @@
-#!/usr/bin/env tsx
+#!/usr/bin/env tsx --no-deprecation
 
 const oclif = require('@oclif/core');
 

--- a/packages/libraries/cli/bin/dev.cmd
+++ b/packages/libraries/cli/bin/dev.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-node "%~dp0\dev" %*
+node --no-deprecation "%~dp0\dev" %*

--- a/packages/libraries/cli/bin/run
+++ b/packages/libraries/cli/bin/run
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --no-deprecation
 
 const oclif = require('@oclif/core');
 

--- a/packages/libraries/cli/bin/run
+++ b/packages/libraries/cli/bin/run
@@ -1,4 +1,7 @@
-#!/usr/bin/env node --no-deprecation
+#!/usr/bin/env node
+
+// Suppress warnings from the CLI
+process.removeAllListeners('warning');
 
 const oclif = require('@oclif/core');
 

--- a/packages/libraries/cli/bin/run.cmd
+++ b/packages/libraries/cli/bin/run.cmd
@@ -1,3 +1,3 @@
 @echo off
 
-node "%~dp0\run" %*
+node --no-deprecation "%~dp0\run" %*

--- a/packages/libraries/cli/package.json
+++ b/packages/libraries/cli/package.json
@@ -87,6 +87,11 @@
       "@oclif/plugin-update"
     ],
     "update": {
+      "node": {
+        "options": [
+          "--no-deprecation"
+        ]
+      },
       "s3": {
         "host": "https://cli.graphql-hive.com/",
         "bucket": "graphql-hive-cli"


### PR DESCRIPTION
It's sub sub sub dependency and from a CLI perspective, it's really not relevant.