### PR TITLE
Use latest version in checksum check

### DIFF
--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -3739,3 +3739,454 @@ test.concurrent(
     });
   },
 );
+
+describe.concurrent(
+  'schema publish should be ignored due to unchanged input schema and being compared to latest schema version',
+  () => {
+    test.concurrent('native federation', async () => {
+      const { createOrg } = await initSeed().createOwner();
+      const { createProject, setFeatureFlag } = await createOrg();
+      const { createToken, setNativeFederation } = await createProject(ProjectType.Federation);
+      await setFeatureFlag('compareToPreviousComposableVersion', true);
+      await setNativeFederation(true);
+
+      const token = await createToken({
+        targetScopes: [
+          TargetAccessScope.Read,
+          TargetAccessScope.RegistryRead,
+          TargetAccessScope.RegistryWrite,
+          TargetAccessScope.Settings,
+        ],
+      });
+
+      const validSdl = /* GraphQL */ `
+        extend schema
+          @link(url: "https://specs.apollo.dev/link/v1.0")
+          @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@tag"])
+
+        type Query {
+          ping: String
+          pong: String
+          foo: User
+        }
+
+        type User {
+          id: ID!
+        }
+      `;
+
+      // here we use @tag without an argument to trigger a validation/composition error
+      const invalidSdl = /* GraphQL */ `
+        extend schema
+          @link(url: "https://specs.apollo.dev/link/v1.0")
+          @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@tag"])
+
+        type Query {
+          ping: String
+          pong: String
+          foo: User @tag
+        }
+
+        type User {
+          id: ID!
+        }
+      `;
+
+      // Publish schema with write rights
+      const validPublish = await token
+        .publishSchema({
+          sdl: validSdl,
+          service: 'serviceA',
+          url: 'http://localhost:4000',
+        })
+        .then(r => r.expectNoGraphQLErrors());
+
+      expect(validPublish.schemaPublish).toMatchObject({
+        valid: true,
+        linkToWebsite: expect.any(String),
+      });
+
+      const invalidPublish = await token
+        .publishSchema({
+          sdl: invalidSdl,
+          service: 'serviceA',
+          url: 'http://localhost:4000',
+        })
+        .then(r => r.expectNoGraphQLErrors());
+
+      expect(invalidPublish.schemaPublish).toMatchObject({
+        valid: false,
+        linkToWebsite: expect.any(String),
+      });
+
+      const invalidSdlCheck = await token
+        .checkSchema(invalidSdl, 'serviceA')
+        .then(r => r.expectNoGraphQLErrors());
+
+      expect(invalidSdlCheck.schemaCheck).toMatchObject({
+        valid: false,
+        __typename: 'SchemaCheckError',
+        changes: expect.objectContaining({
+          total: 0,
+        }),
+        errors: expect.objectContaining({
+          total: 1,
+        }),
+      });
+
+      const validSdlCheck = await token
+        .checkSchema(validSdl, 'serviceA')
+        .then(r => r.expectNoGraphQLErrors());
+
+      expect(validSdlCheck.schemaCheck).toMatchObject({
+        valid: true,
+        __typename: 'SchemaCheckSuccess',
+        changes: expect.objectContaining({
+          total: 0,
+        }),
+      });
+
+      const result = await token
+        .publishSchema({
+          sdl: validSdl,
+          service: 'serviceA',
+          url: 'http://localhost:4000',
+        })
+        .then(r => r.expectNoGraphQLErrors());
+
+      expect(result.schemaPublish).toMatchObject({
+        valid: true,
+        linkToWebsite: expect.any(String),
+      });
+
+      if (
+        !('linkToWebsite' in result.schemaPublish) ||
+        !('linkToWebsite' in invalidPublish.schemaPublish) ||
+        !('linkToWebsite' in validPublish.schemaPublish)
+      ) {
+        throw new Error('linkToWebsite not found');
+      }
+
+      // If the linkToWebsite is the same as one of the previous versions,
+      // the schema publish was ignored due to unchanged input schemas.
+      // It shouldn't be the case.
+      // That's what we're checking here.
+
+      expect(result.schemaPublish.linkToWebsite).not.toEqual(
+        invalidPublish.schemaPublish.linkToWebsite,
+      );
+
+      expect(result.schemaPublish.linkToWebsite).not.toEqual(
+        validPublish.schemaPublish.linkToWebsite,
+      );
+
+      const ignoredResult = await token
+        .publishSchema({
+          sdl: validSdl,
+          service: 'serviceA',
+          url: 'http://localhost:4000',
+        })
+        .then(r => r.expectNoGraphQLErrors());
+
+      // This time the schema publish should be ignored
+      // and link to the previous version
+      expect(ignoredResult.schemaPublish).toMatchObject({
+        valid: true,
+        linkToWebsite: result.schemaPublish.linkToWebsite,
+      });
+    });
+
+    test.concurrent('legacy fed composition', async () => {
+      const { createOrg } = await initSeed().createOwner();
+      const { createProject, setFeatureFlag } = await createOrg();
+      const { createToken, setNativeFederation } = await createProject(ProjectType.Federation);
+      await setFeatureFlag('compareToPreviousComposableVersion', false);
+      await setNativeFederation(false);
+
+      const token = await createToken({
+        targetScopes: [
+          TargetAccessScope.Read,
+          TargetAccessScope.RegistryRead,
+          TargetAccessScope.RegistryWrite,
+          TargetAccessScope.Settings,
+        ],
+      });
+
+      const validSdl = /* GraphQL */ `
+        type Query {
+          ping: String
+          pong: String
+          foo: User
+        }
+
+        type User @key(fields: "id") {
+          id: ID!
+        }
+      `;
+
+      // @key(fields:) is invalid - should trigger a composition error
+      const invalidSdl = /* GraphQL */ `
+        type Query {
+          ping: String
+          pong: String
+          foo: User
+        }
+
+        type User @key(fields: "uuid") {
+          id: ID!
+        }
+      `;
+
+      // Publish schema with write rights
+      const validPublish = await token
+        .publishSchema({
+          sdl: validSdl,
+          service: 'serviceA',
+          url: 'http://localhost:4000',
+        })
+        .then(r => r.expectNoGraphQLErrors());
+
+      expect(validPublish.schemaPublish).toMatchObject({
+        valid: true,
+        linkToWebsite: expect.any(String),
+      });
+
+      const invalidPublish = await token
+        .publishSchema({
+          sdl: invalidSdl,
+          service: 'serviceA',
+          url: 'http://localhost:4000',
+        })
+        .then(r => r.expectNoGraphQLErrors());
+
+      expect(invalidPublish.schemaPublish).toMatchObject({
+        valid: false,
+        linkToWebsite: expect.any(String),
+      });
+
+      const invalidSdlCheck = await token
+        .checkSchema(invalidSdl, 'serviceA')
+        .then(r => r.expectNoGraphQLErrors());
+
+      expect(invalidSdlCheck.schemaCheck).toMatchObject({
+        valid: false,
+        __typename: 'SchemaCheckError',
+        changes: expect.objectContaining({
+          total: 0,
+        }),
+        errors: expect.objectContaining({
+          total: 1,
+        }),
+      });
+
+      const validSdlCheck = await token
+        .checkSchema(validSdl, 'serviceA')
+        .then(r => r.expectNoGraphQLErrors());
+
+      expect(validSdlCheck.schemaCheck).toMatchObject({
+        valid: true,
+        __typename: 'SchemaCheckSuccess',
+        changes: expect.objectContaining({
+          total: 0,
+        }),
+      });
+
+      const result = await token
+        .publishSchema({
+          sdl: validSdl,
+          service: 'serviceA',
+          url: 'http://localhost:4000',
+        })
+        .then(r => r.expectNoGraphQLErrors());
+
+      expect(result.schemaPublish).toMatchObject({
+        valid: true,
+        linkToWebsite: expect.any(String),
+      });
+
+      if (
+        !('linkToWebsite' in result.schemaPublish) ||
+        !('linkToWebsite' in invalidPublish.schemaPublish) ||
+        !('linkToWebsite' in validPublish.schemaPublish)
+      ) {
+        throw new Error('linkToWebsite not found');
+      }
+
+      // If the linkToWebsite is the same as one of the previous versions,
+      // the schema publish was ignored due to unchanged input schemas.
+      // It shouldn't be the case.
+      // That's what we're checking here.
+
+      expect(result.schemaPublish.linkToWebsite).not.toEqual(
+        invalidPublish.schemaPublish.linkToWebsite,
+      );
+
+      expect(result.schemaPublish.linkToWebsite).not.toEqual(
+        validPublish.schemaPublish.linkToWebsite,
+      );
+
+      const ignoredResult = await token
+        .publishSchema({
+          sdl: validSdl,
+          service: 'serviceA',
+          url: 'http://localhost:4000',
+        })
+        .then(r => r.expectNoGraphQLErrors());
+
+      // This time the schema publish should be ignored
+      // and link to the previous version
+      expect(ignoredResult.schemaPublish).toMatchObject({
+        valid: true,
+        linkToWebsite: result.schemaPublish.linkToWebsite,
+      });
+    });
+
+    test.concurrent(
+      'legacy fed composition with compareToPreviousComposableVersion=true',
+      async () => {
+        const { createOrg } = await initSeed().createOwner();
+        const { createProject, setFeatureFlag } = await createOrg();
+        const { createToken, setNativeFederation } = await createProject(ProjectType.Federation);
+        await setFeatureFlag('compareToPreviousComposableVersion', true);
+        await setNativeFederation(false);
+
+        const token = await createToken({
+          targetScopes: [
+            TargetAccessScope.Read,
+            TargetAccessScope.RegistryRead,
+            TargetAccessScope.RegistryWrite,
+            TargetAccessScope.Settings,
+          ],
+        });
+
+        const validSdl = /* GraphQL */ `
+          type Query {
+            ping: String
+            pong: String
+            foo: User
+          }
+
+          type User @key(fields: "id") {
+            id: ID!
+          }
+        `;
+
+        // @key(fields:) is invalid - should trigger a composition error
+        const invalidSdl = /* GraphQL */ `
+          type Query {
+            ping: String
+            pong: String
+            foo: User
+          }
+
+          type User @key(fields: "uuid") {
+            id: ID!
+          }
+        `;
+
+        // Publish schema with write rights
+        const validPublish = await token
+          .publishSchema({
+            sdl: validSdl,
+            service: 'serviceA',
+            url: 'http://localhost:4000',
+          })
+          .then(r => r.expectNoGraphQLErrors());
+
+        expect(validPublish.schemaPublish).toMatchObject({
+          valid: true,
+          linkToWebsite: expect.any(String),
+        });
+
+        const invalidPublish = await token
+          .publishSchema({
+            sdl: invalidSdl,
+            service: 'serviceA',
+            url: 'http://localhost:4000',
+          })
+          .then(r => r.expectNoGraphQLErrors());
+
+        expect(invalidPublish.schemaPublish).toMatchObject({
+          valid: false,
+          linkToWebsite: expect.any(String),
+        });
+
+        const invalidSdlCheck = await token
+          .checkSchema(invalidSdl, 'serviceA')
+          .then(r => r.expectNoGraphQLErrors());
+
+        expect(invalidSdlCheck.schemaCheck).toMatchObject({
+          valid: false,
+          __typename: 'SchemaCheckError',
+          changes: expect.objectContaining({
+            total: 0,
+          }),
+          errors: expect.objectContaining({
+            total: 1,
+          }),
+        });
+
+        const validSdlCheck = await token
+          .checkSchema(validSdl, 'serviceA')
+          .then(r => r.expectNoGraphQLErrors());
+
+        expect(validSdlCheck.schemaCheck).toMatchObject({
+          valid: true,
+          __typename: 'SchemaCheckSuccess',
+          changes: expect.objectContaining({
+            total: 0,
+          }),
+        });
+
+        const result = await token
+          .publishSchema({
+            sdl: validSdl,
+            service: 'serviceA',
+            url: 'http://localhost:4000',
+          })
+          .then(r => r.expectNoGraphQLErrors());
+
+        expect(result.schemaPublish).toMatchObject({
+          valid: true,
+          linkToWebsite: expect.any(String),
+        });
+
+        if (
+          !('linkToWebsite' in result.schemaPublish) ||
+          !('linkToWebsite' in invalidPublish.schemaPublish) ||
+          !('linkToWebsite' in validPublish.schemaPublish)
+        ) {
+          throw new Error('linkToWebsite not found');
+        }
+
+        // If the linkToWebsite is the same as one of the previous versions,
+        // the schema publish was ignored due to unchanged input schemas.
+        // It shouldn't be the case.
+        // That's what we're checking here.
+
+        expect(result.schemaPublish.linkToWebsite).not.toEqual(
+          invalidPublish.schemaPublish.linkToWebsite,
+        );
+
+        expect(result.schemaPublish.linkToWebsite).not.toEqual(
+          validPublish.schemaPublish.linkToWebsite,
+        );
+
+        const ignoredResult = await token
+          .publishSchema({
+            sdl: validSdl,
+            service: 'serviceA',
+            url: 'http://localhost:4000',
+          })
+          .then(r => r.expectNoGraphQLErrors());
+
+        // This time the schema publish should be ignored
+        // and link to the previous version
+        expect(ignoredResult.schemaPublish).toMatchObject({
+          valid: true,
+          linkToWebsite: result.schemaPublish.linkToWebsite,
+        });
+      },
+    );
+  },
+);

