### PR TITLE
feat: batch group maximum sizes

### DIFF
--- a/packages/services/api/src/modules/operations/providers/operations-reader.ts
+++ b/packages/services/api/src/modules/operations/providers/operations-reader.ts
@@ -1077,6 +1077,7 @@ export class OperationsReader {
         schemaCoordinates,
       }).then(result => result.map(result => Promise.resolve(result)));
     },
+    20,
   );
 
   /** Result array retains the order of the input `args.schemaCoordinates`. */
@@ -1247,6 +1248,7 @@ export class OperationsReader {
         schemaCoordinates,
       }).then(result => result.map(result => Promise.resolve(result)));
     },
+    20,
   );
 
   async countClientVersions({


### PR DESCRIPTION
### Background

We are hitting some limits where ClickHouse rejects the SQL query because the HTTP query string becomes too long due to many parameters (aka schema coordinates) being passed. 

```
Poco::Exception. Code: 1000, e.code() = 0, HTML Form Exception: Field value too long (version 24.5.1.22926 (official build))
```

### Description

This introduces a maximum batch size per batch within the `batchBy` helper function. With that we will be sending more queries in total, however, we will not exceed the limit.

Note: This fix is based on the amount of passed schema coordinates. However, someone could still have a single schema coordinate that is hundreds of characters long which could still cause this issue.

The 100% correct solution would be keeping track of the length of the query string (query + parameters) and then starting a new batch once the maximum length is exceeded.


### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
