### PR TITLE
Add missing `global` attribute to `style jsx` fixing Chat position

### DIFF
--- a/packages/web/docs/src/components/page.tsx
+++ b/packages/web/docs/src/components/page.tsx
@@ -10,7 +10,9 @@ export function Page(props: { children: ReactNode; className?: string }) {
       <div className={cn('flex h-full flex-col', props.className)}>{props.children}</div>
       {mounted && <CookiesConsent />}
       {/* position Crisp button below the cookies banner */}
-      <style jsx global>{' .crisp-client { z-index: 40 !important; '}</style>
+      <style jsx global>
+        {' .crisp-client { z-index: 40 !important; '}
+      </style>
     </>
   );
 }

--- a/packages/web/docs/src/components/page.tsx
+++ b/packages/web/docs/src/components/page.tsx
@@ -10,7 +10,7 @@ export function Page(props: { children: ReactNode; className?: string }) {
       <div className={cn('flex h-full flex-col', props.className)}>{props.children}</div>
       {mounted && <CookiesConsent />}
       {/* position Crisp button below the cookies banner */}
-      <style jsx>{' .crisp-client { z-index: 40 !important; '}</style>
+      <style jsx global>{' .crisp-client { z-index: 40 !important; '}</style>
     </>
   );
 }


### PR DESCRIPTION
### Background

<img alt="image" src="https://github.com/user-attachments/assets/abfe4509-f895-40a0-9802-da6079c0a4a2" height="400px" />

### Description

My previous fix didn't work because I forgot about `global` here.

This should stop the chat bubble overlapping with the cookies "Accept" button.

