### PR TITLE
feat: Track clients & operations filters using search params

### DIFF
--- a/packages/web/app/src/components/target/insights/Fallback.tsx
+++ b/packages/web/app/src/components/target/insights/Fallback.tsx
@@ -29,7 +29,7 @@ export function OperationsFallback({
             <AlertCircleIcon className="size-4" />
             <AlertTitle>No stats available yet.</AlertTitle>
             <AlertDescription>
-              There is no information available for the selected date range.
+              There is no information available for the selected filters.
             </AlertDescription>
           </Alert>
         </div>

--- a/packages/web/app/src/components/target/insights/Filters.tsx
+++ b/packages/web/app/src/components/target/insights/Filters.tsx
@@ -54,7 +54,7 @@ function OperationsFilter({
   }
 
   const [selectedItems, setSelectedItems] = useState<string[]>(() =>
-    selected?.length ? selected : getOperationHashes(),
+    getOperationHashes().filter(hash => selected?.includes(hash) ?? true),
   );
 
   const onSelect = useCallback(
@@ -401,7 +401,7 @@ function ClientsFilter({
   }
 
   const [selectedItems, setSelectedItems] = useState<string[]>(() =>
-    selected?.length ? selected : getClientNames(),
+    getClientNames().filter(name => selected?.includes(name) ?? true),
   );
 
   const onSelect = useCallback(

--- a/packages/web/app/src/components/target/insights/List.tsx
+++ b/packages/web/app/src/components/target/insights/List.tsx
@@ -10,6 +10,7 @@ import { env } from '@/env/frontend';
 import { FragmentType, graphql, useFragment } from '@/gql';
 import { DateRangeInput } from '@/gql/graphql';
 import { useDecimal, useFormattedDuration, useFormattedNumber } from '@/lib/hooks';
+import { pick } from '@/lib/object';
 import { ChevronUpIcon, ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import { Link } from '@tanstack/react-router';
 import {
@@ -74,10 +75,11 @@ function OperationRow({
                   operationName: operation.name,
                   operationHash: operation.hash,
                 }}
-                search={{
+                search={searchParams => ({
+                  ...pick(searchParams, ['clients']),
                   from: selectedPeriod?.from ? encodeURIComponent(selectedPeriod.from) : undefined,
                   to: selectedPeriod?.to ? encodeURIComponent(selectedPeriod.to) : undefined,
-                }}
+                })}
               >
                 {operation.name}
               </Link>

--- a/packages/web/app/src/components/target/insights/Stats.tsx
+++ b/packages/web/app/src/components/target/insights/Stats.tsx
@@ -27,6 +27,7 @@ import {
   useFormattedNumber,
   useFormattedThroughput,
 } from '@/lib/hooks';
+import { pick } from '@/lib/object';
 import { useChartStyles } from '@/utils';
 import { useRouter } from '@tanstack/react-router';
 import { OperationsFallback } from './Fallback';
@@ -567,12 +568,7 @@ function ClientsStats(props: {
             name: ev.value,
           },
           search(searchParams) {
-            if ('from' in searchParams && 'to' in searchParams) {
-              return {
-                from: searchParams.from,
-                to: searchParams.to,
-              };
-            }
+            return pick(searchParams, ['from', 'to']);
           },
         });
       }

--- a/packages/web/app/src/lib/hooks/use-date-range-controller.ts
+++ b/packages/web/app/src/lib/hooks/use-date-range-controller.ts
@@ -85,6 +85,7 @@ export function useDateRangeController(args: {
     setSelectedPreset(preset: Preset) {
       void router.navigate({
         search: {
+          ...searchParams,
           from: preset.range.from,
           to: preset.range.to,
         },

--- a/packages/web/app/src/lib/hooks/use-search-params-filters.ts
+++ b/packages/web/app/src/lib/hooks/use-search-params-filters.ts
@@ -1,0 +1,35 @@
+import { useRouter } from '@tanstack/react-router';
+
+type SearchParamsFilter = string | string[];
+
+export function useSearchParamsFilter<TValue extends SearchParamsFilter>(
+  name: string,
+  defaultState: TValue,
+): [TValue, (value: TValue) => void] {
+  const router = useRouter();
+  const searchParams = router.latestLocation.search as any;
+
+  const rawSearchValue =
+    ((name as string) in searchParams && (searchParams[name] as string)) || null;
+  const searchValue = (deserializeSearchValue(rawSearchValue) ?? defaultState) as TValue;
+
+  const setSearchValue = (value: TValue) => {
+    void router.navigate({
+      search: {
+        ...searchParams,
+        [name]: serializeSearchValue(value),
+      },
+      replace: true,
+    });
+  };
+
+  return [searchValue, setSearchValue];
+}
+
+function serializeSearchValue(value: string | string[]) {
+  return value instanceof Array ? value.join(',') : value;
+}
+
+function deserializeSearchValue(value: string | null) {
+  return value?.split(',');
+}

--- a/packages/web/app/src/lib/object.spec.ts
+++ b/packages/web/app/src/lib/object.spec.ts
@@ -1,0 +1,27 @@
+import { pick } from './object';
+
+describe('object', () => {
+  describe('#pick', () => {
+    it('returns a new object with only picked keys', () => {
+      const input = { a: 1, b: 2, c: '1234' };
+      const result = pick(input, ['a', 'c']);
+      expect(result).toEqual({ a: 1, c: '1234' });
+      expect(result).not.toBe(input);
+    });
+
+    it('returns an empty object if no key is present on input', () => {
+      const input = { a: 1, b: 2, c: '1234' };
+      expect(pick(input, ['d'])).toEqual({});
+    });
+
+    it('returns an empty object if no key is passed', () => {
+      const input = { a: 1, b: 2, c: '1234' };
+      expect(pick(input, [])).toEqual({});
+    });
+
+    it('returns an object with only presented keys', () => {
+      const input = { a: 1, b: 2, c: '1234' };
+      expect(pick(input, ['a', 'd'])).toEqual({ a: 1 });
+    });
+  });
+});

--- a/packages/web/app/src/lib/object.ts
+++ b/packages/web/app/src/lib/object.ts
@@ -1,0 +1,11 @@
+export const pick = <TValue extends Record<string, any>>(value: TValue, keys: string[]) => {
+  return keys.reduce(
+    (acc, key) => {
+      if (key in value) {
+        acc[key] = value[key];
+      }
+      return acc;
+    },
+    {} as Record<string, any>,
+  );
+};

--- a/packages/web/app/src/pages/target-insights-client.tsx
+++ b/packages/web/app/src/pages/target-insights-client.tsx
@@ -16,6 +16,7 @@ import { CHART_PRIMARY_COLOR } from '@/constants';
 import { graphql } from '@/gql';
 import { formatNumber, formatThroughput, toDecimal } from '@/lib/hooks';
 import { useDateRangeController } from '@/lib/hooks/use-date-range-controller';
+import { pick } from '@/lib/object';
 import { useChartStyles } from '@/utils';
 import { Link } from '@tanstack/react-router';
 
@@ -280,14 +281,7 @@ function ClientView(props: {
                               operationName: operation.name,
                               operationHash: operation.operationHash ?? '_',
                             }}
-                            search={searchParams => {
-                              if ('from' in searchParams && 'to' in searchParams) {
-                                return {
-                                  from: searchParams.from,
-                                  to: searchParams.to,
-                                };
-                              }
-                            }}
+                            search={searchParams => pick(searchParams, ['from', 'to'])}
                           >
                             {operation.name}
                           </Link>

--- a/packages/web/app/src/pages/target-insights-operation.tsx
+++ b/packages/web/app/src/pages/target-insights-operation.tsx
@@ -16,6 +16,7 @@ import { Subtitle, Title } from '@/components/ui/page';
 import { QueryError } from '@/components/ui/query-error';
 import { FragmentType, graphql, useFragment } from '@/gql';
 import { useDateRangeController } from '@/lib/hooks/use-date-range-controller';
+import { useSearchParamsFilter } from '@/lib/hooks/use-search-params-filters';
 
 const GraphQLOperationBody_OperationFragment = graphql(`
   fragment GraphQLOperationBody_OperationFragment on Operation {
@@ -69,7 +70,7 @@ function OperationView({
     dataRetentionInDays,
     defaultPreset: presetLast1Day,
   });
-  const [selectedClients, setSelectedClients] = useState<string[]>([]);
+  const [selectedClients, setSelectedClients] = useSearchParamsFilter<string[]>('clients', []);
   const operationsList = useMemo(() => [operationHash], [operationHash]);
 
   const [result] = useQuery({

--- a/packages/web/app/src/pages/target-insights.tsx
+++ b/packages/web/app/src/pages/target-insights.tsx
@@ -16,6 +16,7 @@ import { Subtitle, Title } from '@/components/ui/page';
 import { QueryError } from '@/components/ui/query-error';
 import { graphql } from '@/gql';
 import { useDateRangeController } from '@/lib/hooks/use-date-range-controller';
+import { useSearchParamsFilter } from '@/lib/hooks/use-search-params-filters';
 
 function OperationsView({
   organizationCleanId,
@@ -28,8 +29,11 @@ function OperationsView({
   targetCleanId: string;
   dataRetentionInDays: number;
 }): ReactElement {
-  const [selectedOperations, setSelectedOperations] = useState<string[]>([]);
-  const [selectedClients, setSelectedClients] = useState<string[]>([]);
+  const [selectedOperations, setSelectedOperations] = useSearchParamsFilter<string[]>(
+    'operations',
+    [],
+  );
+  const [selectedClients, setSelectedClients] = useSearchParamsFilter<string[]>('clients', []);
   const dateRangeController = useDateRangeController({
     dataRetentionInDays,
     defaultPreset: presetLast7Days,


### PR DESCRIPTION
### Background

At Toast, every team has a weekly metric review meeting where teams go through their dashboards and metrics for their services and SPAs. Teams have been using Hive Insights for client metrics. As teams go through a spreadsheet with all dashboard links, it has been a bit annoying to have to set the filters every time.

This PR adds the clients and operations filters to the search params (same done already for the date presets).

### Description

- Created a hook to manage any search params filter.
- Changed clients and operations filters to use `useSearchParamsFilter` instead of `useState`.
- Fixed `useDateRangeController` to not remove current search params when the user changes it.
- Changed Fallback component to display a more generic message as there might not be stats for a given combination of filters (clients, operations, date).
- Changed clients and operations triggers so it ignores values that are not present in the backend response.
- Added a new util helper to pick partial objects from a set of keys

### Checklist

- [ ] Input validation
  - I tested with a couple inputs (invalid ones, with special characters, long strings). Same as below. Should I truncate the list?
- [ ] Memory management
  - Should we truncate to specific size for clients and operations filter?
