### PR TITLE
feat: skip presigned url step + analytics

### DIFF
--- a/deployment/utils/cloudflare.ts
+++ b/deployment/utils/cloudflare.ts
@@ -55,6 +55,10 @@ export class CloudflareCDN {
           dataset: `hive_ha_cdn_r2_${this.config.envName}`,
         },
         {
+          name: 'S3_ANALYTICS',
+          dataset: `hive_ha_cdn_s3_${this.config.envName}`,
+        },
+        {
           name: 'RESPONSE_ANALYTICS',
           dataset: `hive_ha_cdn_response_${this.config.envName}`,
         },

--- a/deployment/utils/cloudflare.ts
+++ b/deployment/utils/cloudflare.ts
@@ -55,10 +55,6 @@ export class CloudflareCDN {
           dataset: `hive_ha_cdn_r2_${this.config.envName}`,
         },
         {
-          name: 'S3_ANALYTICS',
-          dataset: `hive_ha_cdn_s3_${this.config.envName}`,
-        },
-        {
           name: 'RESPONSE_ANALYTICS',
           dataset: `hive_ha_cdn_response_${this.config.envName}`,
         },

--- a/packages/services/cdn-worker/src/analytics.ts
+++ b/packages/services/cdn-worker/src/analytics.ts
@@ -57,7 +57,7 @@ type Event =
   | {
       type: 'r2';
       action:
-        | 'HEAD artifact'
+        | 'GET artifact'
         | 'GET cdn-legacy-keys'
         | 'GET cdn-access-token'
         | 'GET persistedOperation'

--- a/packages/services/cdn-worker/src/analytics.ts
+++ b/packages/services/cdn-worker/src/analytics.ts
@@ -62,7 +62,10 @@ type Event =
         | 'GET cdn-access-token'
         | 'GET persistedOperation'
         | 'HEAD appDeploymentIsEnabled';
-      statusCode: number;
+      // Either 3 digit status code or error code e.g. timeout, http error etc.
+      statusCodeOrErrCode: number | string;
+      /** duration in milliseconds */
+      duration: number;
     }
   | {
       type: 'response';
@@ -97,7 +100,8 @@ export function createAnalytics(
           });
         case 'r2':
           return engines.r2.writeDataPoint({
-            blobs: [event.action, event.statusCode.toString(), targetId],
+            blobs: [event.action, event.statusCodeOrErrCode.toString(), targetId],
+            doubles: [event.duration],
             indexes: [targetId.substring(0, 32)],
           });
         case 'response':

