### PR TITLE
Add CORS headers to CDN Worker

### DIFF
--- a/packages/services/cdn-worker/src/index.ts
+++ b/packages/services/cdn-worker/src/index.ts
@@ -196,6 +196,8 @@ const handler: ExportedHandler<Env> = {
 
     const router = itty
       .Router()
+      // Handles all OPTIONS and preflight requests.
+      // https://github.com/kwhitley/itty.dev/blob/v4.x/src/routes/itty-router/cors/%2Bpage.md#preflight-middleware
       .all('*', preflight)
       .get(
         '/_health',
@@ -208,25 +210,29 @@ const handler: ExportedHandler<Env> = {
       // Legacy CDN Handlers
       .get('*', handleRequest);
 
-    return router
-      .handle(request, sentry.captureException.bind(sentry))
-      .then(response => {
-        if (response) {
-          return response;
-        }
+    return (
+      router
+        .handle(request, sentry.captureException.bind(sentry))
+        .then(response => {
+          if (response) {
+            return response;
+          }
 
-        sentry.addBreadcrumb({
-          message: 'No response from router',
-        });
+          sentry.addBreadcrumb({
+            message: 'No response from router',
+          });
 
-        return createResponse(analytics, 'Not found', { status: 404 }, 'unknown', request);
-      })
-      .catch(error => {
-        console.error(error);
-        sentry.captureException(error);
-        return new UnexpectedError(analytics, request);
-      })
-      .then(corsify);
+          return createResponse(analytics, 'Not found', { status: 404 }, 'unknown', request);
+        })
+        .catch(error => {
+          console.error(error);
+          sentry.captureException(error);
+          return new UnexpectedError(analytics, request);
+        })
+        // Adds the appropriate CORS headers to any Response.
+        // https://github.com/kwhitley/itty.dev/blob/v4.x/src/routes/itty-router/cors/%2Bpage.md#corsify
+        .then(corsify)
+    );
   },
 };
 


### PR DESCRIPTION
Adds `preflight` to handles all OPTIONS and preflight requests.
Adds `corsify` to add the appropriate CORS headers to any Response.