### PR TITLE
Update feature dropdown to pin to current

### DIFF
--- a/packages/web/docs/src/components/community-section.tsx
+++ b/packages/web/docs/src/components/community-section.tsx
@@ -17,7 +17,7 @@ export function CommunitySection({ className }: { className?: string }) {
       <p className="mt-4 text-white/80 lg:text-center">
         Supported by a network of early advocates, contributors, and champions.
       </p>
-      <div className="my-6 grid grid-cols-1 gap-6 md:grid-cols-2 lg:my-24 lg:grid-cols-4">
+      <div className="my-6 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:my-24 lg:grid-cols-4">
         <CommunityCard
           title="GitHub integration"
           description="Our CLI integrates smoothly with GitHub Actions / repositories."

--- a/packages/web/docs/src/components/feature-tabs.tsx
+++ b/packages/web/docs/src/components/feature-tabs.tsx
@@ -46,8 +46,8 @@ export function FeatureTabs({ className }: { className?: string }) {
             ' group mx-4 mt-6 md:mx-0 md:mt-0' +
             ' max-sm:h-[58px] max-sm:focus-within:rounded-b-none' +
             ' max-sm:focus-within:pointer-events-none' + // <- blur on click of current
-            ' focus-within:has-[>:nth-child(2)[data-state="active"]]:translate-y-[-100%]' +
-            ' focus-within:has-[>:nth-child(3)[data-state="active"]]:translate-y-[-200%]' +
+            ' max-sm:focus-within:has-[>:nth-child(2)[data-state="active"]]:translate-y-[-100%]' +
+            ' max-sm:focus-within:has-[>:nth-child(3)[data-state="active"]]:translate-y-[-200%]' +
             ' relative z-10 overflow-hidden focus-within:overflow-visible'
           }
         >

--- a/packages/web/docs/src/components/feature-tabs.tsx
+++ b/packages/web/docs/src/components/feature-tabs.tsx
@@ -42,9 +42,13 @@ export function FeatureTabs({ className }: { className?: string }) {
       <Tabs.Root defaultValue={tabs[0]} {...useSmallScreenTabsHandlers()}>
         <Tabs.List
           className={
-            'bg-beige-200 mb-12 flex flex-col rounded-2xl sm:flex-row' +
+            'sm:bg-beige-200 mb-12 flex flex-col sm:flex-row sm:rounded-2xl' +
             ' group mx-4 mt-6 md:mx-0 md:mt-0' +
-            ' max-sm:h-[58px] max-sm:focus-within:rounded-b-none'
+            ' max-sm:h-[58px] max-sm:focus-within:rounded-b-none' +
+            ' max-sm:focus-within:pointer-events-none' + // <- blur on click of current
+            ' focus-within:has-[>:nth-child(2)[data-state="active"]]:translate-y-[-100%]' +
+            ' focus-within:has-[>:nth-child(3)[data-state="active"]]:translate-y-[-200%]' +
+            ' relative z-10 overflow-hidden focus-within:overflow-visible'
           }
         >
           {tabs.map((tab, i) => {
@@ -59,11 +63,14 @@ export function FeatureTabs({ className }: { className?: string }) {
                   ' text-base sm:text-sm lg:text-base [&>svg]:shrink-0' +
                   ' max-sm:rdx-state-inactive:hidden group-focus-within:rdx-state-inactive:flex [&[data-state="inactive"]>:last-child]:invisible' +
                   ' rounded-lg sm:rounded-[15px]' +
-                  ' max-sm:bg-beige-200 max-sm:rdx-state-inactive:rounded-none max-sm:rdx-state-inactive:order-1 z-10' +
-                  ' max-sm:[&[data-state="active"]~:nth-child(3)]:rounded-b-lg max-sm:[&[data-state="active"]~:nth-child(3)]:border-b' +
-                  ' max-sm:[&[data-state="inactive"]:first-child+&[data-state="inactive"]]:rounded-b-lg max-sm:[&[data-state="inactive"]:first-child+&[data-state="inactive"]]:border-b' +
-                  ' max-sm:group-focus-within:border-beige-600 max-sm:rdx-state-active:border max-sm:group-focus-within:border-x' +
-                  ' max-sm:group-focus-within:rdx-state-active:rounded-b-none max-sm:group-focus-within:rdx-state-active:border-b-0' +
+                  ' max-sm:bg-beige-200 max-sm:rdx-state-inactive:rounded-none z-10' +
+                  ' max-sm:border-beige-600 max-sm:group-focus-within:rdx-state-inactive:border-y-beige-200 max-sm:border' +
+                  ' max-sm:group-focus-within:[&:last-child]:border-t-beige-200 max-sm:group-focus-within:[&:nth-child(3)]:rounded-t-none' +
+                  ' max-sm:group-focus-within:[&[data-state="inactive"]:first-child]:border-t-beige-600 max-sm:group-focus-within:[&[data-state="inactive"]:first-child]:rounded-t-lg' +
+                  ' max-sm:group-focus-within:[&:nth-child(2)]:rdx-state-active:rounded-none max-sm:group-focus-within:[&:nth-child(2)]:rdx-state-active:border-y-beige-200' +
+                  ' max-sm:group-focus-within:[[data-state="active"]+&:last-child]:border-b-beige-600 max-sm:group-focus-within:[[data-state="active"]+&:last-child]:rounded-b-lg' +
+                  ' max-sm:group-focus-within:[[data-state="inactive"]+&:last-child[data-state="inactive"]]:border-b-beige-600 max-sm:group-focus-within:[[data-state="inactive"]+&:last-child[data-state="inactive"]]:rounded-b-lg' +
+                  ' max-sm:group-focus-within:first:rdx-state-active:border-b-beige-200 max-sm:group-focus-within:first:rdx-state-active:rounded-b-none' +
                   ' max-sm:group-focus-within:aria-selected:z-20 max-sm:group-focus-within:aria-selected:ring-4' +
                   ' max-sm:rdx-state-inactive:pointer-events-none max-sm:rdx-state-inactive:group-focus-within:pointer-events-auto' +
                   // between 640px and 721px we still want tabs, but they won't fit with big padding
@@ -72,7 +79,7 @@ export function FeatureTabs({ className }: { className?: string }) {
               >
                 {icons[i]}
                 {tab}
-                <ChevronDownIcon className="ml-auto size-6 text-green-800 sm:hidden" />
+                <ChevronDownIcon className="ml-auto size-6 text-green-800 transition group-focus-within:rotate-90 sm:hidden" />
               </Tabs.Trigger>
             );
           })}
@@ -296,9 +303,7 @@ function useSmallScreenTabsHandlers() {
         return;
       }
 
-      const items = activeElement.parentElement?.querySelectorAll(
-        '[role="tab"][data-state="inactive"]',
-      );
+      const items = activeElement.parentElement?.querySelectorAll('[role="tab"]');
       if (!items) {
         return;
       }
@@ -323,7 +328,11 @@ function useSmallScreenTabsHandlers() {
         case 'Enter': {
           const item = items[index];
           if (item instanceof HTMLElement) {
-            item.focus();
+            if (item.dataset.state === 'active') {
+              item.blur();
+            } else {
+              item.focus();
+            }
           }
           break;
         }


### PR DESCRIPTION
### Background

<img width="488" alt="image" src="https://github.com/user-attachments/assets/ade64dbe-00fc-4db7-8a9b-66c922800999">
<img width="608" alt="image" src="https://github.com/user-attachments/assets/eb8c5221-1ec7-42b5-9776-854638f33717">
<img width="487" alt="image" src="https://github.com/user-attachments/assets/2011d4fb-447a-40ce-a254-9d7fd3d5caa4">

### Description

We now always display the options in order.
We also close the dropdown when the current option is clicked, what wasn't working before.
