### PR TITLE
Fix Member Role selector

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -131,8 +131,6 @@ module.exports = {
         'prefer-const': 'off',
         'no-useless-escape': 'off',
         '@typescript-eslint/no-unnecessary-type-assertion': 'off',
-
-        // 🚨 The following rules needs to be fixed and was temporarily disabled to avoid printing warning
         '@typescript-eslint/no-explicit-any': 'off',
         '@typescript-eslint/explicit-module-boundary-types': 'off',
         '@typescript-eslint/no-non-null-assertion': 'off',
@@ -173,8 +171,8 @@ module.exports = {
         'jsx-a11y/alt-text': ['warn', { elements: ['img'], img: ['Image', 'NextImage'] }],
         'no-restricted-syntax': ['error', ...HIVE_RESTRICTED_SYNTAX, ...REACT_RESTRICTED_SYNTAX],
         'prefer-destructuring': 'off',
-        // TODO: enable below rules👇
         'no-console': 'off',
+        'no-useless-escape': 'off',
         '@typescript-eslint/no-non-null-assertion': 'off',
         'react/jsx-no-useless-fragment': 'off',
         '@typescript-eslint/no-explicit-any': 'off',

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -129,6 +129,7 @@ module.exports = {
         'no-restricted-syntax': ['error', ...HIVE_RESTRICTED_SYNTAX, ...RESTRICTED_SYNTAX],
         'prefer-destructuring': 'off',
         'prefer-const': 'off',
+        'no-useless-escape': 'off',
         '@typescript-eslint/no-unnecessary-type-assertion': 'off',
 
         // 🚨 The following rules needs to be fixed and was temporarily disabled to avoid printing warning

--- a/packages/web/app/src/components/organization/members/common.tsx
+++ b/packages/web/app/src/components/organization/members/common.tsx
@@ -90,6 +90,11 @@ export function RoleSelector<T>(props: {
                     <Tooltip delayDuration={200} {...(isActive ? { open: false } : {})}>
                       <TooltipTrigger className="w-full text-left">
                         <CommandItem
+                          // We have to remove characters that may break [data-value="..."] query selector
+                          value={`${role.name} - ${role.description}`.replaceAll(
+                            /[^a-z0-9\-\:\ ]+/gi,
+                            '',
+                          )}
                           onSelect={() => {
                             setPhase('busy');
                             setOpen(false);


### PR DESCRIPTION
The `cmdk` library has an issue with `Item` element containing double quotes or new lines in its children. The new version of `cmdk` contains a fix, but after upgrading, it introduces another issue related to the service filter in /:org/:project/:target view (opening a Command throws an exception).