### PR TITLE
fix: usage reports are sent at set intervals

### DIFF
--- a/.changeset/healthy-pears-look.md
+++ b/.changeset/healthy-pears-look.md
@@ -1,0 +1,9 @@
+---
+'@graphql-hive/apollo': patch
+'@graphql-hive/core': patch
+'@graphql-hive/yoga': patch
+'@graphql-hive/envelop': patch
+---
+
+Fixed issue where usage reports were sent only on app disposal or max batch size, now also sent at
+set intervals.

--- a/packages/libraries/yoga/tests/yoga.spec.ts
+++ b/packages/libraries/yoga/tests/yoga.spec.ts
@@ -182,7 +182,7 @@ test('should capture client name and version headers', async () => {
 }, 1_000);
 
 test('send usage reports in intervals', async () => {
-  const fetchSpy = vi.fn<[RequestInfo | URL, options: RequestInit | undefined]>(async () =>
+  const fetchSpy = vi.fn(async (_input: string | URL | globalThis.Request, _init?: RequestInit) =>
     Response.json({}, { status: 200 }),
   );
   const clean = handleProcess();

--- a/packages/libraries/yoga/tests/yoga.spec.ts
+++ b/packages/libraries/yoga/tests/yoga.spec.ts
@@ -181,6 +181,114 @@ test('should capture client name and version headers', async () => {
   );
 }, 1_000);
 
+test('send usage reports in intervals', async () => {
+  const fetchSpy = vi.fn<[RequestInfo | URL, options: RequestInit | undefined]>(async () =>
+    Response.json({}, { status: 200 }),
+  );
+  const clean = handleProcess();
+  const hive = createHive({
+    enabled: true,
+    debug: false,
+    token: 'my-token',
+    agent: {
+      maxRetries: 0,
+      sendInterval: 10,
+      timeout: 50,
+      __testing: {
+        fetch: fetchSpy,
+      },
+    },
+    reporting: false,
+    usage: {
+      endpoint: 'http://yoga.localhost:4200/usage',
+    },
+  });
+
+  const yoga = createYoga({
+    schema: createSchema({
+      typeDefs,
+      resolvers,
+    }),
+    plugins: [useHive(hive)],
+    logging: false,
+  });
+
+  await yoga.fetch(`http://localhost/graphql`, {
+    method: 'POST',
+    body: JSON.stringify({
+      query: /* GraphQL */ `
+        {
+          hello
+        }
+      `,
+    }),
+    headers: {
+      'content-type': 'application/json',
+      'x-graphql-client-name': 'vitest',
+      'x-graphql-client-version': '1.0.0',
+    },
+  });
+
+  await waitFor(50);
+
+  expect(fetchSpy).toHaveBeenCalledWith(
+    'http://yoga.localhost:4200/usage',
+    expect.objectContaining({
+      body: expect.stringContaining('"client":{"name":"vitest","version":"1.0.0"}'),
+    }),
+  );
+
+  await yoga.fetch(`http://localhost/graphql`, {
+    method: 'POST',
+    body: JSON.stringify({
+      query: /* GraphQL */ `
+        {
+          hello
+        }
+      `,
+    }),
+    headers: {
+      'content-type': 'application/json',
+      'x-graphql-client-name': 'vitest',
+      'x-graphql-client-version': '2.0.0',
+    },
+  });
+
+  await waitFor(50);
+
+  expect(fetchSpy).toHaveBeenCalledWith(
+    'http://yoga.localhost:4200/usage',
+    expect.objectContaining({
+      body: expect.stringContaining('"client":{"name":"vitest","version":"2.0.0"}'),
+    }),
+  );
+
+  await yoga.fetch(`http://localhost/graphql`, {
+    method: 'POST',
+    body: JSON.stringify({
+      query: /* GraphQL */ `
+        {
+          hello
+        }
+      `,
+    }),
+    headers: {
+      'content-type': 'application/json',
+      'x-graphql-client-name': 'vitest',
+      'x-graphql-client-version': '3.0.0',
+    },
+  });
+
+  await hive.dispose();
+  expect(fetchSpy).toHaveBeenCalledWith(
+    'http://yoga.localhost:4200/usage',
+    expect.objectContaining({
+      body: expect.stringContaining('"client":{"name":"vitest","version":"3.0.0"}'),
+    }),
+  );
+  clean();
+}, 1_000);
+
 test('reports usage', async ({ expect }) => {
   const graphqlScope = nock('http://localhost')
     .post('/usage', body => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4024,6 +4024,7 @@ packages:
 
   '@fastify/vite@6.0.7':
     resolution: {integrity: sha512-+dRo9KUkvmbqdmBskG02SwigWl06Mwkw8SBDK1zTNH6vd4DyXbRvI7RmJEmBkLouSU81KTzy1+OzwHSffqSD6w==}
+    bundledDependencies: []
 
   '@floating-ui/core@1.2.6':
     resolution: {integrity: sha512-EvYTiXet5XqweYGClEmpu3BoxmsQ4hkj3QaYA6qEnigCWffTP3vNRwBReTdrwDwo7OoJ3wM8Uoe9Uk4n+d4hfg==}


### PR DESCRIPTION
Usage reports were previously only sent when the app was disposed or when the maximum batch size was reached.
With this fix, they are also sent at regular intervals (as they were before the regression).