### PR TITLE
fix: do not log initiated requests and successful responses

### DIFF
--- a/.changeset/wild-horses-swim.md
+++ b/.changeset/wild-horses-swim.md
@@ -1,0 +1,8 @@
+---
+'@graphql-hive/apollo': patch
+'@graphql-hive/core': patch
+'@graphql-hive/yoga': patch
+'@graphql-hive/cli': patch
+---
+
+Fixed a logging issue where both initiated requests and successful responses were being recorded. This was causing the logs to be filled with unnecessary information and affected `hive artifact:fetch --artifact` command.

--- a/packages/libraries/apollo/src/version.ts
+++ b/packages/libraries/apollo/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.33.4';
+export const version = '0.34.0';

--- a/packages/libraries/core/src/client/http-client.ts
+++ b/packages/libraries/core/src/client/http-client.ts
@@ -18,7 +18,7 @@ interface SharedConfig {
   /**
    * Function for determining whether the request response is okay.
    * You can override it if you want to accept other status codes as well.
-   * @default {response => response.ok}
+   * @default (response) => response.ok
    **/
   isRequestOk?: ResponseAssertFunction;
 }
@@ -75,7 +75,7 @@ export async function makeFetchCall(
     /**
      * Function for determining whether the request response is okay.
      * You can override it if you want to accept other status codes as well.
-     * @default {response => response.ok}
+     * @default (response) => response.ok
      **/
     isRequestOk?: ResponseAssertFunction;
   },
@@ -96,11 +96,6 @@ export async function makeFetchCall(
 
   return await asyncRetry(
     async (bail, attempt) => {
-      logger.info(
-        `${config.method} ${endpoint}` +
-          (retries > 0 ? ' ' + getAttemptMessagePart(attempt, retries + 1) : ''),
-      );
-
       const getDuration = measureTime();
       const signal = AbortSignal.timeout(config.timeout ?? 20_000);
 
@@ -130,10 +125,6 @@ export async function makeFetchCall(
       });
 
       if (isRequestOk(response)) {
-        logger.info(
-          `${config.method} ${endpoint} succeeded with status ${response.status} ${getDuration()}.`,
-        );
-
         return response;
       }
 

--- a/packages/libraries/core/src/client/http-client.ts
+++ b/packages/libraries/core/src/client/http-client.ts
@@ -167,10 +167,6 @@ function getErrorMessage(error: unknown): string {
   return '<no error message>';
 }
 
-function getAttemptMessagePart(attempt: number, retry: number): string {
-  return `Attempt (${attempt}/${retry})`;
-}
-
 function measureTime() {
   const start = Date.now();
   return () => '(' + formatTimestamp(Date.now() - start) + ')';

--- a/packages/libraries/core/src/version.ts
+++ b/packages/libraries/core/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.5.0';
+export const version = '0.6.0';

--- a/packages/libraries/core/tests/http-client.spec.ts
+++ b/packages/libraries/core/tests/http-client.spec.ts
@@ -15,7 +15,6 @@ test('HTTP call without retries and system level error', async () => {
   }
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
-    [INF] GET https://ap.localhost.noop
     [ERR] Error: getaddrinfo ENOTFOUND ap.localhost.noop
     [ERR] GET https://ap.localhost.noop failed (666ms). getaddrinfo ENOTFOUND ap.localhost.noop
   `);
@@ -33,10 +32,8 @@ test('HTTP with retries and system', async () => {
   }).catch(_ => {});
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
-    [INF] GET https://ap.localhost.noop Attempt (1/2)
     [ERR] Error: getaddrinfo ENOTFOUND ap.localhost.noop
     [ERR] GET https://ap.localhost.noop failed (666ms). getaddrinfo ENOTFOUND ap.localhost.noop
-    [INF] GET https://ap.localhost.noop Attempt (2/2)
     [ERR] Error: getaddrinfo ENOTFOUND ap.localhost.noop
     [ERR] GET https://ap.localhost.noop failed (666ms). getaddrinfo ENOTFOUND ap.localhost.noop
   `);
@@ -60,7 +57,6 @@ test('HTTP with 4xx status code will not be retried', async () => {
   }).catch(_ => {});
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
-    [INF] GET https://ap.localhost.noop Attempt (1/2)
     [ERR] GET https://ap.localhost.noop failed with status 404 (666ms): Bubatzbieber
     [ERR] Abort retry because of status code 404.
   `);
@@ -85,9 +81,7 @@ test('HTTP with 5xx status code will be retried', async () => {
   }).catch(_ => {});
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
-    [INF] GET https://ap.localhost.noop Attempt (1/2)
     [ERR] GET https://ap.localhost.noop failed with status 500 (666ms): Bubatzbieber
-    [INF] GET https://ap.localhost.noop Attempt (2/2)
     [ERR] GET https://ap.localhost.noop failed with status 500 (666ms): Bubatzbieber
     [ERR] GET https://ap.localhost.noop retry limit exceeded after 2 attempts.
   `);
@@ -112,9 +106,7 @@ test('HTTP with status 3xx will be retried', async () => {
   }).catch(_ => {});
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
-    [INF] GET https://ap.localhost.noop Attempt (1/2)
     [ERR] GET https://ap.localhost.noop failed with status 302 (666ms): Bubatzbieber
-    [INF] GET https://ap.localhost.noop Attempt (2/2)
     [ERR] GET https://ap.localhost.noop failed with status 302 (666ms): Bubatzbieber
     [ERR] GET https://ap.localhost.noop retry limit exceeded after 2 attempts.
   `);
@@ -139,8 +131,6 @@ test('HTTP with status 3xx will not be retried with custom "isRequestOk" impleme
     isRequestOk: response => response.status === 302,
   }).catch(_ => {});
 
-  expect(logger.getLogs()).toMatchInlineSnapshot(`
-    [INF] GET https://ap.localhost.noop Attempt (1/2)
-    [INF] GET https://ap.localhost.noop succeeded with status 302 (666ms).
-  `);
+  // Make sure that the 3xx status code is not retried.
+  expect(logger.getLogs()).toMatchInlineSnapshot(``);
 });

--- a/packages/libraries/core/tests/reporting.spec.ts
+++ b/packages/libraries/core/tests/reporting.spec.ts
@@ -50,7 +50,6 @@ test('should not leak the exception', async () => {
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][reporting] Publish schema
-    [INF] [hive][reporting] POST http://127.0.0.1:55404 Attempt (1/6)
     [ERR] [hive][reporting] Error: connect ECONNREFUSED 127.0.0.1:55404
     [ERR] [hive][reporting]     at TCPConnectWrap.afterConnect [as oncomplete] (node:net:666:666)
     [ERR] [hive][reporting] POST http://127.0.0.1:55404 failed (666ms). connect ECONNREFUSED 127.0.0.1:55404
@@ -125,8 +124,6 @@ test('should send data to Hive', async () => {
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][reporting] Publish schema
-    [INF] [hive][reporting] POST http://localhost/200 Attempt (1/6)
-    [INF] [hive][reporting] POST http://localhost/200 succeeded with status 200 (666ms).
     [INF] [hive][reporting] Published schema
   `);
 });
