### PR TITLE
Optimize get_top_operations_for_types query

### DIFF
--- a/packages/services/api/src/modules/operations/providers/operations-reader.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-reader.ts
@@ -1297,7 +1297,7 @@ export class OperationsReader {
     >
   > {
     const ORs = args.typeNames.map(
-      typeName => sql`( cd.coordinate = ${typeName} OR cd.coordinate LIKE ${typeName + '.%'} )`,
+      typeName => sql`( cdi.coordinate = ${typeName} OR cdi.coordinate LIKE ${typeName + '.%'} )`,
     );
 
     const result = await this.clickHouse.query<{
@@ -1320,14 +1320,13 @@ export class OperationsReader {
                 ${this.createFilter({
                   target: args.targetId,
                   period: args.period,
-                  extra: [sql`cdi.coordinate NOT LIKE '%.%.%'`],
+                  extra: [sql`cdi.coordinate NOT LIKE '%.%.%'`, sql`(${sql.join(ORs, ' OR ')})`],
                   namespace: 'cdi',
                 })}
               GROUP BY cdi.hash, cdi.coordinate ORDER by total DESC, cdi.hash ASC LIMIT ${sql.raw(
                 String(args.limit),
               )} by cdi.coordinate
             ) as cd
-            WHERE ${sql.join(ORs, ' OR ')}
           )
           SELECT total, hash, coordinate, ocd.name
           FROM coordinates as c LEFT JOIN (

--- a/packages/services/api/src/modules/shared/providers/http-client.ts
+++ b/packages/services/api/src/modules/shared/providers/http-client.ts
@@ -69,11 +69,10 @@ export class HttpClient {
           return Promise.resolve(response.body);
         },
         error => {
-          span.setAttribute('http.response.status_code', error.response.statusCode);
-
           let details: string | null = null;
 
           if (error instanceof HTTPError) {
+            span.setAttribute('http.response.status_code', error.response.statusCode);
             if (typeof error.response.body === 'string') {
               details = error.response.body;
               logger.error(details);


### PR DESCRIPTION
Moves the where condition to the inner query. Reduces both memory and latency by 8 times. We got a few requests with 504s.