### PR TITLE
Move the rounded border class to a proper place

### DIFF
--- a/packages/web/docs/src/components/ecosystem-management.tsx
+++ b/packages/web/docs/src/components/ecosystem-management.tsx
@@ -313,7 +313,7 @@ function SafariLinearGradientDefs() {
         gradientUnits="objectBoundingBox"
       >
         <stop stop-color="#8CBEB3" />
-        <stop offset="1" stop-color="#68A8B6" />
+        <stop offset="1" stopColor="#68A8B6" />
       </linearGradient>
       <linearGradient
         id="linear-white"
@@ -323,8 +323,8 @@ function SafariLinearGradientDefs() {
         y2="100%"
         gradientUnits="objectBoundingBox"
       >
-        <stop stop-color="white" stop-opacity="0.4" />
-        <stop offset="1" stop-color="white" stop-opacity="0.1" />
+        <stop stop-color="white" stopOpacity="0.4" />
+        <stop offset="1" stopColor="white" stopOpacity="0.1" />
       </linearGradient>
     </defs>
   );

--- a/packages/web/docs/src/components/info-card.tsx
+++ b/packages/web/docs/src/components/info-card.tsx
@@ -16,7 +16,7 @@ export function InfoCard({
   ...rest
 }: InfoCardProps) {
   return (
-    <Root className={cn('bg-beige-100 rounded-3xl p-12', className)} {...rest}>
+    <Root className={cn('bg-beige-100 p-12', className)} {...rest}>
       <Stud>{icon}</Stud>
       <h3 className="text-green-1000 mt-6 text-xl font-medium leading-[1.4]">{heading}</h3>
       <p className="mt-4 text-green-800">{children}</p>

--- a/packages/web/docs/src/components/landing-page.tsx
+++ b/packages/web/docs/src/components/landing-page.tsx
@@ -166,7 +166,7 @@ function UltimatePerformanceCards() {
           as="li"
           heading="Deliver improvements faster"
           icon={<PerformanceListItemIcon />}
-          className="flex-1"
+          className="flex-1 rounded-3xl"
         >
           Accelerate feature improvements and experiments, by seamless decoupling of backend and
           frontend environments.
@@ -175,7 +175,7 @@ function UltimatePerformanceCards() {
           as="li"
           heading="Network efficiency"
           icon={<PerformanceListItemIcon />}
-          className="flex-1"
+          className="flex-1 rounded-3xl"
         >
           Accelerate feature improvements and experiments, by seamless decoupling of backend and
           frontend environments.
@@ -184,7 +184,7 @@ function UltimatePerformanceCards() {
           as="li"
           heading="Optimized data retrieval"
           icon={<PerformanceListItemIcon />}
-          className="flex-1 basis-full lg:basis-0"
+          className="flex-1 basis-full rounded-3xl lg:basis-0"
         >
           Reduce latency effectively with Hive by enabling frontend teams to obtain all required
           data in a single request, maximizing GraphQL’s inherent performance benefits.


### PR DESCRIPTION
### Background

I fixed the missing border radius on cards earlier today, but I added it to _all the cards_ instead of just the 3 that needed it.

### Description

This PR moves the className, so now the cards that need to be rounded are still rounded and the cards that need to have a straight border have a straight border.

