### PR TITLE
Account for usedOverridden arg in extractSuperGraphInformation

### DIFF
--- a/packages/services/api/src/modules/schema/lib/federation-super-graph.ts
+++ b/packages/services/api/src/modules/schema/lib/federation-super-graph.ts
@@ -57,9 +57,17 @@ export const extractSuperGraphInformation = traceInlineSync(
       for (const fieldNode of node.fields) {
         const schemaCoordinate = `${node.name.value}.${fieldNode.name.value}`;
 
-        const graphArg = fieldNode.directives
-          ?.find(directive => directive.name.value === 'join__field')
-          ?.arguments?.find(arg => arg.name.value === 'graph');
+        const joinField = fieldNode.directives?.find(
+          (directive) =>
+            directive.name.value === "join__field" &&
+            !directive.arguments?.find(
+              (arg) =>
+                arg.name.value === "usedOverridden" &&
+                arg.value.kind === Kind.BOOLEAN &&
+                arg.value.value === true,
+            ),
+        );
+        const graphArg = joinField?.arguments?.find((arg) => arg.name.value === "graph");
 
         if (graphArg === undefined) {
           schemaCoordinateToServiceEnumValueMappings.set(


### PR DESCRIPTION
### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->
I have noticed fields provided by interfaces have the wrong subgraph associated with them in Hive's explorer.

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
Interfaces are being marked as resolved by the wrong subgraph in Hive. Although very poorly documented in the federation spec, there is a "usedOverridden" argument inside the "join__field" in these cases. Ignore any join__field directives with this argument.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
