### PR TITLE
fix: lock acq log message

### DIFF
--- a/packages/services/api/src/modules/shared/providers/mutex.ts
+++ b/packages/services/api/src/modules/shared/providers/mutex.ts
@@ -101,7 +101,7 @@ export class Mutex {
               'abort',
               event => {
                 // TODO: how to bubble this to the caller? the lock is basically released at this point
-                this.logger.error('Lock auto-extension failed (id=%s, event=%s)', id, event);
+                this.logger.error('Lock auto-extension failed (id=%s, event=%o)', id, event);
               },
               { once: true },
             );


### PR DESCRIPTION
this will stringify the object properly 

![CleanShot 2024-08-20 at 08 54 53@2x](https://github.com/user-attachments/assets/d65e981d-3f65-4858-8891-22f5a10964dc)