--- a/packages/services/cdn-worker/src/artifact-handler.ts
+++ b/packages/services/cdn-worker/src/artifact-handler.ts
@@ -129,7 +129,7 @@ export const createArtifactRequestHandler = (deps: ArtifactRequestHandler) => {
 
     const eTag = request.headers.get('if-none-match');
 
-    const result = await deps.artifactStorageReader.generateArtifactReadUrl(
+    const result = await deps.artifactStorageReader.readArtifact(
       params.targetId,
       params.contractName,
       params.artifactType,

--- a/packages/services/cdn-worker/src/artifact-storage-reader.ts
+++ b/packages/services/cdn-worker/src/artifact-storage-reader.ts
@@ -151,38 +151,29 @@ export class ArtifactStorageReader {
   async isAppDeploymentEnabled(targetId: string, appName: string, appVersion: string) {
     const key = buildAppDeploymentIsEnabledKey(targetId, appName, appVersion);
 
-    const start = performance.now();
-
-    const response = await this.s3.client
-      .fetch([this.s3.endpoint, this.s3.bucketName, key].join('/'), {
+    const response = await this.s3.client.fetch(
+      [this.s3.endpoint, this.s3.bucketName, key].join('/'),
+      {
         method: 'HEAD',
         aws: {
           signQuery: true,
         },
         timeout: READ_TIMEOUT_MS,
-      })
-      .catch((err: Error) => {
-        this.analytics?.track(
-          {
-            type: 'r2',
-            statusCodeOrErrCode: String(err.name ?? 'unknown'),
-            action: 'HEAD appDeploymentIsEnabled',
-            duration: performance.now() - start,
-          },
-          targetId,
-        );
-
-        throw err;
-      });
-
-    this.analytics?.track(
-      {
-        type: 'r2',
-        statusCodeOrErrCode: response.status,
-        action: 'HEAD appDeploymentIsEnabled',
-        duration: performance.now() - start,
+        onAttempt: args => {
+          this.analytics?.track(
+            {
+              type: 'r2',
+              statusCodeOrErrCode:
+                args.result.type === 'error'
+                  ? String(args.result.error.name ?? 'unknown')
+                  : args.result.response.status,
+              action: 'HEAD appDeploymentIsEnabled',
+              duration: args.duration,
+            },
+            targetId,
+          );
+        },
       },
-      targetId,
     );
 
     return response.status === 200;
@@ -202,39 +193,30 @@ export class ArtifactStorageReader {
       headers['if-none-match'] = etagValue;
     }
 
-    const start = performance.now();
-
-    const response = await this.s3.client
-      .fetch([this.s3.endpoint, this.s3.bucketName, key].join('/'), {
+    const response = await this.s3.client.fetch(
+      [this.s3.endpoint, this.s3.bucketName, key].join('/'),
+      {
         method: 'GET',
         aws: {
           signQuery: true,
         },
         headers,
         timeout: READ_TIMEOUT_MS,
-      })
-      .catch((err: Error) => {
-        this.analytics?.track(
-          {
-            type: 'r2',
-            statusCodeOrErrCode: String(err.name ?? 'unknown'),
-            action: 'GET persistedOperation',
-            duration: performance.now() - start,
-          },
-          targetId,
-        );
-
-        throw err;
-      });
-
-    this.analytics?.track(
-      {
-        type: 'r2',
-        statusCodeOrErrCode: response.status,
-        action: 'GET persistedOperation',
-        duration: performance.now() - start,
+        onAttempt: args => {
+          this.analytics?.track(
+            {
+              type: 'r2',
+              statusCodeOrErrCode:
+                args.result.type === 'error'
+                  ? String(args.result.error.name ?? 'unknown')
+                  : args.result.response.status,
+              action: 'GET persistedOperation',
+              duration: args.duration,
+            },
+            targetId,
+          );
+        },
       },
-      targetId,
     );
 
     if (etagValue && response.status === 304) {
@@ -258,35 +240,26 @@ export class ArtifactStorageReader {
   }
 
   async readLegacyAccessKey(targetId: string) {
-    const start = performance.now();
-
-    const response = await this.s3.client
-      .fetch([this.s3.endpoint, this.s3.bucketName, 'cdn-legacy-keys', targetId].join('/'), {
+    const response = await this.s3.client.fetch(
+      [this.s3.endpoint, this.s3.bucketName, 'cdn-legacy-keys', targetId].join('/'),
+      {
         method: 'GET',
         timeout: READ_TIMEOUT_MS,
-      })
-      .catch(err => {
-        this.analytics?.track(
-          {
-            type: 'r2',
-            statusCodeOrErrCode: String(err.name ?? 'unknown'),
-            action: 'GET cdn-legacy-keys',
-            duration: performance.now() - start,
-          },
-          targetId,
-        );
-
-        throw err;
-      });
-
-    this.analytics?.track(
-      {
-        type: 'r2',
-        statusCodeOrErrCode: response.status,
-        action: 'GET cdn-legacy-keys',
-        duration: performance.now() - start,
+        onAttempt: args => {
+          this.analytics?.track(
+            {
+              type: 'r2',
+              statusCodeOrErrCode:
+                args.result.type === 'error'
+                  ? String(args.result.error.name ?? 'unknown')
+                  : args.result.response.status,
+              action: 'GET cdn-legacy-keys',
+              duration: args.duration,
+            },
+            targetId,
+          );
+        },
       },
-      targetId,
     );
 
     return response;
@@ -295,39 +268,30 @@ export class ArtifactStorageReader {
   async readAccessKey(targetId: string, keyId: string) {
     const s3KeyParts = ['cdn-keys', targetId, keyId];
 
-    const start = performance.now();
-
-    const response = await this.s3.client
-      .fetch([this.s3.endpoint, this.s3.bucketName, ...s3KeyParts].join('/'), {
+    const response = await this.s3.client.fetch(
+      [this.s3.endpoint, this.s3.bucketName, ...s3KeyParts].join('/'),
+      {
         method: 'GET',
         aws: {
           // This boolean makes Google Cloud Storage & AWS happy.
           signQuery: true,
         },
         timeout: READ_TIMEOUT_MS,
-      })
-      .catch(err => {
-        this.analytics?.track(
-          {
-            type: 'r2',
-            statusCodeOrErrCode: String(err.name ?? 'unknown'),
-            action: 'GET cdn-access-token',
-            duration: performance.now() - start,
-          },
-          targetId,
-        );
-
-        throw err;
-      });
-
-    this.analytics?.track(
-      {
-        type: 'r2',
-        statusCodeOrErrCode: response.status,
-        action: 'GET cdn-access-token',
-        duration: performance.now() - start,
+        onAttempt: args => {
+          this.analytics?.track(
+            {
+              type: 'r2',
+              statusCodeOrErrCode:
+                args.result.type === 'error'
+                  ? String(args.result.error.name ?? 'unknown')
+                  : args.result.response.status,
+              action: 'GET cdn-access-token',
+              duration: args.duration,
+            },
+            targetId,
+          );
+        },
       },
-      targetId,
     );
 
     return response;

--- a/packages/services/cdn-worker/src/aws.ts
+++ b/packages/services/cdn-worker/src/aws.ts
@@ -82,7 +82,7 @@ export class AwsClient {
     this.service = args.service;
     this.region = args.region;
     this.cache = args.cache || new Map();
-    this.retries = args.retries != null ? args.retries : 10; // Up to 25.6 secs
+    this.retries = args.retries != null ? args.retries : 3;
     this.initRetryMs = args.initRetryMs || 50;
     this._fetch = args.fetch || fetch.bind(globalThis);
   }

--- a/packages/services/cdn-worker/src/dev.ts
+++ b/packages/services/cdn-worker/src/dev.ts
@@ -28,12 +28,7 @@ const artifactStorageReader = new ArtifactStorageReader(s3, null);
 const handleRequest = createRequestHandler({
   isKeyValid: createIsKeyValid({ s3, getCache: null, waitUntil: null, analytics: null }),
   async getArtifactAction(targetId, contractName, artifactType, eTag) {
-    return artifactStorageReader.generateArtifactReadUrl(
-      targetId,
-      contractName,
-      artifactType,
-      eTag,
-    );
+    return artifactStorageReader.readArtifact(targetId, contractName, artifactType, eTag);
   },
   async fetchText(url) {
     const r = await fetch(url);

--- a/packages/services/cdn-worker/src/dev.ts
+++ b/packages/services/cdn-worker/src/dev.ts
@@ -26,7 +26,12 @@ const PORT = process.env.PORT ? parseInt(process.env.PORT, 10) : 4010;
 const artifactStorageReader = new ArtifactStorageReader(s3, null);
 
 const handleRequest = createRequestHandler({
-  isKeyValid: createIsKeyValid({ s3, getCache: null, waitUntil: null, analytics: null }),
+  isKeyValid: createIsKeyValid({
+    artifactStorageReader,
+    getCache: null,
+    waitUntil: null,
+    analytics: null,
+  }),
   async getArtifactAction(targetId, contractName, artifactType, eTag) {
     return artifactStorageReader.readArtifact(targetId, contractName, artifactType, eTag);
   },
@@ -42,7 +47,12 @@ const handleRequest = createRequestHandler({
 });
 
 const handleArtifactRequest = createArtifactRequestHandler({
-  isKeyValid: createIsKeyValid({ s3, getCache: null, waitUntil: null, analytics: null }),
+  isKeyValid: createIsKeyValid({
+    artifactStorageReader,
+    getCache: null,
+    waitUntil: null,
+    analytics: null,
+  }),
   isAppDeploymentActive: createIsAppDeploymentActive({
     artifactStorageReader,
     getCache: null,

--- a/packages/services/cdn-worker/src/index.ts
+++ b/packages/services/cdn-worker/src/index.ts
@@ -61,7 +61,7 @@ const handler: ExportedHandler<Env> = {
     const isKeyValid = createIsKeyValid({
       waitUntil: p => ctx.waitUntil(p),
       getCache: () => caches.open('artifacts-auth'),
-      s3,
+      artifactStorageReader,
       analytics,
     });
 

--- a/packages/services/cdn-worker/src/index.ts
+++ b/packages/services/cdn-worker/src/index.ts
@@ -67,12 +67,7 @@ const handler: ExportedHandler<Env> = {
 
     const handleRequest = createRequestHandler({
       async getArtifactAction(targetId, contractName, artifactType, eTag) {
-        return artifactStorageReader.generateArtifactReadUrl(
-          targetId,
-          contractName,
-          artifactType,
-          eTag,
-        );
+        return artifactStorageReader.readArtifact(targetId, contractName, artifactType, eTag);
       },
       isKeyValid,
       analytics,

--- a/packages/services/cdn-worker/src/key-validation.ts
+++ b/packages/services/cdn-worker/src/key-validation.ts
@@ -1,23 +1,17 @@
 import bcrypt from 'bcryptjs';
 import { Analytics } from './analytics';
-import { type AwsClient } from './aws';
+import { ArtifactStorageReader } from './artifact-storage-reader';
 import { decodeCdnAccessTokenSafe, isCDNAccessToken } from './cdn-token';
 
 export type KeyValidator = (targetId: string, headerKey: string) => Promise<boolean>;
 
 type WaitUntil = (promise: Promise<void>) => void;
 
-type S3Config = {
-  client: AwsClient;
-  bucketName: string;
-  endpoint: string;
-};
-
 type GetCache = () => Promise<Cache | null>;
 
 type CreateKeyValidatorDeps = {
   waitUntil: null | WaitUntil;
-  s3: S3Config;
+  artifactStorageReader: ArtifactStorageReader;
   getCache: null | GetCache;
   analytics: null | Analytics;
 };
@@ -39,7 +33,7 @@ export const createIsKeyValid =
 const handleLegacyCDNAccessToken = async (args: {
   targetId: string;
   accessToken: string;
-  s3: S3Config;
+  artifactStorageReader: ArtifactStorageReader;
   getCache: null | GetCache;
   waitUntil: null | WaitUntil;
   analytics: null | Analytics;
@@ -118,21 +112,7 @@ const handleLegacyCDNAccessToken = async (args: {
     }
   }
 
-  const key = await args.s3.client.fetch(
-    [args.s3.endpoint, args.s3.bucketName, 'cdn-legacy-keys', args.targetId].join('/'),
-    {
-      method: 'GET',
-    },
-  );
-
-  args.analytics?.track(
-    {
-      type: 'r2',
-      statusCode: key.status,
-      action: 'GET cdn-legacy-keys',
-    },
-    args.targetId,
-  );
+  const key = await args.artifactStorageReader.readLegacyAccessKey(args.targetId);
 
   if (key.status !== 200) {
     return withCache(false);
@@ -237,27 +217,7 @@ async function handleCDNAccessToken(
     return withCache(false);
   }
 
-  const s3KeyParts = ['cdn-keys', targetId, decodeResult.token.keyId];
-
-  const key = await deps.s3.client.fetch(
-    [deps.s3.endpoint, deps.s3.bucketName, ...s3KeyParts].join('/'),
-    {
-      method: 'GET',
-      aws: {
-        // This boolean makes Google Cloud Storage & AWS happy.
-        signQuery: true,
-      },
-    },
-  );
-
-  deps.analytics?.track(
-    {
-      type: 'r2',
-      statusCode: key.status,
-      action: 'GET cdn-access-token',
-    },
-    targetId,
-  );
+  const key = await deps.artifactStorageReader.readAccessKey(targetId, decodeResult.token.keyId);
 
   if (key.status !== 200) {
     return withCache(false);

--- a/packages/services/cdn-worker/tests/cdn.spec.ts
+++ b/packages/services/cdn-worker/tests/cdn.spec.ts
@@ -3,6 +3,7 @@ import * as bcrypt from 'bcryptjs';
 import '../src/dev-polyfill';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { describe, expect, test } from 'vitest';
+import { ArtifactStorageReader } from '../src/artifact-storage-reader';
 import {
   InvalidArtifactTypeResponse,
   InvalidAuthKeyResponse,
@@ -48,17 +49,20 @@ describe('CDN Worker', () => {
         getCache: null,
         waitUntil: null,
         analytics: null,
-        s3: {
-          endpoint: 'http://localhost:1337',
-          bucketName: 'artifacts',
-          client: {
-            async fetch() {
-              return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
-                status: 200,
-              });
-            },
-          } as any,
-        },
+        artifactStorageReader: new ArtifactStorageReader(
+          {
+            endpoint: 'http://localhost:1337',
+            bucketName: 'artifacts',
+            client: {
+              async fetch() {
+                return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
+                  status: 200,
+                });
+              },
+            } as any,
+          },
+          null,
+        ),
       }),
       async getArtifactAction(targetId, _, artifactType) {
         return map.has(`target:${targetId}:${artifactType}`)
@@ -124,17 +128,20 @@ describe('CDN Worker', () => {
         getCache: null,
         waitUntil: null,
         analytics: null,
-        s3: {
-          endpoint: 'http://localhost:1337',
-          bucketName: 'artifacts',
-          client: {
-            async fetch() {
-              return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
-                status: 200,
-              });
-            },
-          } as any,
-        },
+        artifactStorageReader: new ArtifactStorageReader(
+          {
+            endpoint: 'http://localhost:1337',
+            bucketName: 'artifacts',
+            client: {
+              async fetch() {
+                return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
+                  status: 200,
+                });
+              },
+            } as any,
+          },
+          null,
+        ),
       }),
       async getArtifactAction(targetId, _, artifactType) {
         return map.has(`target:${targetId}:${artifactType}`)
@@ -216,17 +223,20 @@ describe('CDN Worker', () => {
         getCache: null,
         waitUntil: null,
         analytics: null,
-        s3: {
-          endpoint: 'http://localhost:1337',
-          bucketName: 'artifacts',
-          client: {
-            async fetch() {
-              return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
-                status: 200,
-              });
-            },
-          } as any,
-        },
+        artifactStorageReader: new ArtifactStorageReader(
+          {
+            endpoint: 'http://localhost:1337',
+            bucketName: 'artifacts',
+            client: {
+              async fetch() {
+                return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
+                  status: 200,
+                });
+              },
+            } as any,
+          },
+          null,
+        ),
       }),
       async getArtifactAction(targetId, _, artifactType) {
         return map.has(`target:${targetId}:${artifactType}`)
@@ -292,17 +302,20 @@ describe('CDN Worker', () => {
         getCache: null,
         waitUntil: null,
         analytics: null,
-        s3: {
-          endpoint: 'http://localhost:1337',
-          bucketName: 'artifacts',
-          client: {
-            async fetch() {
-              return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
-                status: 200,
-              });
-            },
-          } as any,
-        },
+        artifactStorageReader: new ArtifactStorageReader(
+          {
+            endpoint: 'http://localhost:1337',
+            bucketName: 'artifacts',
+            client: {
+              async fetch() {
+                return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
+                  status: 200,
+                });
+              },
+            } as any,
+          },
+          null,
+        ),
       }),
       async getArtifactAction(targetId, _, artifactType) {
         return map.has(`target:${targetId}:${artifactType}`)
@@ -374,17 +387,20 @@ describe('CDN Worker', () => {
         getCache: null,
         waitUntil: null,
         analytics: null,
-        s3: {
-          endpoint: 'http://localhost:1337',
-          bucketName: 'artifacts',
-          client: {
-            async fetch() {
-              return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
-                status: 200,
-              });
-            },
-          } as any,
-        },
+        artifactStorageReader: new ArtifactStorageReader(
+          {
+            endpoint: 'http://localhost:1337',
+            bucketName: 'artifacts',
+            client: {
+              async fetch() {
+                return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
+                  status: 200,
+                });
+              },
+            } as any,
+          },
+          null,
+        ),
       }),
       async getArtifactAction(targetId, _, artifactType) {
         return map.has(`target:${targetId}:${artifactType}`)
@@ -454,17 +470,20 @@ describe('CDN Worker', () => {
         getCache: null,
         waitUntil: null,
         analytics: null,
-        s3: {
-          endpoint: 'http://localhost:1337',
-          bucketName: 'artifacts',
-          client: {
-            async fetch() {
-              return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
-                status: 200,
-              });
-            },
-          } as any,
-        },
+        artifactStorageReader: new ArtifactStorageReader(
+          {
+            endpoint: 'http://localhost:1337',
+            bucketName: 'artifacts',
+            client: {
+              async fetch() {
+                return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
+                  status: 200,
+                });
+              },
+            } as any,
+          },
+          null,
+        ),
       }),
       async getArtifactAction(targetId, _, artifactType) {
         return map.has(`target:${targetId}:${artifactType}`)
@@ -619,17 +638,20 @@ describe('CDN Worker', () => {
           getCache: null,
           waitUntil: null,
           analytics: null,
-          s3: {
-            endpoint: 'http://localhost:1337',
-            bucketName: 'artifacts',
-            client: {
-              async fetch() {
-                return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
-                  status: 200,
-                });
-              },
-            } as any,
-          },
+          artifactStorageReader: new ArtifactStorageReader(
+            {
+              endpoint: 'http://localhost:1337',
+              bucketName: 'artifacts',
+              client: {
+                async fetch() {
+                  return new Response(await bcrypt.hash(token, await bcrypt.genSalt()), {
+                    status: 200,
+                  });
+                },
+              } as any,
+            },
+            null,
+          ),
         }),
         async getArtifactAction(targetId, _, artifactType) {
           return map.has(`target:${targetId}:${artifactType}`)
@@ -667,17 +689,20 @@ describe('CDN Worker', () => {
           getCache: null,
           waitUntil: null,
           analytics: null,
-          s3: {
-            endpoint: 'http://localhost:1337',
-            bucketName: 'artifacts',
-            client: {
-              async fetch() {
-                return new Response(null, {
-                  status: 404,
-                });
-              },
-            } as any,
-          },
+          artifactStorageReader: new ArtifactStorageReader(
+            {
+              endpoint: 'http://localhost:1337',
+              bucketName: 'artifacts',
+              client: {
+                async fetch() {
+                  return new Response(null, {
+                    status: 404,
+                  });
+                },
+              } as any,
+            },
+            null,
+          ),
         }),
         async getArtifactAction(targetId, _, artifactType) {
           return map.has(`target:${targetId}:${artifactType}`)
@@ -713,17 +738,20 @@ describe('CDN Worker', () => {
           getCache: null,
           waitUntil: null,
           analytics: null,
-          s3: {
-            endpoint: 'http://localhost:1337',
-            bucketName: 'artifacts',
-            client: {
-              async fetch() {
-                return new Response(await bcrypt.hash('foobars', await bcrypt.genSalt()), {
-                  status: 200,
-                });
-              },
-            } as any,
-          },
+          artifactStorageReader: new ArtifactStorageReader(
+            {
+              endpoint: 'http://localhost:1337',
+              bucketName: 'artifacts',
+              client: {
+                async fetch() {
+                  return new Response(await bcrypt.hash('foobars', await bcrypt.genSalt()), {
+                    status: 200,
+                  });
+                },
+              } as any,
+            },
+            null,
+          ),
         }),
         async getArtifactAction() {
           return {

--- a/packages/services/server/src/index.ts
+++ b/packages/services/server/src/index.ts
@@ -542,7 +542,12 @@ export async function main() {
       const artifactStorageReader = new ArtifactStorageReader(s3, null);
 
       const artifactHandler = createArtifactRequestHandler({
-        isKeyValid: createIsKeyValid({ s3, analytics: null, getCache: null, waitUntil: null }),
+        isKeyValid: createIsKeyValid({
+          artifactStorageReader,
+          analytics: null,
+          getCache: null,
+          waitUntil: null,
+        }),
         artifactStorageReader,
         isAppDeploymentActive: createIsAppDeploymentActive({
           artifactStorageReader,


### PR DESCRIPTION
### Background

Requests being made to R2 keep hanging for long periods and cause problems in our production setup for a minimal amount of traffic.

### Description

- Make sure these long-running requests are aborted and retried
- Track analytics (duration, status code, error) for every single request made to R2
- Avoid resigned URLs and unnecessary requests to R2. Previously by redirecting, we lost all control and insights about the actual requests being performed to the bucket. Now we always proxy the R2 object through the CF worker.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
