### PR TITLE
feat: improve error handling for webhook broker

### DIFF
--- a/packages/services/webhooks/src/jobs.ts
+++ b/packages/services/webhooks/src/jobs.ts
@@ -77,7 +77,7 @@ export function createWebhookJob({ config }: { config: Config }) {
       } catch (error) {
         config.logger.error('Failed to call webhook (job=%s)', job.name, error);
         // so we can re-try
-        throw error
+        throw error;
       }
     } else {
       config.logger.warn('Giving up on webhook (job=%s)', job.name);

--- a/packages/services/webhooks/src/jobs.ts
+++ b/packages/services/webhooks/src/jobs.ts
@@ -76,6 +76,7 @@ export function createWebhookJob({ config }: { config: Config }) {
         }
       } catch (error) {
         config.logger.error('Failed to call webhook (job=%s)', job.name, error);
+        // so we can re-try
         throw error
       }
     } else {

--- a/packages/services/webhooks/src/jobs.ts
+++ b/packages/services/webhooks/src/jobs.ts
@@ -39,39 +39,44 @@ export function createWebhookJob({ config }: { config: Config }) {
         config.maxAttempts,
       );
 
-      if (config.requestBroker) {
-        await got.post(config.requestBroker.endpoint, {
-          headers: {
-            Accept: 'text/plain',
-            'x-hive-signature': config.requestBroker.signature,
-          },
-          timeout: {
-            request: 10_000,
-          },
-          json: {
-            url: job.data.endpoint,
-            method: 'POST',
+      try {
+        if (config.requestBroker) {
+          await got.post(config.requestBroker.endpoint, {
+            headers: {
+              Accept: 'text/plain',
+              'x-hive-signature': config.requestBroker.signature,
+            },
+            timeout: {
+              request: 10_000,
+            },
+            json: {
+              url: job.data.endpoint,
+              method: 'POST',
+              headers: {
+                Accept: 'application/json',
+                'Accept-Encoding': 'gzip, deflate, br',
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify(job.data.event),
+              resolveResponseBody: false,
+            },
+          });
+        } else {
+          await got.post(job.data.endpoint, {
             headers: {
               Accept: 'application/json',
               'Accept-Encoding': 'gzip, deflate, br',
               'Content-Type': 'application/json',
             },
-            body: JSON.stringify(job.data.event),
-            resolveResponseBody: false,
-          },
-        });
-      } else {
-        await got.post(job.data.endpoint, {
-          headers: {
-            Accept: 'application/json',
-            'Accept-Encoding': 'gzip, deflate, br',
-            'Content-Type': 'application/json',
-          },
-          timeout: {
-            request: 10_000,
-          },
-          json: job.data.event,
-        });
+            timeout: {
+              request: 10_000,
+            },
+            json: job.data.event,
+          });
+        }
+      } catch (error) {
+        config.logger.error('Failed to call webhook (job=%s)', job.name, error);
+        throw error
       }
     } else {
       config.logger.warn('Giving up on webhook (job=%s)', job.name);


### PR DESCRIPTION
In logs we saw HTTP 400 but not the actual reason of 400. So this will log an error even for us to track


Context: https://guild-oss.slack.com/archives/C01E8ATBQGN/p1725619720474049
