### PR TITLE
Downgrade log level of an error when retrying an S3 call

### DIFF
--- a/packages/services/cdn-worker/src/aws.ts
+++ b/packages/services/cdn-worker/src/aws.ts
@@ -188,7 +188,7 @@ export class AwsClient {
       } catch (error) {
         const duration = performance.now() - attemptStart;
         // Retry also when there's an exception
-        console.error(error);
+        console.warn(error);
         init.onAttempt?.({
           attempt: retryCounter,
           duration,

--- a/packages/services/cdn-worker/src/index.ts
+++ b/packages/services/cdn-worker/src/index.ts
@@ -156,7 +156,7 @@ const handler: ExportedHandler<Env> = {
             }
           } catch (error) {
             // Retry also when there's an exception
-            console.error(error);
+            console.warn(error);
           }
           await new Promise(resolve =>
             setTimeout(resolve, Math.random() * initRetryMs * Math.pow(2, i)),


### PR DESCRIPTION
No point of reporting it to Sentry and it's not a fatal error.