@@ -198,8 +195,6 @@ test('should send data to Hive (deprecated endpoint)', async () => {
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][reporting] Publish schema
-    [INF] [hive][reporting] POST http://localhost/200 Attempt (1/6)
-    [INF] [hive][reporting] POST http://localhost/200 succeeded with status 200 (666ms).
     [INF] [hive][reporting] Published schema
   `);
 
@@ -273,8 +268,6 @@ test('should send data to app.graphql-hive.com/graphql by default', async () => 
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][reporting] Publish schema
-    [INF] [hive][reporting] POST https://app.graphql-hive.com/graphql Attempt (1/6)
-    [INF] [hive][reporting] POST https://app.graphql-hive.com/graphql succeeded with status 200 (666ms).
     [INF] [hive][reporting] Published schema
   `);
 
@@ -348,11 +341,9 @@ test('should send data to Hive immediately', async () => {
   expect(logger.getLogs()).toMatchInlineSnapshot(`[INF] [hive][reporting] Publish schema`);
   logger.clear();
   await waitFor(50);
-  expect(logger.getLogs()).toMatchInlineSnapshot(`
-    [INF] [hive][reporting] POST http://localhost/200 Attempt (1/6)
-    [INF] [hive][reporting] POST http://localhost/200 succeeded with status 200 (666ms).
-    [INF] [hive][reporting] Successfully published schema
-  `);
+  expect(logger.getLogs()).toMatchInlineSnapshot(
+    `[INF] [hive][reporting] Successfully published schema`,
+  );
   expect(body.variables.input.sdl).toBe(`type Query{foo:String}`);
   expect(body.variables.input.author).toBe(author);
   expect(body.variables.input.commit).toBe(commit);
@@ -361,11 +352,9 @@ test('should send data to Hive immediately', async () => {
   expect(body.variables.input.force).toBe(true);
 
   await waitFor(100);
-  expect(logger.getLogs()).toMatchInlineSnapshot(`
-    [INF] [hive][reporting] POST http://localhost/200 Attempt (1/6)
-    [INF] [hive][reporting] POST http://localhost/200 succeeded with status 200 (666ms).
-    [INF] [hive][reporting] Successfully published schema
-  `);
+  expect(logger.getLogs()).toMatchInlineSnapshot(
+    `[INF] [hive][reporting] Successfully published schema`,
+  );
 
   await hive.dispose();
   http.done();
@@ -433,8 +422,6 @@ test('should send original schema of a federated (v1) service', async () => {
   const logs = logger.getLogs();
   expect(logs).toMatchInlineSnapshot(`
     [INF] [hive][reporting] Publish schema
-    [INF] [hive][reporting] POST http://localhost/200 Attempt (1/6)
-    [INF] [hive][reporting] POST http://localhost/200 succeeded with status 200 (666ms).
     [INF] [hive][reporting] Published schema
   `);
   http.done();
@@ -502,8 +489,6 @@ test('should send original schema of a federated (v2) service', async () => {
   const logs = logger.getLogs();
   expect(logs).toMatchInlineSnapshot(`
     [INF] [hive][reporting] Publish schema
-    [INF] [hive][reporting] POST http://localhost/200 Attempt (1/6)
-    [INF] [hive][reporting] POST http://localhost/200 succeeded with status 200 (666ms).
     [INF] [hive][reporting] Published schema
   `);
   http.done();
@@ -563,8 +548,6 @@ test('should display SchemaPublishMissingServiceError', async () => {
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][reporting] Publish schema
-    [INF] [hive][reporting] POST http://localhost/200 Attempt (1/6)
-    [INF] [hive][reporting] POST http://localhost/200 succeeded with status 200 (666ms).
     [ERR] [hive][reporting] Failed to report schema: Service name is not defined
   `);
 });
@@ -624,12 +607,9 @@ test('should display SchemaPublishMissingUrlError', async () => {
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][reporting] Publish schema
-    [INF] [hive][reporting] POST http://localhost/200 Attempt (1/6)
-    [INF] [hive][reporting] POST http://localhost/200 succeeded with status 200 (666ms).
     [ERR] [hive][reporting] Failed to report schema: Service url is not defined
   `);
 
-  expect(logger.getLogs()).toContain('POST http://localhost/200 Attempt (1/6)');
   expect(logger.getLogs()).toContain('Service url is not defined');
 });
 
@@ -677,7 +657,6 @@ test('retry on non-200', async () => {
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][reporting] Publish schema
-    [INF] [hive][reporting] POST http://localhost/registry Attempt (1/6)
     [ERR] [hive][reporting] Error: connect ECONNREFUSED ::1:80
     [ERR] [hive][reporting]     at createConnectionError (node:net:666:666)
     [ERR] [hive][reporting]     at afterConnectMultiple (node:net:666:666)

--- a/packages/libraries/core/tests/usage.spec.ts
+++ b/packages/libraries/core/tests/usage.spec.ts
@@ -167,8 +167,6 @@ test('should send data to Hive', async () => {
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][usage] Disposing
     [INF] [hive][usage] Sending report (queue 1)
-    [INF] [hive][usage] POST http://localhost/200
-    [INF] [hive][usage] POST http://localhost/200 succeeded with status 200 (666ms).
     [INF] [hive][usage] Report sent!
   `);
 
@@ -273,8 +271,6 @@ test('should send data to Hive (deprecated endpoint)', async () => {
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][usage] Disposing
     [INF] [hive][usage] Sending report (queue 1)
-    [INF] [hive][usage] POST http://localhost/200
-    [INF] [hive][usage] POST http://localhost/200 succeeded with status 200 (666ms).
     [INF] [hive][usage] Report sent!
   `);
 
@@ -358,7 +354,6 @@ test('should not leak the exception', async () => {
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][usage] Sending report (queue 1)
-    [INF] [hive][usage] POST http://404.localhost.noop Attempt (1/2)
     [ERR] [hive][usage] Error: getaddrinfo ENOTFOUND 404.localhost.noop
     [ERR] [hive][usage]     at GetAddrInfoReqWrap.onlookupall [as oncomplete] (node:dns:666:666)
     [ERR] [hive][usage] POST http://404.localhost.noop failed (666ms). getaddrinfo ENOTFOUND 404.localhost.noop
@@ -425,8 +420,6 @@ test('sendImmediately should not stop the schedule', async () => {
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][usage] Sending report (queue 1)
-    [INF] [hive][usage] POST http://localhost/200
-    [INF] [hive][usage] POST http://localhost/200 succeeded with status 200 (666ms).
     [INF] [hive][usage] Report sent!
   `);
   logger.clear();
@@ -438,17 +431,13 @@ test('sendImmediately should not stop the schedule', async () => {
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][usage] Sending immediately
     [INF] [hive][usage] Sending report (queue 2)
-    [INF] [hive][usage] POST http://localhost/200
   `);
   logger.clear();
   await waitFor(100);
   // Let's check if the scheduled send task is still running
   await collect(args, {});
   await waitFor(30);
-  expect(logger.getLogs()).toMatchInlineSnapshot(`
-    [INF] [hive][usage] POST http://localhost/200 succeeded with status 200 (666ms).
-    [INF] [hive][usage] Report sent!
-  `);
+  expect(logger.getLogs()).toMatchInlineSnapshot(`[INF] [hive][usage] Report sent!`);
 
   await hive.dispose();
   http.done();
@@ -542,8 +531,6 @@ test('should send data to Hive at least once when using atLeastOnceSampler', asy
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][usage] Disposing
     [INF] [hive][usage] Sending report (queue 2)
-    [INF] [hive][usage] POST http://localhost/200
-    [INF] [hive][usage] POST http://localhost/200 succeeded with status 200 (666ms).
     [INF] [hive][usage] Report sent!
   `);
 
@@ -646,8 +633,6 @@ test('should not send excluded operation name data to Hive', async () => {
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][usage] Disposing
     [INF] [hive][usage] Sending report (queue 2)
-    [INF] [hive][usage] POST http://localhost/200
-    [INF] [hive][usage] POST http://localhost/200 succeeded with status 200 (666ms).
     [INF] [hive][usage] Report sent!
   `);
 
@@ -744,7 +729,6 @@ test('retry on non-200', async () => {
 
   expect(logger.getLogs()).toMatchInlineSnapshot(`
     [INF] [hive][usage] Sending report (queue 1)
-    [INF] [hive][usage] POST http://localhost/200 Attempt (1/2)
     [ERR] [hive][usage] POST http://localhost/200 failed with status 500 (666ms): No no no
     [INF] [hive][usage] Disposing
   `);

--- a/packages/libraries/envelop/src/version.ts
+++ b/packages/libraries/envelop/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.33.3';
+export const version = '0.33.4';

--- a/packages/libraries/yoga/src/version.ts
+++ b/packages/libraries/yoga/src/version.ts
@@ -1,1 +1,1 @@
-export const version = '0.33.3';
+export const version = '0.34.0';

--- a/packages/libraries/yoga/tests/yoga.spec.ts
+++ b/packages/libraries/yoga/tests/yoga.spec.ts
@@ -99,7 +99,7 @@ test('should not interrupt the process', async () => {
       },
     }),
   );
-  await waitFor(50);
+  await waitFor(100);
 
   const reportingLogs = logger
     .getLogs()

--- a/packages/libraries/yoga/tests/yoga.spec.ts
+++ b/packages/libraries/yoga/tests/yoga.spec.ts
@@ -107,6 +107,8 @@ test('should not interrupt the process', async () => {
     .filter(item => item.includes(`[hive][reporting]`))
     .join(`\n`);
 
+  console.log('reportingLogs', reportingLogs);
+
   expect(reportingLogs).includes('Publish schema');
   expect(reportingLogs).includes('POST http://404.localhost.noop/registry');
 

--- a/packages/libraries/yoga/tests/yoga.spec.ts
+++ b/packages/libraries/yoga/tests/yoga.spec.ts
@@ -107,8 +107,6 @@ test('should not interrupt the process', async () => {
     .filter(item => item.includes(`[hive][reporting]`))
     .join(`\n`);
 
-  console.log('reportingLogs', reportingLogs);
-
   expect(reportingLogs).includes('Publish schema');
   expect(reportingLogs).includes('POST http://404.localhost.noop/registry');
 


### PR DESCRIPTION
Fixed a logging issue where both initiated requests and successful responses were being recorded. This was causing the logs to be filled with unnecessary information and affected `hive artifact:fetch --artifact` command.