### PR TITLE
feat: deduplicate persisted document resolution requests

### DIFF
--- a/.changeset/fresh-walls-push.md
+++ b/.changeset/fresh-walls-push.md
@@ -1,0 +1,8 @@
+---
+'@graphql-hive/apollo': minor
+'@graphql-hive/core': minor
+'@graphql-hive/yoga': minor
+---
+
+Deduplicate persisted document lookups from the registry for reducing the amount of concurrent HTTP
+requests.

--- a/packages/libraries/apollo/tests/persisted-documents.spec.ts
+++ b/packages/libraries/apollo/tests/persisted-documents.spec.ts
@@ -13,8 +13,13 @@ type ApolloServerContext = {
   req: IncomingMessage;
 };
 
+const logger = {
+  info: () => {},
+  error: () => {},
+};
+
 test('use persisted documents (GraphQL over HTTP "documentId")', async () => {
-  const httpScope = nock('http://artifatcs-cdn.localhost', {
+  const httpScope = nock('http://artifacts-cdn.localhost', {
     reqheaders: {
       'X-Hive-CDN-Key': value => {
         expect(value).toBe('foo');
@@ -36,9 +41,12 @@ test('use persisted documents (GraphQL over HTTP "documentId")', async () => {
         token: 'token',
         experimental__persistedDocuments: {
           cdn: {
-            endpoint: 'http://artifatcs-cdn.localhost',
+            endpoint: 'http://artifacts-cdn.localhost',
             accessToken: 'foo',
           },
+        },
+        agent: {
+          logger,
         },
       }),
     ],
@@ -68,7 +76,7 @@ test('use persisted documents (GraphQL over HTTP "documentId")', async () => {
 });
 
 test('persisted document not found (GraphQL over HTTP "documentId")', async () => {
-  const httpScope = nock('http://artifatcs-cdn.localhost', {
+  const httpScope = nock('http://artifacts-cdn.localhost', {
     reqheaders: {
       'X-Hive-CDN-Key': value => {
         expect(value).toBe('foo');
@@ -90,9 +98,12 @@ test('persisted document not found (GraphQL over HTTP "documentId")', async () =
         token: 'token',
         experimental__persistedDocuments: {
           cdn: {
-            endpoint: 'http://artifatcs-cdn.localhost',
+            endpoint: 'http://artifacts-cdn.localhost',
             accessToken: 'foo',
           },
+        },
+        agent: {
+          logger,
         },
       }),
     ],
@@ -143,10 +154,13 @@ test('arbitrary options are rejected with allowArbitraryDocuments=false (GraphQL
         token: 'token',
         experimental__persistedDocuments: {
           cdn: {
-            endpoint: 'http://artifatcs-cdn.localhost',
+            endpoint: 'http://artifacts-cdn.localhost',
             accessToken: 'foo',
           },
           allowArbitraryDocuments: false,
+        },
+        agent: {
+          logger,
         },
       }),
     ],
@@ -193,10 +207,13 @@ test('arbitrary options are allowed with allowArbitraryDocuments=true (GraphQL o
         token: 'token',
         experimental__persistedDocuments: {
           cdn: {
-            endpoint: 'http://artifatcs-cdn.localhost',
+            endpoint: 'http://artifacts-cdn.localhost',
             accessToken: 'foo',
           },
           allowArbitraryDocuments: true,
+        },
+        agent: {
+          logger,
         },
       }),
     ],
@@ -229,7 +246,7 @@ test('arbitrary options are allowed with allowArbitraryDocuments=true (GraphQL o
 });
 
 test('usage reporting for persisted document', async () => {
-  const httpScope = nock('http://artifatcs-cdn.localhost', {
+  const httpScope = nock('http://artifacts-cdn.localhost', {
     reqheaders: {
       'X-Hive-CDN-Key': value => {
         expect(value).toBe('foo');
@@ -286,7 +303,7 @@ test('usage reporting for persisted document', async () => {
         token: 'brrrt',
         experimental__persistedDocuments: {
           cdn: {
-            endpoint: 'http://artifatcs-cdn.localhost',
+            endpoint: 'http://artifacts-cdn.localhost',
             accessToken: 'foo',
           },
         },
@@ -300,6 +317,7 @@ test('usage reporting for persisted document', async () => {
         },
         agent: {
           maxSize: 1,
+          logger,
         },
       }),
     ],

--- a/packages/libraries/core/src/client/client.ts
+++ b/packages/libraries/core/src/client/client.ts
@@ -220,7 +220,10 @@ export function createHive(options: HivePluginOptions): HiveClient {
     createInstrumentedSubscribe,
     createInstrumentedExecute,
     experimental__persistedDocuments: options.experimental__persistedDocuments
-      ? createPersistedDocuments(options.experimental__persistedDocuments)
+      ? createPersistedDocuments({
+          ...options.experimental__persistedDocuments,
+          logger,
+        })
       : null,
   };
 }

--- a/packages/libraries/core/src/client/persisted-documents.ts
+++ b/packages/libraries/core/src/client/persisted-documents.ts
@@ -1,12 +1,17 @@
 import type { PromiseOrValue } from 'graphql/jsutils/PromiseOrValue.js';
 import LRU from 'tiny-lru';
-import type { PersistedDocumentsConfiguration } from './types';
+import { http } from './http-client';
+import type { Logger, PersistedDocumentsConfiguration } from './types';
 
 type HeadersObject = {
   get(name: string): string | null;
 };
 
-export function createPersistedDocuments(config: PersistedDocumentsConfiguration): null | {
+export function createPersistedDocuments(
+  config: PersistedDocumentsConfiguration & {
+    logger: Logger;
+  },
+): null | {
   resolve(documentId: string): Promise<string | null>;
   allowArbitraryDocuments(context: { headers?: HeadersObject }): PromiseOrValue<boolean>;
 } {
@@ -23,31 +28,50 @@ export function createPersistedDocuments(config: PersistedDocumentsConfiguration
     allowArbitraryDocuments = () => false;
   }
 
+  /** if there is already a in-flight request for a document, we re-use it. */
+  const fetchCache = new Map<string, Promise<string | null>>();
+
+  /** Batch load a persisted documents */
+  async function loadPersistedDocument(documentId: string) {
+    const document = persistedDocumentsCache.get(documentId);
+    if (document) {
+      return document;
+    }
+
+    const cdnDocumentId = documentId.replaceAll('~', '/');
+
+    const url = config.cdn.endpoint + '/apps/' + cdnDocumentId;
+    let promise = fetchCache.get(url);
+
+    if (!promise) {
+      promise = http
+        .get(url, {
+          headers: {
+            'X-Hive-CDN-Key': config.cdn.accessToken,
+          },
+          logger: config.logger,
+          isRequestOk: response => response.status === 200 || response.status === 404,
+        })
+        .then(async response => {
+          if (response.status !== 200) {
+            return null;
+          }
+          const text = await response.text();
+          persistedDocumentsCache.set(documentId, text);
+          return text;
+        })
+        .finally(() => {
+          fetchCache.delete(url);
+        });
+
+      fetchCache.set(url, promise);
+    }
+
+    return promise;
+  }
+
   return {
     allowArbitraryDocuments,
-    async resolve(documentId: string) {
-      const document = persistedDocumentsCache.get(documentId);
-
-      if (document) {
-        return document;
-      }
-
-      const cdnHttpId = documentId.replaceAll('~', '/');
-
-      const response = await fetch(config.cdn.endpoint + '/apps/' + cdnHttpId, {
-        method: 'GET',
-        headers: {
-          'X-Hive-CDN-Key': config.cdn.accessToken,
-        },
-      });
-
-      if (response.status !== 200) {
-        return null;
-      }
-      const txt = await response.text();
-      persistedDocumentsCache.set(documentId, txt);
-
-      return txt;
-    },
+    resolve: loadPersistedDocument,
   };
 }

--- a/packages/libraries/core/src/client/persisted-documents.ts
+++ b/packages/libraries/core/src/client/persisted-documents.ts
@@ -1,6 +1,6 @@
 import type { PromiseOrValue } from 'graphql/jsutils/PromiseOrValue.js';
 import LRU from 'tiny-lru';
-import { http } from './http-client';
+import { http } from './http-client.js';
 import type { Logger, PersistedDocumentsConfiguration } from './types';
 
 type HeadersObject = {

--- a/packages/libraries/yoga/tests/persisted-documents.spec.ts
+++ b/packages/libraries/yoga/tests/persisted-documents.spec.ts
@@ -8,8 +8,10 @@ beforeAll(() => {
   nock.cleanAll();
 });
 
+const logger = createLogger('silent');
+
 test('use persisted documents (GraphQL over HTTP "documentId")', async () => {
-  const httpScope = nock('http://artifatcs-cdn.localhost', {
+  const httpScope = nock('http://artifacts-cdn.localhost', {
     reqheaders: {
       'X-Hive-CDN-Key': value => {
         expect(value).toBe('foo');
@@ -33,9 +35,12 @@ test('use persisted documents (GraphQL over HTTP "documentId")', async () => {
         enabled: false,
         experimental__persistedDocuments: {
           cdn: {
-            endpoint: 'http://artifatcs-cdn.localhost',
+            endpoint: 'http://artifacts-cdn.localhost',
             accessToken: 'foo',
           },
+        },
+        agent: {
+          logger,
         },
       }),
     ],
@@ -58,7 +63,7 @@ test('use persisted documents (GraphQL over HTTP "documentId")', async () => {
 });
 
 test('use persisted documents (GraphQL over HTTP "documentId") real thing', async () => {
-  const httpScope = nock('http://artifatcs-cdn.localhost', {
+  const httpScope = nock('http://artifacts-cdn.localhost', {
     reqheaders: {
       'X-Hive-CDN-Key': value => {
         expect(value).toBe('foo');
@@ -82,9 +87,12 @@ test('use persisted documents (GraphQL over HTTP "documentId") real thing', asyn
         enabled: false,
         experimental__persistedDocuments: {
           cdn: {
-            endpoint: 'http://artifatcs-cdn.localhost',
+            endpoint: 'http://artifacts-cdn.localhost',
             accessToken: 'foo',
           },
+        },
+        agent: {
+          logger,
         },
       }),
     ],
@@ -114,6 +122,17 @@ test('use persisted documents (GraphQL over HTTP "documentId") real thing', asyn
 });
 
 test('persisted document not found (GraphQL over HTTP "documentId")', async () => {
+  const httpScope = nock('http://artifacts-cdn.localhost', {
+    reqheaders: {
+      'X-Hive-CDN-Key': value => {
+        expect(value).toBe('foo');
+        return true;
+      },
+    },
+  })
+    .get('/apps/client-name/client-version/hash')
+    .reply(404);
+
   const yoga = createYoga({
     schema: createSchema({
       typeDefs: /* GraphQL */ `
@@ -127,24 +146,16 @@ test('persisted document not found (GraphQL over HTTP "documentId")', async () =
         enabled: false,
         experimental__persistedDocuments: {
           cdn: {
-            endpoint: 'http://artifatcs-cdn.localhost',
+            endpoint: 'http://artifacts-cdn.localhost',
             accessToken: 'foo',
           },
+        },
+        agent: {
+          logger,
         },
       }),
     ],
   });
-
-  const httpScope = nock('http://artifatcs-cdn.localhost', {
-    reqheaders: {
-      'X-Hive-CDN-Key': value => {
-        expect(value).toBe('foo');
-        return true;
-      },
-    },
-  })
-    .get('/apps/client-name/client-version/hash')
-    .reply(404);
 
   const response = await yoga.fetch('http://localhost/graphql', {
     method: 'POST',
@@ -185,7 +196,7 @@ test('arbitrary options are rejected with allowArbitraryDocuments=false (GraphQL
         enabled: false,
         experimental__persistedDocuments: {
           cdn: {
-            endpoint: 'http://artifatcs-cdn.localhost',
+            endpoint: 'http://artifacts-cdn.localhost',
             accessToken: 'foo',
           },
           allowArbitraryDocuments: false,
@@ -229,7 +240,7 @@ test('arbitrary options are allowed with allowArbitraryDocuments=true (GraphQL o
         enabled: false,
         experimental__persistedDocuments: {
           cdn: {
-            endpoint: 'http://artifatcs-cdn.localhost',
+            endpoint: 'http://artifacts-cdn.localhost',
             accessToken: 'foo',
           },
           allowArbitraryDocuments: true,
@@ -256,7 +267,7 @@ test('arbitrary options are allowed with allowArbitraryDocuments=true (GraphQL o
 });
 
 test('use persisted documents for subscription (GraphQL over HTTP "documentId")', async () => {
-  const httpScope = nock('http://artifatcs-cdn.localhost', {
+  const httpScope = nock('http://artifacts-cdn.localhost', {
     reqheaders: {
       'X-Hive-CDN-Key': value => {
         expect(value).toBe('foo');
@@ -293,9 +304,12 @@ test('use persisted documents for subscription (GraphQL over HTTP "documentId")'
         enabled: false,
         experimental__persistedDocuments: {
           cdn: {
-            endpoint: 'http://artifatcs-cdn.localhost',
+            endpoint: 'http://artifacts-cdn.localhost',
             accessToken: 'foo',
           },
+        },
+        agent: {
+          logger,
         },
       }),
     ],
@@ -327,7 +341,7 @@ test('use persisted documents for subscription (GraphQL over HTTP "documentId")'
 });
 
 test('usage reporting for persisted document', async () => {
-  const httpScope = nock('http://artifatcs-cdn.localhost', {
+  const httpScope = nock('http://artifacts-cdn.localhost', {
     reqheaders: {
       'X-Hive-CDN-Key': value => {
         expect(value).toBe('foo');
@@ -386,7 +400,7 @@ test('usage reporting for persisted document', async () => {
         token: 'brrrt',
         experimental__persistedDocuments: {
           cdn: {
-            endpoint: 'http://artifatcs-cdn.localhost',
+            endpoint: 'http://artifacts-cdn.localhost',
             accessToken: 'foo',
           },
         },
@@ -440,7 +454,7 @@ test('usage reporting for persisted document', async () => {
 });
 
 test('usage reporting for persisted document (subscription)', async () => {
-  const httpScope = nock('http://artifatcs-cdn.localhost', {
+  const httpScope = nock('http://artifacts-cdn.localhost', {
     reqheaders: {
       'X-Hive-CDN-Key': value => {
         expect(value).toBe('foo');
@@ -511,7 +525,7 @@ test('usage reporting for persisted document (subscription)', async () => {
         token: 'brrrt',
         experimental__persistedDocuments: {
           cdn: {
-            endpoint: 'http://artifatcs-cdn.localhost',
+            endpoint: 'http://artifacts-cdn.localhost',
             accessToken: 'foo',
           },
         },
@@ -571,4 +585,63 @@ test('usage reporting for persisted document (subscription)', async () => {
 
   httpScope.done();
   usageScope.done();
+});
+
+test('deduplication of parallel requests resolving the same document from CDN', async () => {
+  const httpScope = nock('http://artifacts-cdn.localhost', {
+    reqheaders: {
+      'X-Hive-CDN-Key': value => {
+        expect(value).toBe('foo');
+        return true;
+      },
+    },
+  })
+    // Note: this handler is only invoked for the first call, additional calls will fail.
+    .get('/apps/client-name/client-version/hash')
+    .reply(200, () => {
+      return 'query { hi }';
+    });
+
+  const yoga = createYoga({
+    schema: createSchema({
+      typeDefs: /* GraphQL */ `
+        type Query {
+          hi: String
+        }
+      `,
+    }),
+    plugins: [
+      useHive({
+        enabled: false,
+        experimental__persistedDocuments: {
+          cdn: {
+            endpoint: 'http://artifacts-cdn.localhost',
+            accessToken: 'foo',
+          },
+        },
+        agent: {
+          logger,
+        },
+      }),
+    ],
+  });
+
+  const request = async () =>
+    yoga.fetch('http://localhost/graphql', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        documentId: 'client-name~client-version~hash',
+      }),
+    });
+
+  const [request1, request2] = await Promise.all([request(), request()]);
+  expect(request1.status).toBe(200);
+  expect(await request1.json()).toEqual({ data: { hi: null } });
+  expect(request2.status).toBe(200);
+  expect(await request2.json()).toEqual({ data: { hi: null } });
+
+  httpScope.done();
 });


### PR DESCRIPTION
### Background

Deduplicate persisted document lookups from the registry for reducing the amount of concurrent HTTP
requests.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
