### PR TITLE
Team section

### DIFF
--- a/packages/web/docs/package.json
+++ b/packages/web/docs/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@next/env": "14.2.4",
+    "@radix-ui/react-icons": "1.3.0",
     "@radix-ui/react-tabs": "1.1.0",
     "@radix-ui/react-tooltip": "1.1.2",
     "@theguild/components": "^7.0.0-alpha",
@@ -23,7 +24,6 @@
     "react-avatar": "5.0.3",
     "react-countup": "6.5.3",
     "react-dom": "18.3.1",
-    "react-icons": "5.2.1",
     "rss": "1.2.2",
     "tailwind-merge": "2.4.0"
   },

--- a/packages/web/docs/src/components/ecosystem-management.tsx
+++ b/packages/web/docs/src/components/ecosystem-management.tsx
@@ -312,7 +312,7 @@ function SafariLinearGradientDefs() {
         y2="100%"
         gradientUnits="objectBoundingBox"
       >
-        <stop stop-color="#8CBEB3" />
+        <stop stopColor="#8CBEB3" />
         <stop offset="1" stopColor="#68A8B6" />
       </linearGradient>
       <linearGradient
@@ -323,7 +323,7 @@ function SafariLinearGradientDefs() {
         y2="100%"
         gradientUnits="objectBoundingBox"
       >
-        <stop stop-color="white" stopOpacity="0.4" />
+        <stop stopColor="white" stopOpacity="0.4" />
         <stop offset="1" stopColor="white" stopOpacity="0.1" />
       </linearGradient>
     </defs>

--- a/packages/web/docs/src/components/landing-page.tsx
+++ b/packages/web/docs/src/components/landing-page.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
 import * as Tooltip from '@radix-ui/react-tooltip';
+import { cn } from '../lib';
 import { CallToAction } from './call-to-action';
 import { CheckIcon } from './check-icon';
 import { ArchDecoration, HighlightDecoration, LargeHiveIconDecoration } from './decorations';
@@ -12,6 +13,7 @@ import { AligentLogo, KarrotLogo, LinktreeLogo, MeetupLogo, SoundYXZLogo } from 
 import { Page } from './page';
 import { Pricing } from './pricing';
 import { StatsItem, StatsList } from './stats';
+import { TeamSection } from './team-section';
 
 export function IndexPage(): ReactElement {
   return (
@@ -76,16 +78,22 @@ export function IndexPage(): ReactElement {
         </StatsList>
         <UltimatePerformanceCards />
         <Pricing />
-        <GetStartedTodaySection />
+        <TeamSection />
+        <GetStartedTodaySection className="mt-6" />
         <EnterpriseFocusedCards />
       </Page>
     </Tooltip.Provider>
   );
 }
 
-function GetStartedTodaySection() {
+function GetStartedTodaySection({ className }: { className?: string }) {
   return (
-    <section className="relative overflow-hidden bg-[#003834] p-12 text-center sm:rounded-3xl sm:p-24">
+    <section
+      className={cn(
+        'relative overflow-hidden bg-[#003834] p-12 text-center sm:rounded-3xl sm:p-24',
+        className,
+      )}
+    >
       <ArchDecoration className="absolute -left-1/2 -top-1/2 rotate-180 md:left-[-105px] md:top-[-109px] [&>path]:fill-none" />
       <HighlightDecoration className="absolute -left-1 -top-16 size-[600px] -scale-x-100 overflow-visible" />
       <LargeHiveIconDecoration className="absolute bottom-0 right-8 hidden lg:block" />

--- a/packages/web/docs/src/components/landing-page.tsx
+++ b/packages/web/docs/src/components/landing-page.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import { ReactElement } from 'react';
 import * as Tooltip from '@radix-ui/react-tooltip';
 import { cn } from '../lib';
 import { CallToAction } from './call-to-action';

--- a/packages/web/docs/src/components/team-section.tsx
+++ b/packages/web/docs/src/components/team-section.tsx
@@ -9,7 +9,7 @@ export function TeamSection({ className }: { className?: string }) {
   return (
     <section
       className={cn(
-        'flex h-[748px] flex-col flex-wrap bg-blue-400' +
+        'flex h-[748px] flex-col flex-wrap justify-center bg-blue-400' +
           ' p-24 sm:rounded-3xl md:grid-cols-[467px_1fr] md:py-[120px]',
         className,
       )}

--- a/packages/web/docs/src/components/team-section.tsx
+++ b/packages/web/docs/src/components/team-section.tsx
@@ -1,0 +1,113 @@
+import { GlobeIcon } from '@radix-ui/react-icons';
+import { DiscordIcon, GitHubIcon, TwitterIcon } from '@theguild/components';
+import { cn } from '../lib';
+import { ArrowIcon } from './arrow-icon';
+import { CallToAction } from './call-to-action';
+import { Heading } from './heading';
+
+export function TeamSection({ className }: { className?: string }) {
+  return (
+    <section
+      className={cn(
+        'flex h-[748px] flex-col flex-wrap bg-blue-400' +
+          ' p-24 sm:rounded-3xl md:grid-cols-[467px_1fr] md:py-[120px]',
+        className,
+      )}
+    >
+      <Heading as="h3" size="md" className="text-green-1000 w-[468px] max-w-full">
+        Built by The Guild. Industry veterans.
+      </Heading>
+
+      <p className="mt-6 hidden w-[468px] max-w-full text-green-800 md:block">
+        Contrary to most, we believe in long-term sight, not temporary growth. We believe in extreme
+        quality, not scrappy pivots. We believe in open, not locked. We fight for a world where
+        software liberates, not confines — ensuring technology serves, not subjugates.
+      </p>
+
+      <CallToAction
+        variant="secondary-inverted"
+        href="https://the-guild.dev/"
+        target="_blank"
+        rel="noreferrer"
+        className="mt-12"
+      >
+        Visit The Guild
+        <ArrowIcon />
+      </CallToAction>
+
+      <TeamGallery
+        className="w-[636px]"
+        style={{
+          '--size': '120px',
+        }}
+      />
+    </section>
+  );
+}
+
+type TeamMember = [name: string, avatar: string, social: string];
+const team: TeamMember[] = [
+  ['Denis Badurina', '', ''],
+  ['Dimitri Postolov', '', ''],
+  ['Dotan Simha', '', ''],
+  ['Gil Gardosh', '', ''],
+
+  ['Kamil Kisiela', '', ''],
+  ['Laurin Quast', '', ''],
+  ['Noam Malka', '', ''],
+  ['Saihajpreet Singh', '', ''],
+
+  ['Tuval Simha', '', ''],
+  ['Uri Goldshtein', '', ''],
+  ['Valentin Cocaud', '', ''],
+  ['Yassin Eldeeb', '', ''],
+];
+
+function TeamGallery(props: React.HTMLAttributes<HTMLElement>) {
+  return (
+    <ul
+      {...props}
+      className={cn(
+        'flex flex-row flex-wrap gap-8' + ' shrink-0 [&>:nth-child(8n-7)]:ml-[calc(var(--size)/2)]',
+        props.className,
+      )}
+    >
+      {team.map((member, i) => (
+        <TeamAvatar key={i} data={member} />
+      ))}
+    </ul>
+  );
+}
+
+function TeamAvatar({ data: [name, avatar, social] }: { data: TeamMember }) {
+  return (
+    <div className="relative">
+      <a
+        className={
+          'absolute right-0 top-0 rounded-full border-2 bg-[#222530] p-[9px] text-white hover:border-[#222530]' +
+          ' -translate-y-1/2 translate-x-1/2 border-transparent'
+        }
+        href={social}
+      >
+        {social.startsWith('https://github.com') ? (
+          <GitHubIcon className="size-[14px]" />
+        ) : social.startsWith('https://discord.com') ? (
+          <DiscordIcon className="size-[14px]" />
+        ) : social.startsWith('https://twitter.com') ? (
+          <TwitterIcon className="size-[14px]" />
+        ) : (
+          <GlobeIcon className="size-[14px]" />
+        )}
+      </a>
+      <div
+        role="presentation"
+        className="size-[var(--size)] rounded-2xl bg-['linear-gradient(0deg,#A2C1C4_0%,#A2C1C4_100%),url(var(--src))_lightgray_50%_/_cover_no-repeat'] bg-blue-300"
+        style={{
+          '--src': 'https://place.dog/120/120' + '?' + 'name=' + avatar,
+          backgroundBlendMode: 'multiply, normal',
+        }}
+      />
+      <span className="text-green-1000 mt-2 text-sm font-medium leading-5">{name}</span>
+    </div>
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1988,6 +1988,9 @@ importers:
       '@next/env':
         specifier: 14.2.4
         version: 14.2.4
+      '@radix-ui/react-icons':
+        specifier: 1.3.0
+        version: 1.3.0(react@18.3.1)
       '@radix-ui/react-tabs':
         specifier: 1.1.0
         version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2027,9 +2030,6 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
-      react-icons:
-        specifier: 5.2.1
-        version: 5.2.1(react@18.3.1)
       rss:
         specifier: 1.2.2
         version: 1.2.2


### PR DESCRIPTION
### Background

<img width="1191" alt="image" src="https://github.com/user-attachments/assets/2e4d4cb2-e24b-4a9b-8d84-5a661d0e80fe">

### Description

Laid out the new team section.

Work in progress:

- [ ] Get new avatar illustrations for everybody
- [ ] Grab everybody's chosen social links
- Integrating it with a CMS like Notion would be an overkill probably, right? Can keep it in code or a CSV file in repo.
