### PR TITLE
fix: retry lock and avoid gateway timeout

### DIFF
--- a/.changeset/flat-dragons-share.md
+++ b/.changeset/flat-dragons-share.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': minor
+---
+
+Introduce schema publish retries, when being blocked by other concurrent schema publishes.

--- a/packages/libraries/cli/src/base-command.ts
+++ b/packages/libraries/cli/src/base-command.ts
@@ -196,14 +196,23 @@ export default abstract class BaseCommand<T extends typeof Command> extends Comm
 
     return {
       async request<TResult, TVariables>(
-        operation: TypedDocumentNode<TResult, TVariables>,
-        ...[variables]: TVariables extends Record<string, never> ? [] : [TVariables]
+        args: {
+          operation: TypedDocumentNode<TResult, TVariables>;
+          /** timeout in milliseconds */
+          timeout?: number;
+        } & (TVariables extends Record<string, never>
+          ? {
+              variables?: never;
+            }
+          : {
+              variables: TVariables;
+            }),
       ): Promise<TResult> {
         const response = await http.post(
           endpoint,
           JSON.stringify({
-            query: typeof operation === 'string' ? operation : print(operation),
-            variables,
+            query: typeof args.operation === 'string' ? args.operation : print(args.operation),
+            variables: args.variables,
           }),
           {
             logger: {
@@ -217,6 +226,7 @@ export default abstract class BaseCommand<T extends typeof Command> extends Comm
               },
             },
             headers: requestHeaders,
+            timeout: args.timeout,
           },
         );
 

--- a/packages/libraries/cli/src/commands/app/create.ts
+++ b/packages/libraries/cli/src/commands/app/create.ts
@@ -59,15 +59,15 @@ export default class AppCreate extends Command<typeof AppCreate> {
       throw new Error('Invalid manifest');
     }
 
-    const result = await this.registryApi(endpoint, accessToken).request(
-      CreateAppDeploymentMutation,
-      {
+    const result = await this.registryApi(endpoint, accessToken).request({
+      operation: CreateAppDeploymentMutation,
+      variables: {
         input: {
           appName: flags['name'],
           appVersion: flags['version'],
         },
       },
-    );
+    });
 
     if (result.createAppDeployment.error) {
       // TODO: better error message formatting :)
@@ -89,16 +89,16 @@ export default class AppCreate extends Command<typeof AppCreate> {
 
     const flush = async (force = false) => {
       if (buffer.length >= 100 || force) {
-        const result = await this.registryApi(endpoint, accessToken).request(
-          AddDocumentsToAppDeploymentMutation,
-          {
+        const result = await this.registryApi(endpoint, accessToken).request({
+          operation: AddDocumentsToAppDeploymentMutation,
+          variables: {
             input: {
               appName: flags['name'],
               appVersion: flags['version'],
               documents: buffer,
             },
           },
-        );
+        });
 
         if (result.addDocumentsToAppDeployment.error) {
           // TODO: better error message formatting :)

--- a/packages/libraries/cli/src/commands/app/publish.ts
+++ b/packages/libraries/cli/src/commands/app/publish.ts
@@ -37,15 +37,15 @@ export default class AppPublish extends Command<typeof AppPublish> {
       env: 'HIVE_TOKEN',
     });
 
-    const result = await this.registryApi(endpoint, accessToken).request(
-      ActivateAppDeploymentMutation,
-      {
+    const result = await this.registryApi(endpoint, accessToken).request({
+      operation: ActivateAppDeploymentMutation,
+      variables: {
         input: {
           appName: flags['name'],
           appVersion: flags['version'],
         },
       },
-    );
+    });
 
     if (result.activateAppDeployment.error) {
       throw new Error(result.activateAppDeployment.error.message);

--- a/packages/libraries/cli/src/commands/dev.ts
+++ b/packages/libraries/cli/src/commands/dev.ts
@@ -479,7 +479,7 @@ export default class Dev extends Command<typeof Dev> {
 
   private async resolveSdlFromUrl(url: string) {
     const result = await this.graphql(url)
-      .request(ServiceIntrospectionQuery)
+      .request({ operation: ServiceIntrospectionQuery })
       .catch(error => {
         this.handleFetchError(error);
       });

--- a/packages/libraries/cli/src/commands/dev.ts
+++ b/packages/libraries/cli/src/commands/dev.ts
@@ -342,14 +342,17 @@ export default class Dev extends Command<typeof Dev> {
     onError: (message: string) => void | never;
   }) {
     const result = await this.registryApi(input.registry, input.token)
-      .request(CLI_SchemaComposeMutation, {
-        input: {
-          useLatestComposableVersion: !input.unstable__forceLatest,
-          services: input.services.map(service => ({
-            name: service.name,
-            url: service.url,
-            sdl: service.sdl,
-          })),
+      .request({
+        operation: CLI_SchemaComposeMutation,
+        variables: {
+          input: {
+            useLatestComposableVersion: !input.unstable__forceLatest,
+            services: input.services.map(service => ({
+              name: service.name,
+              url: service.url,
+              sdl: service.sdl,
+            })),
+          },
         },
       })
       .catch(error => {

--- a/packages/libraries/cli/src/commands/operations/check.ts
+++ b/packages/libraries/cli/src/commands/operations/check.ts
@@ -119,7 +119,9 @@ export default class OperationsCheck extends Command<typeof OperationsCheck> {
         return;
       }
 
-      const result = await this.registryApi(endpoint, accessToken).request(fetchLatestVersionQuery);
+      const result = await this.registryApi(endpoint, accessToken).request({
+        operation: fetchLatestVersionQuery,
+      });
 
       const sdl = result.latestValidVersion?.sdl;
 

--- a/packages/libraries/cli/src/commands/schema/check.ts
+++ b/packages/libraries/cli/src/commands/schema/check.ts
@@ -211,21 +211,24 @@ export default class SchemaCheck extends Command<typeof SchemaCheck> {
         };
       }
 
-      const result = await this.registryApi(endpoint, accessToken).request(schemaCheckMutation, {
-        input: {
-          service,
-          sdl: minifySchema(sdl),
-          github,
-          meta:
-            !!commit && !!author
-              ? {
-                  commit,
-                  author,
-                }
-              : null,
-          contextId: flags.contextId ?? undefined,
+      const result = await this.registryApi(endpoint, accessToken).request({
+        operation: schemaCheckMutation,
+        variables: {
+          input: {
+            service,
+            sdl: minifySchema(sdl),
+            github,
+            meta:
+              !!commit && !!author
+                ? {
+                    commit,
+                    author,
+                  }
+                : null,
+            contextId: flags.contextId ?? undefined,
+          },
+          usesGitHubApp,
         },
-        usesGitHubApp,
       });
 
       if (result.schemaCheck.__typename === 'SchemaCheckSuccess') {

--- a/packages/libraries/cli/src/commands/schema/delete.ts
+++ b/packages/libraries/cli/src/commands/schema/delete.ts
@@ -112,10 +112,13 @@ export default class SchemaDelete extends Command<typeof SchemaDelete> {
         env: 'HIVE_TOKEN',
       });
 
-      const result = await this.registryApi(endpoint, accessToken).request(schemaDeleteMutation, {
-        input: {
-          serviceName: service,
-          dryRun: flags.dryRun,
+      const result = await this.registryApi(endpoint, accessToken).request({
+        operation: schemaDeleteMutation,
+        variables: {
+          input: {
+            serviceName: service,
+            dryRun: flags.dryRun,
+          },
         },
       });
 

--- a/packages/libraries/cli/src/commands/schema/fetch.ts
+++ b/packages/libraries/cli/src/commands/schema/fetch.ts
@@ -97,14 +97,14 @@ export default class SchemaFetch extends Command<typeof SchemaFetch> {
       defaultValue: 'sdl',
     });
 
-    const result = await this.registryApi(endpoint, accessToken).request(
-      SchemaVersionForActionIdQuery,
-      {
+    const result = await this.registryApi(endpoint, accessToken).request({
+      operation: SchemaVersionForActionIdQuery,
+      variables: {
         actionId,
         includeSDL: sdlType === 'sdl',
         includeSupergraph: sdlType === 'supergraph',
       },
-    );
+    });
 
     if (result.schemaVersionForActionId == null) {
       return this.error(`No schema found for action id ${actionId}`);

--- a/packages/libraries/cli/src/commands/schema/publish.ts
+++ b/packages/libraries/cli/src/commands/schema/publish.ts
@@ -314,6 +314,7 @@ export default class SchemaPublish extends Command<typeof SchemaPublish> {
           }
         } else if (result.schemaPublish.__typename === 'SchemaPublishRetry') {
           this.log(result.schemaPublish.reason);
+          this.log('Waiting for other schema publishes to complete...');
           result = null;
         } else if (result.schemaPublish.__typename === 'SchemaPublishMissingServiceError') {
           this.fail(

--- a/packages/libraries/cli/src/commands/schema/publish.ts
+++ b/packages/libraries/cli/src/commands/schema/publish.ts
@@ -3,7 +3,7 @@ import { GraphQLError, print } from 'graphql';
 import { transformCommentsToDescriptions } from '@graphql-tools/utils';
 import { Args, Errors, Flags } from '@oclif/core';
 import Command from '../../base-command';
-import { graphql } from '../../gql';
+import { DocumentType, graphql } from '../../gql';
 import { graphqlEndpoint } from '../../helpers/config';
 import { gitInfo } from '../../helpers/git';
 import { loadSchema, minifySchema, renderChanges, renderErrors } from '../../helpers/schema';
@@ -58,6 +58,9 @@ const schemaPublishMutation = graphql(/* GraphQL */ `
       }
       ... on GitHubSchemaPublishError @include(if: $usesGitHubApp) {
         message
+      }
+      ... on SchemaPublishRetry {
+        reason
       }
     }
   }
@@ -266,78 +269,91 @@ export default class SchemaPublish extends Command<typeof SchemaPublish> {
         throw err;
       }
 
-      const result = await this.registryApi(endpoint, accessToken).request(schemaPublishMutation, {
-        input: {
-          service,
-          url,
-          author,
-          commit,
-          sdl,
-          force,
-          experimental_acceptBreakingChanges: experimental_acceptBreakingChanges === true,
-          metadata,
-          gitHub,
-        },
-        usesGitHubApp: !!gitHub,
-      });
+      let result: DocumentType<typeof schemaPublishMutation> | null = null;
 
-      if (result.schemaPublish.__typename === 'SchemaPublishSuccess') {
-        const changes = result.schemaPublish.changes;
+      do {
+        result = await this.registryApi(endpoint, accessToken).request({
+          operation: schemaPublishMutation,
+          variables: {
+            input: {
+              service,
+              url,
+              author,
+              commit,
+              sdl,
+              force,
+              experimental_acceptBreakingChanges: experimental_acceptBreakingChanges === true,
+              metadata,
+              gitHub,
+              supportsRetry: true,
+            },
+            usesGitHubApp: !!gitHub,
+          },
+          /** Gateway timeout is 60 seconds. */
+          timeout: 55_000,
+        });
 
-        if (result.schemaPublish.initial) {
-          this.success('Published initial schema.');
-        } else if (result.schemaPublish.successMessage) {
-          this.success(result.schemaPublish.successMessage);
-        } else if (changes && changes.total === 0) {
-          this.success('No changes. Skipping.');
-        } else {
-          if (changes) {
+        if (result.schemaPublish.__typename === 'SchemaPublishSuccess') {
+          const changes = result.schemaPublish.changes;
+
+          if (result.schemaPublish.initial) {
+            this.success('Published initial schema.');
+          } else if (result.schemaPublish.successMessage) {
+            this.success(result.schemaPublish.successMessage);
+          } else if (changes && changes.total === 0) {
+            this.success('No changes. Skipping.');
+          } else {
+            if (changes) {
+              renderChanges.call(this, changes);
+            }
+            this.success('Schema published');
+          }
+
+          if (result.schemaPublish.linkToWebsite) {
+            this.info(`Available at ${result.schemaPublish.linkToWebsite}`);
+          }
+        } else if (result.schemaPublish.__typename === 'SchemaPublishRetry') {
+          this.log(result.schemaPublish.reason);
+          result = null;
+        } else if (result.schemaPublish.__typename === 'SchemaPublishMissingServiceError') {
+          this.fail(
+            `${result.schemaPublish.missingServiceError} Please use the '--service <name>' parameter.`,
+          );
+          this.exit(1);
+        } else if (result.schemaPublish.__typename === 'SchemaPublishMissingUrlError') {
+          this.fail(
+            `${result.schemaPublish.missingUrlError} Please use the '--url <url>' parameter.`,
+          );
+          this.exit(1);
+        } else if (result.schemaPublish.__typename === 'SchemaPublishError') {
+          const changes = result.schemaPublish.changes;
+          const errors = result.schemaPublish.errors;
+          renderErrors.call(this, errors);
+
+          if (changes && changes.total) {
+            this.log('');
             renderChanges.call(this, changes);
           }
-          this.success('Schema published');
-        }
-
-        if (result.schemaPublish.linkToWebsite) {
-          this.info(`Available at ${result.schemaPublish.linkToWebsite}`);
-        }
-      } else if (result.schemaPublish.__typename === 'SchemaPublishMissingServiceError') {
-        this.fail(
-          `${result.schemaPublish.missingServiceError} Please use the '--service <name>' parameter.`,
-        );
-        this.exit(1);
-      } else if (result.schemaPublish.__typename === 'SchemaPublishMissingUrlError') {
-        this.fail(
-          `${result.schemaPublish.missingUrlError} Please use the '--url <url>' parameter.`,
-        );
-        this.exit(1);
-      } else if (result.schemaPublish.__typename === 'SchemaPublishError') {
-        const changes = result.schemaPublish.changes;
-        const errors = result.schemaPublish.errors;
-        renderErrors.call(this, errors);
-
-        if (changes && changes.total) {
           this.log('');
-          renderChanges.call(this, changes);
-        }
-        this.log('');
 
-        if (!force) {
-          this.fail('Failed to publish schema');
-          this.exit(1);
+          if (!force) {
+            this.fail('Failed to publish schema');
+            this.exit(1);
+          } else {
+            this.success('Schema published (forced)');
+          }
+
+          if (result.schemaPublish.linkToWebsite) {
+            this.info(`Available at ${result.schemaPublish.linkToWebsite}`);
+          }
+        } else if (result.schemaPublish.__typename === 'GitHubSchemaPublishSuccess') {
+          this.success(result.schemaPublish.message);
         } else {
-          this.success('Schema published (forced)');
+          this.error(
+            'message' in result.schemaPublish ? result.schemaPublish.message : 'Unknown error',
+          );
         }
-
-        if (result.schemaPublish.linkToWebsite) {
-          this.info(`Available at ${result.schemaPublish.linkToWebsite}`);
-        }
-      } else if (result.schemaPublish.__typename === 'GitHubSchemaPublishSuccess') {
-        this.success(result.schemaPublish.message);
-      } else {
-        this.error(
-          'message' in result.schemaPublish ? result.schemaPublish.message : 'Unknown error',
-        );
-      }
+      } while (result === null);
     } catch (error) {
       if (error instanceof Errors.ExitError) {
         throw error;

--- a/packages/libraries/cli/src/commands/whoami.ts
+++ b/packages/libraries/cli/src/commands/whoami.ts
@@ -80,7 +80,9 @@ export default class WhoAmI extends Command<typeof WhoAmI> {
     });
 
     const result = await this.registryApi(registry, token)
-      .request(myTokenInfoQuery)
+      .request({
+        operation: myTokenInfoQuery,
+      })
       .catch(error => {
         this.handleFetchError(error);
       });

--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -296,6 +296,7 @@ export default gql`
 
   union SchemaPublishPayload =
     | SchemaPublishSuccess
+    | SchemaPublishRetry
     | SchemaPublishError
     | SchemaPublishMissingServiceError
     | SchemaPublishMissingUrlError
@@ -334,6 +335,10 @@ export default gql`
     Link GitHub version to a GitHub commit on a repository.
     """
     gitHub: SchemaPublishGitHubInput
+    """
+    Whether the CLI supports retrying the schema publish, in case acquiring the schema publish lock fails due to a busy queue.
+    """
+    supportsRetry: Boolean = False
   }
 
   input SchemaComposeInput {
@@ -593,6 +598,10 @@ export default gql`
     linkToWebsite: String
     message: String
     changes: SchemaChangeConnection
+  }
+
+  type SchemaPublishRetry {
+    reason: String!
   }
 
   type SchemaPublishError {

--- a/packages/services/api/src/modules/shared/__tests__/mutex.spec.ts
+++ b/packages/services/api/src/modules/shared/__tests__/mutex.spec.ts
@@ -15,7 +15,7 @@ it('should allow only one lock at a time', async ({ expect }) => {
   // second lock shouldnt resolve
   await expect(Promise.race([throwAfter(50), lock2])).rejects.toBeTruthy();
 
-  unlock1();
+  await unlock1();
 
   // after the first lock releases, second one resolves
   await expect(lock2).resolves.toBeTruthy();
@@ -97,7 +97,7 @@ it('should keep auto-extending lock until unlock', async ({ expect }) => {
   // second lock still cannot be acquired resolve
   await expect(Promise.race([throwAfter(50), lock2])).rejects.toBeTruthy();
 
-  unlock();
+  await unlock();
 
   // only after unlock can the second lock be acquired
   await expect(lock2).resolves.toBeTruthy();

--- a/packages/services/api/src/modules/shared/__tests__/mutex.spec.ts
+++ b/packages/services/api/src/modules/shared/__tests__/mutex.spec.ts
@@ -31,43 +31,6 @@ it('should allow different locks at any time', async ({ expect }) => {
   await expect(mutex.lock('3', { signal })).resolves.toBeTruthy();
 });
 
-it('should cancel locking on abort signal', async ({ expect }) => {
-  const mutex = new Mutex(new Tlogger(), new Redis(differentPort()));
-
-  const [signal, abort] = createSignal();
-
-  const unlock1 = await mutex.lock('1', { signal });
-
-  const lock2 = mutex.lock('1', { signal });
-
-  abort();
-
-  await expect(lock2).rejects.toMatchInlineSnapshot('[Error: Locking aborted]');
-
-  unlock1();
-
-  // make sure that the aborted lock does not lock
-  await expect(mutex.lock('1', { signal: createSignal()[0] })).resolves.toBeTruthy();
-});
-
-it('should unlock on abort signal', async ({ expect }) => {
-  const mutex = new Mutex(new Tlogger(), new Redis(differentPort()));
-
-  const [signal, abort] = createSignal();
-
-  await mutex.lock('1', { signal });
-
-  const lock2 = mutex.lock('1', { signal: createSignal()[0] });
-
-  // second lock shouldnt resolve
-  await expect(Promise.race([throwAfter(50), lock2])).rejects.toBeTruthy();
-
-  abort();
-
-  // first lock is aborted, second one should resolve now
-  await expect(lock2).resolves.toBeTruthy();
-});
-
 it('should release lock in perform after return', async ({ expect }) => {
   const mutex = new Mutex(new Tlogger(), new Redis(differentPort()));
 

--- a/packages/services/api/src/modules/shared/providers/mutex.ts
+++ b/packages/services/api/src/modules/shared/providers/mutex.ts
@@ -119,7 +119,7 @@ export class Mutex {
         throw err;
       });
 
-      logger.debug('Acquired lock (id=%s)', id);
+    logger.debug('Acquired lock (id=%s)', id);
 
     // If we acquired the lock but the request got canceled, we want to immediately release it,
     // so other pending requests can take over.

--- a/packages/services/api/src/modules/shared/providers/mutex.ts
+++ b/packages/services/api/src/modules/shared/providers/mutex.ts
@@ -119,6 +119,8 @@ export class Mutex {
         throw err;
       });
 
+      logger.debug('Acquired lock (id=%s)', id);
+
     // If we acquired the lock but the request got canceled, we want to immediately release it,
     // so other pending requests can take over.
     if (signal.aborted) {

--- a/packages/services/api/src/modules/shared/providers/mutex.ts
+++ b/packages/services/api/src/modules/shared/providers/mutex.ts
@@ -193,11 +193,11 @@ export class Mutex {
 
     async function extendLock(isInitial = false) {
       if (isInitial === false) {
-        logger.debug('Attempt extended lock (id=%s)', id);
+        logger.debug('Attempt extending lock (id=%s)', id);
         try {
           // NOTE: extending a lock creates a new lock instance, so we need to replace it here.
           lock = await lock.extend(duration);
-          logger.debug('Lock extend succeeded (id=%s)', id);
+          logger.debug('Lock extension succeeded (id=%s)', id);
         } catch (err) {
           logger.error('Failed to extend lock (id=%s)', id);
           console.error(err);

--- a/packages/services/api/src/modules/shared/providers/mutex.ts
+++ b/packages/services/api/src/modules/shared/providers/mutex.ts
@@ -60,10 +60,10 @@ export class Mutex {
     this.logger = logger.child({ service: 'Mutex' });
     this.redlock = new Redlock([redis]);
     this.redlock.on('error', err => {
+      // these errors will be reported directly by the locking mechanism
       if (err instanceof ResourceLockedError) {
         return;
       }
-      // these errors will be reported directly by the locking mechanism
       this.logger.error(err);
     });
   }

--- a/packages/services/api/src/modules/shared/providers/mutex.ts
+++ b/packages/services/api/src/modules/shared/providers/mutex.ts
@@ -44,7 +44,7 @@ export interface MutexLockOptions {
 export class MutexResourceLockedError extends Error {
   constructor(message: string) {
     super(message);
-    this.name = 'MutexError';
+    this.name = 'MutexResourceLockedError';
   }
 }
 /**

--- a/packages/services/api/src/modules/shared/providers/mutex.ts
+++ b/packages/services/api/src/modules/shared/providers/mutex.ts
@@ -94,7 +94,7 @@ export class Mutex {
     const { logger } = this;
     logger.debug('Acquiring lock (id=%s)', id);
 
-    const requestAbortedD = Promise.withResolvers<void>();
+    const requestAbortedD = Promise.withResolvers<never>();
     let retryCounter = 0;
     let lockToAcquire: Lock | null = null;
 
@@ -147,6 +147,7 @@ export class Mutex {
       }
 
       await Promise.race([requestAbortedD.promise, setTimeoutP(retryDelay)]);
+      // eslint-disable-next-line no-constant-condition
     } while (true);
 
     let lock: Lock = lockToAcquire;

--- a/packages/services/api/src/modules/shared/providers/mutex.ts
+++ b/packages/services/api/src/modules/shared/providers/mutex.ts
@@ -131,11 +131,11 @@ export class Mutex {
     // we have a global timeout of 90 seconds to avoid dead-licks
     const globalTimeout = setTimeout(() => {
       logger.error('Global lock timeout exceeded (id=%s)', id);
-      cleanup();
+      void cleanup();
     }, 90_000);
 
     /** cleanup timers and release the lock. */
-    async function cleanup() {
+    function cleanup() {
       if (extendTimeout === undefined) {
         return;
       }
@@ -146,7 +146,10 @@ export class Mutex {
 
       extendTimeout = undefined;
       if (lock.expiration > new Date().getTime()) {
-        await lock.release();
+        void lock.release().catch(err => {
+          logger.error('Failed to release lock (id=%s)', id);
+          console.error(err);
+        });
       }
     }
 
@@ -169,7 +172,7 @@ export class Mutex {
 
     logger.debug('Lock acquired (id=%s)', id);
 
-    extendLock(true);
+    await extendLock(true);
 
     return cleanup;
   }


### PR DESCRIPTION
### Background

Use a lock acquire timeout smaller than the gateway HTTP timeout and retry requests from CLI in case lock acquiring failures.

```
try to acquire lock
--- not acquired after 30 seconds ----> send response to CLI to retry
--- acquired --> global timeout of lock for 90 seconds; extend lock every few seconds + run action
```

That way we can prevent requests from the CLI reach the envoy timeout of 60 seconds - after the lock is acquired the actual schema publish usually takes around 5-15 seconds, so even in the worst-case scenario if the lock is acquired after 29 seconds, the total request time would not get close to 60 seconds.

The 90 seconds is a hard limit to avoid a resource being locked forever (such as in the case of the bug we encountered yesterday). After this one is exceeded we force release the lock with the trade-off that race conditions can happen as two actors are mutating the resources.


### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
