### PR TITLE
feat: make container logs grafana more readable

### DIFF
--- a/deployment/grafana-dashboards/Container-Logs.json
+++ b/deployment/grafana-dashboards/Container-Logs.json
@@ -26,7 +26,6 @@
   "graphTooltip": 0,
   "id": 54,
   "links": [],
-  "liveNow": false,
   "panels": [
     {
       "datasource": {
@@ -39,12 +38,14 @@
             "mode": "palette-classic"
           },
           "custom": {
+            "axisBorderShow": false,
             "axisCenteredZero": false,
             "axisColorMode": "text",
             "axisLabel": "",
             "axisPlacement": "auto",
             "axisSoftMin": 0,
             "barAlignment": 0,
+            "barWidthFactor": 0.6,
             "drawStyle": "line",
             "fillOpacity": 0,
             "gradientMode": "none",
@@ -53,6 +54,7 @@
               "tooltip": false,
               "viz": false
             },
+            "insertNulls": false,
             "lineInterpolation": "linear",
             "lineStyle": {
               "fill": "solid"
@@ -107,6 +109,7 @@
           "sort": "none"
         }
       },
+      "pluginVersion": "11.2.0-74515",
       "targets": [
         {
           "datasource": {
@@ -135,7 +138,6 @@
       "id": 4,
       "panels": [],
       "repeat": "service",
-      "repeatDirection": "h",
       "title": "$service",
       "type": "row"
     },
@@ -143,6 +145,10 @@
       "datasource": {
         "type": "loki",
         "uid": "grafanacloud-logs"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
       },
       "gridPos": {
         "h": 13,
@@ -154,13 +160,14 @@
       "options": {
         "dedupStrategy": "none",
         "enableLogDetails": true,
-        "prettifyLogMessage": true,
+        "prettifyLogMessage": false,
         "showCommonLabels": false,
         "showLabels": false,
         "showTime": true,
         "sortOrder": "Descending",
         "wrapLogMessage": false
       },
+      "pluginVersion": "11.2.0-74515",
       "targets": [
         {
           "datasource": {
@@ -168,7 +175,7 @@
             "uid": "grafanacloud-logs"
           },
           "editorMode": "code",
-          "expr": "{container_name=\"$service\"} | json | __error__!=\"JSONParserErr\" | level>30 ",
+          "expr": "{container_name=\"$service\"} | json | regexp `(?P<requestId>[a-f0-9-]{36})`| line_format \"{{ .msg }}\" | __error__ != `JSONParserErr` | level > 30",
           "hide": false,
           "key": "Q-4f74f5b0-5837-415a-b726-56138193c25e-0",
           "queryType": "range",
@@ -182,6 +189,10 @@
       "datasource": {
         "type": "loki",
         "uid": "grafanacloud-logs"
+      },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
       },
       "gridPos": {
         "h": 11,
@@ -200,6 +211,7 @@
         "sortOrder": "Descending",
         "wrapLogMessage": false
       },
+      "pluginVersion": "11.2.0-74515",
       "targets": [
         {
           "datasource": {
@@ -207,7 +219,7 @@
             "uid": "grafanacloud-logs"
           },
           "editorMode": "code",
-          "expr": "{container_name=\"$service\"} | json | __error__!=\"JSONParserErr\" ",
+          "expr": "{container_name=\"$service\"} | json | __error__ != `JSONParserErr` | regexp `(?P<requestId>[a-f0-9-]{36})` | line_format `{{ .msg }}`",
           "queryType": "range",
           "refId": "A"
         }
@@ -216,28 +228,24 @@
       "type": "logs"
     }
   ],
+  "preload": false,
   "refresh": "30s",
-  "revision": 1,
-  "schemaVersion": 38,
-  "style": "dark",
+  "schemaVersion": 39,
   "tags": ["kubernetes", "logs"],
   "templating": {
     "list": [
       {
         "current": {
-          "selected": false,
-          "text": "rate-limiter",
-          "value": "rate-limiter"
+          "text": "graphql-api",
+          "value": "graphql-api"
         },
         "datasource": {
           "type": "loki",
           "uid": "grafanacloud-logs"
         },
         "definition": "",
-        "hide": 0,
         "includeAll": false,
         "label": "Service:",
-        "multi": false,
         "name": "service",
         "options": [],
         "query": {
@@ -248,9 +256,16 @@
         },
         "refresh": 1,
         "regex": "",
-        "skipUrlSync": false,
-        "sort": 0,
         "type": "query"
+      },
+      {
+        "datasource": {
+          "type": "loki",
+          "uid": "grafanacloud-logs"
+        },
+        "filters": [],
+        "name": "Filters",
+        "type": "adhoc"
       }
     ]
   },
@@ -262,6 +277,6 @@
   "timezone": "",
   "title": "Container Logs",
   "uid": "ih6KH0aVz",
-  "version": 8,
+  "version": 9,
   "weekStart": ""
 }


### PR DESCRIPTION
Show just the messages part of the container logs in collapsed view and on expanded view shows everything


**Collapsed View**
![CleanShot 2024-08-20 at 08 58 18@2x](https://github.com/user-attachments/assets/901c4df5-fa4d-4731-80db-cce31551ce18)

**Expanded view**
![CleanShot 2024-08-20 at 08 58 30@2x](https://github.com/user-attachments/assets/86e5426c-90f6-48d4-a88e-45c4d111329e)
