### PR TITLE
fix: always pass timeout

### DIFF
--- a/packages/services/cdn-worker/src/aws.ts
+++ b/packages/services/cdn-worker/src/aws.ts
@@ -144,7 +144,6 @@ export class AwsClient {
           return res;
         }
       } catch (error) {
-        console.log('no');
 
         // Retry also when there's an exception
         console.error(error);

--- a/packages/services/cdn-worker/src/aws.ts
+++ b/packages/services/cdn-worker/src/aws.ts
@@ -100,7 +100,6 @@ export class AwsClient {
           method,
           url,
           headers,
-          signal: init?.timeout ? AbortSignal.timeout(init.timeout) : undefined,
         },
         init,
       );
@@ -113,8 +112,15 @@ export class AwsClient {
       input = url;
     }
     const signer = new AwsV4Signer(Object.assign({ url: input }, init, this, init && init.aws));
-    const signed = Object.assign({}, init, await signer.sign());
+    const signed = Object.assign(
+      {
+        signal: init?.timeout ? AbortSignal.timeout(init.timeout) : undefined,
+      },
+      init,
+      await signer.sign(),
+    );
     delete signed.aws;
+
     try {
       return new Request(signed.url.toString(), signed);
     } catch (e) {
@@ -128,6 +134,7 @@ export class AwsClient {
 
   async fetch(input: RequestInfo, init: AwsRequestInit): Promise<Response> {
     for (let i = 0; i <= this.retries; i++) {
+      console.log('GO');
       const fetched = fetch(await this.sign(input, init));
       if (i === this.retries) {
         return fetched; // No need to await if we're returning anyway
@@ -138,6 +145,8 @@ export class AwsClient {
           return res;
         }
       } catch (error) {
+        console.log('no');
+
         // Retry also when there's an exception
         console.error(error);
       }

--- a/packages/services/cdn-worker/src/aws.ts
+++ b/packages/services/cdn-worker/src/aws.ts
@@ -134,7 +134,6 @@ export class AwsClient {
 
   async fetch(input: RequestInfo, init: AwsRequestInit): Promise<Response> {
     for (let i = 0; i <= this.retries; i++) {
-      console.log('GO');
       const fetched = fetch(await this.sign(input, init));
       if (i === this.retries) {
         return fetched; // No need to await if we're returning anyway


### PR DESCRIPTION
### Background

pass timeout at the correct location (https://github.com/kamilkisiela/graphql-hive/commit/3100043bb1b22fc0ec988aba7eca5b96c6f17888)

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