--- a/packages/services/api/src/modules/schema/providers/models/composite-legacy.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite-legacy.ts
@@ -78,21 +78,20 @@ export class CompositeLegacyModel {
     };
 
     const latestVersion = latest;
-    const schemas = latestVersion
-      ? swapServices(latestVersion.schemas, incoming).schemas
-      : [incoming];
+    const schemaSwapResult = latestVersion ? swapServices(latestVersion.schemas, incoming) : null;
+    const schemas = schemaSwapResult ? schemaSwapResult.schemas : [incoming];
     schemas.sort((a, b) => a.service_name.localeCompare(b.service_name));
     const orchestrator = project.type === ProjectType.FEDERATION ? this.federation : this.stitching;
 
     const checksumCheck = await this.checks.checksum({
-      existing: latestVersion
+      existing: schemaSwapResult?.existing
         ? {
-            schemas: latestVersion.schemas,
+            schema: schemaSwapResult.existing,
             contractNames: null,
           }
         : null,
       incoming: {
-        schemas,
+        schema: incoming,
         contractNames: null,
       },
     });
@@ -195,9 +194,9 @@ export class CompositeLegacyModel {
     const isFederation = project.type === ProjectType.FEDERATION;
     const orchestrator = isFederation ? this.federation : this.stitching;
     const latestVersion = latest;
-    const swap = latestVersion ? swapServices(latestVersion.schemas, incoming) : null;
-    const previousService = swap?.existing;
-    const schemas = swap?.schemas ?? [incoming];
+    const schemaSwapResult = latestVersion ? swapServices(latestVersion.schemas, incoming) : null;
+    const previousService = schemaSwapResult?.existing;
+    const schemas = schemaSwapResult?.schemas ?? [incoming];
     schemas.sort((a, b) => a.service_name.localeCompare(b.service_name));
 
     const forced = input.force === true;
@@ -246,14 +245,14 @@ export class CompositeLegacyModel {
     }
 
     const checksumCheck = await this.checks.checksum({
-      existing: latestVersion
+      existing: schemaSwapResult?.existing
         ? {
-            schemas: latestVersion.schemas,
+            schema: schemaSwapResult.existing,
             contractNames: null,
           }
         : null,
       incoming: {
-        schemas,
+        schema: incoming,
         contractNames: null,
       },
     });

--- a/packages/services/api/src/modules/schema/providers/models/composite.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite.ts
@@ -386,9 +386,9 @@ export class CompositeModel {
     }
 
     const checksumCheck = await this.checks.checksum({
-      existing: schemaVersionToCompareAgainst
+      existing: latest
         ? {
-            schemas: schemaVersionToCompareAgainst.schemas,
+            schemas: latest.schemas,
             contractNames: schemaVersionContractNames,
           }
         : null,

--- a/packages/services/api/src/modules/schema/providers/models/composite.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite.ts
@@ -163,9 +163,9 @@ export class CompositeModel {
     const comparedVersion = compareToPreviousComposableVersion ? latestComposable : latest;
 
     const checksumCheck = await this.checks.checksum({
-      existing: comparedVersion
+      existing: latest
         ? {
-            schemas: comparedVersion.schemas,
+            schemas: latest.schemas,
             contractNames: schemaVersionContractNames,
           }
         : null,

--- a/packages/services/api/src/modules/schema/providers/models/composite.ts
+++ b/packages/services/api/src/modules/schema/providers/models/composite.ts
@@ -98,7 +98,6 @@ export class CompositeModel {
     selector,
     latest,
     latestComposable,
-    schemaVersionContractNames,
     project,
     organization,
     baseSchema,
@@ -119,13 +118,13 @@ export class CompositeModel {
       isComposable: boolean;
       sdl: string | null;
       schemas: PushedCompositeSchema[];
+      contractNames: string[] | null;
     } | null;
     latestComposable: {
       isComposable: boolean;
       sdl: string | null;
       schemas: PushedCompositeSchema[];
     } | null;
-    schemaVersionContractNames: string[] | null;
     baseSchema: string | null;
     project: Project;
     organization: Organization;
@@ -152,7 +151,8 @@ export class CompositeModel {
       metadata: null,
     };
 
-    const schemas = latest ? swapServices(latest.schemas, incoming).schemas : [incoming];
+    const schemaSwapResult = latest ? swapServices(latest.schemas, incoming) : null;
+    const schemas = schemaSwapResult ? schemaSwapResult.schemas : [incoming];
     schemas.sort((a, b) => a.service_name.localeCompare(b.service_name));
 
     const compareToPreviousComposableVersion = shouldUseLatestComposableVersion(
@@ -163,14 +163,14 @@ export class CompositeModel {
     const comparedVersion = compareToPreviousComposableVersion ? latestComposable : latest;
 
     const checksumCheck = await this.checks.checksum({
-      existing: latest
+      existing: schemaSwapResult?.existing
         ? {
-            schemas: latest.schemas,
-            contractNames: schemaVersionContractNames,
+            schema: schemaSwapResult.existing,
+            contractNames: latest?.contractNames ?? null,
           }
         : null,
       incoming: {
-        schemas,
+        schema: incoming,
         contractNames: contracts?.map(({ contract }) => contract.contractName) ?? null,
       },
     });
@@ -298,7 +298,6 @@ export class CompositeModel {
     organization,
     latest,
     latestComposable,
-    schemaVersionContractNames,
     baseSchema,
     contracts,
     conditionalBreakingChangeDiffConfig,
@@ -311,13 +310,13 @@ export class CompositeModel {
       isComposable: boolean;
       sdl: string | null;
       schemas: PushedCompositeSchema[];
+      contractNames: string[] | null;
     } | null;
     latestComposable: {
       isComposable: boolean;
       sdl: string | null;
       schemas: PushedCompositeSchema[];
     } | null;
-    schemaVersionContractNames: string[] | null;
     baseSchema: string | null;
     contracts: Array<ContractInput> | null;
     conditionalBreakingChangeDiffConfig: null | ConditionalBreakingChangeDiffConfig;
@@ -337,9 +336,9 @@ export class CompositeModel {
     };
 
     const latestVersion = latest;
-    const swap = latestVersion ? swapServices(latestVersion.schemas, incoming) : null;
-    const previousService = swap?.existing;
-    const schemas = swap?.schemas ?? [incoming];
+    const schemaSwapResult = latestVersion ? swapServices(latestVersion.schemas, incoming) : null;
+    const previousService = schemaSwapResult?.existing;
+    const schemas = schemaSwapResult?.schemas ?? [incoming];
     schemas.sort((a, b) => a.service_name.localeCompare(b.service_name));
     const compareToLatestComposable = shouldUseLatestComposableVersion(
       target.id,
@@ -386,14 +385,14 @@ export class CompositeModel {
     }
 
     const checksumCheck = await this.checks.checksum({
-      existing: latest
+      existing: schemaSwapResult?.existing
         ? {
-            schemas: latest.schemas,
-            contractNames: schemaVersionContractNames,
+            schema: schemaSwapResult.existing,
+            contractNames: latest?.contractNames ?? null,
           }
         : null,
       incoming: {
-        schemas,
+        schema: incoming,
         contractNames: contracts?.map(contract => contract.contract.contractName) ?? null,
       },
     });

--- a/packages/services/api/src/modules/schema/providers/models/shared.ts
+++ b/packages/services/api/src/modules/schema/providers/models/shared.ts
@@ -43,7 +43,10 @@ export const SchemaCheckConclusion = {
    */
   Failure: 'FAILURE',
   /**
-   * Skipped as the schemas have not changed from the compared schema version
+   * Skipped as the schemas have not changed from the latest schema version
+   *
+   * At this point, the schema is not checked for breaking changes or composition errors,
+   * these are passed from the latest schema version (not necessarily the latest composable version).
    */
   Skip: 'SKIP',
 } as const;

--- a/packages/services/api/src/modules/schema/providers/models/single-legacy.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single-legacy.ts
@@ -70,12 +70,12 @@ export class SingleLegacyModel {
     const checksumCheck = await this.checks.checksum({
       existing: latestVersion
         ? {
-            schemas: latestVersion.schemas,
+            schema: latestVersion.schemas[0],
             contractNames: null,
           }
         : null,
       incoming: {
-        schemas,
+        schema: incoming,
         contractNames: null,
       },
     });
@@ -181,12 +181,12 @@ export class SingleLegacyModel {
     const checksumCheck = await this.checks.checksum({
       existing: latestVersion
         ? {
-            schemas: latestVersion.schemas,
+            schema: latestVersion.schemas[0],
             contractNames: null,
           }
         : null,
       incoming: {
-        schemas,
+        schema: incoming,
         contractNames: null,
       },
     });

--- a/packages/services/api/src/modules/schema/providers/models/single.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single.ts
@@ -86,9 +86,9 @@ export class SingleModel {
     const comparedVersion = compareToPreviousComposableVersion ? latestComposable : latest;
 
     const checksumResult = await this.checks.checksum({
-      existing: comparedVersion
+      existing: latest
         ? {
-            schemas: comparedVersion.schemas,
+            schemas: latest.schemas,
             contractNames: null,
           }
         : null,

--- a/packages/services/api/src/modules/schema/providers/models/single.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single.ts
@@ -88,12 +88,12 @@ export class SingleModel {
     const checksumResult = await this.checks.checksum({
       existing: latest
         ? {
-            schemas: latest.schemas,
+            schema: latest.schemas[0],
             contractNames: null,
           }
         : null,
       incoming: {
-        schemas,
+        schema: incoming,
         contractNames: null,
       },
     });
@@ -216,12 +216,12 @@ export class SingleModel {
     const checksumCheck = await this.checks.checksum({
       existing: latest
         ? {
-            schemas: latest.schemas,
+            schema: latest.schemas[0],
             contractNames: null,
           }
         : null,
       incoming: {
-        schemas,
+        schema: incoming,
         contractNames: null,
       },
     });

--- a/packages/services/api/src/modules/schema/providers/models/single.ts
+++ b/packages/services/api/src/modules/schema/providers/models/single.ts
@@ -214,9 +214,9 @@ export class SingleModel {
     const comparedVersion = compareToPreviousComposableVersion ? latestComposable : latest;
 
     const checksumCheck = await this.checks.checksum({
-      existing: comparedVersion
+      existing: latest
         ? {
-            schemas: comparedVersion.schemas,
+            schemas: latest.schemas,
             contractNames: null,
           }
         : null,

--- a/packages/services/api/src/modules/schema/providers/registry-checks.ts
+++ b/packages/services/api/src/modules/schema/providers/registry-checks.ts
@@ -172,21 +172,27 @@ export class RegistryChecks {
     private operationsReader: OperationsReader,
   ) {}
 
+  /**
+   * Compare the incoming schema with the existing schema.
+   * In case of a Federated schema, it's a subgraph.
+   * Comparing the whole collection of subgraphs makes no sense,
+   * as the only element that is different is the subgraph that is updated.
+   * The rest of the subgraphs are inherited from the previous version, meaning they are the same.
+   */
   async checksum(args: {
     incoming: {
-      schemas: Schemas;
+      schema: SingleSchema | PushedCompositeSchema;
       contractNames: null | Array<string>;
     };
     existing: null | {
-      schemas: Schemas;
+      schema: SingleSchema | PushedCompositeSchema;
       contractNames: null | Array<string>;
     };
   }) {
     this.logger.debug(
-      'Checksum check (existingSchemaCount=%s, existingContractCount=%s, incomingSchemaCount=%s, existingContractCount=%s)',
-      args.existing?.schemas.length ?? null,
+      'Checksum check (existingSchema=%s, existingContractCount=%s, incomingContractCount=%s)',
+      args.existing?.schema ? 'yes' : 'no',
       args.existing?.contractNames?.length ?? null,
-      args.incoming.schemas.length,
       args.incoming.contractNames?.length ?? null,
     );
 
@@ -196,8 +202,8 @@ export class RegistryChecks {
     }
 
     const isSchemasModified =
-      this.helper.createChecksumFromSchemas(args.existing.schemas) !==
-      this.helper.createChecksumFromSchemas(args.incoming.schemas);
+      this.helper.createChecksum(args.existing.schema) !==
+      this.helper.createChecksum(args.incoming.schema);
 
     if (isSchemasModified) {
       this.logger.debug('Schema is modified.');

--- a/packages/services/api/src/modules/schema/providers/schema-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-helper.ts
@@ -117,70 +117,31 @@ export class SchemaHelper {
     return createSchemaObject(schema);
   }
 
-  sortSchemas(schemas: CompositeSchema[]) {
-    return schemas.sort((a, b) => (a.service_name ?? '').localeCompare(b.service_name ?? ''));
-  }
-
   createChecksum(schema: SingleSchema | PushedCompositeSchema): string {
-    return this.createChecksumFromSchemas([schema] as [SingleSchema] | PushedCompositeSchema[]);
-  }
-
-  createChecksumFromSchemas(schemas: [SingleSchema] | PushedCompositeSchema[]): string {
     const hasher = createHash('md5');
 
-    for (const schema of schemas) {
-      hasher.update(print(sortDocumentNode(this.createSchemaObject(schema).document)), 'utf-8');
-      hasher.update(
-        `service_name: ${
-          'service_name' in schema && typeof schema.service_name === 'string'
-            ? schema.service_name
-            : ''
-        }`,
-        'utf-8',
-      );
-      hasher.update(
-        `service_url: ${
-          'service_url' in schema && typeof schema.service_url === 'string'
-            ? schema.service_url
-            : ''
-        }`,
-        'utf-8',
-      );
-      hasher.update(
-        `metadata: ${
-          'metadata' in schema && schema.metadata ? objectHash(JSON.parse(schema.metadata)) : ''
-        }`,
-        'utf-8',
-      );
-    }
+    hasher.update(print(sortDocumentNode(this.createSchemaObject(schema).document)), 'utf-8');
+    hasher.update(
+      `service_name: ${
+        'service_name' in schema && typeof schema.service_name === 'string'
+          ? schema.service_name
+          : ''
+      }`,
+      'utf-8',
+    );
+    hasher.update(
+      `service_url: ${
+        'service_url' in schema && typeof schema.service_url === 'string' ? schema.service_url : ''
+      }`,
+      'utf-8',
+    );
+    hasher.update(
+      `metadata: ${
+        'metadata' in schema && schema.metadata ? objectHash(JSON.parse(schema.metadata)) : ''
+      }`,
+      'utf-8',
+    );
 
     return hasher.digest('hex');
-  }
-
-  compare({
-    schemas,
-    latestVersion,
-  }: {
-    schemas: [SingleSchema] | PushedCompositeSchema[];
-    latestVersion: {
-      isComposable: boolean;
-      schemas: [SingleSchema] | PushedCompositeSchema[];
-    } | null;
-  }) {
-    const isInitial = latestVersion === null;
-
-    if (isInitial) {
-      return 'initial' as const;
-    }
-
-    const isModified =
-      this.createChecksumFromSchemas(schemas) !==
-      this.createChecksumFromSchemas(latestVersion.schemas);
-
-    if (!isModified) {
-      return 'unchanged' as const;
-    }
-
-    return 'modified' as const;
   }
 }


### PR DESCRIPTION
Using the latest composable version to produce a checksum can lead to a problem where publishing a new version is ignored, due to unchanged input schema, even though it actually leads to fixing the composition state of the latest version.

This PR uses latest version to produce a checksum (to detect identical versions and return early and avoid doing unnecessary work), and instead of using all subgraphs, it's using the relevant subgraph only.