### PR TITLE
[docs] Add docuementation for  and WS headers propagation

### DIFF
--- a/packages/web/docs/src/pages/docs/api-reference/gateway-config.mdx
+++ b/packages/web/docs/src/pages/docs/api-reference/gateway-config.mdx
@@ -121,7 +121,7 @@ Most Gateway Transports can be configured using the `transportEntries` option.
 
 This option is mostly used to customize the subscription transport to be used when it's not using
 the one used for queries and mutations. To learn more about subscriptions between gateway and
-upstream, please visit the [Subscriptions page](/graphql/hive/docs/gateway/subscriptions)
+upstream, please visit the [Subscriptions page](/docs/gateway/subscriptions)
 
 Otherwise, all configuration is derived from subgraphs definition.
 
@@ -215,7 +215,7 @@ the specific documentation of each transport.
 
 A special case of the `option` fields is `subcriptions`. It allows to override the transport options
 (including the kind) only for subscripions. Please see
-[Subscriptions page](/graphql/hive/docs/gateway/subscriptions) for more details.
+[Subscriptions page](/docs/gateway/subscriptions) for more details.
 
 ### Subgraphs
 

--- a/packages/web/docs/src/pages/docs/api-reference/gateway-config.mdx
+++ b/packages/web/docs/src/pages/docs/api-reference/gateway-config.mdx
@@ -115,6 +115,108 @@ And see the implementation of the default `transport` loading logic
 
 You can replace this logic by providing your own `transports`.
 
+### `transportEntries`
+
+Most Gateway Transports can be configured using the `transportEntries` option.
+
+This option is mostly used to customize the subscription transport to be used when it's not using
+the one used for queries and mutations. To learn more about subscriptions between gateway and
+upstream, please visit the [Subscriptions page](/graphql/hive/docs/gateway/subscriptions)
+
+Otherwise, all configuration is derived from subgraphs definition.
+
+#### Subgraph matcher
+
+Each subgraph's transport can be configured by adding a configuration object to the
+`transportEntries` map, using the subgraph's name as a key.
+
+```ts filename="gateway.config.ts"
+import { defineConfig } from '@graphql-hive/gateway'
+
+export const gatewayConfig = defineConfig({
+  transportEntries: {
+    subgraphName: {
+      // configuration for the 'subgraphName' subgraph transport.
+    }
+  }
+})
+```
+
+Most of the time, all subgraph using the same transport will have the same configuration. To avoid
+duplicating the configuration object for each subgraphs, you can use a transport matcher syntax
+`*.transportKind`:
+
+```ts filename="gateway.config.ts"
+import { defineConfig } from '@graphql-hive/gateway'
+
+export const gatewayConfig = defineConfig({
+  transportEntries: {
+    '*.http': {
+      // configuration for all subgraph using the http transport.
+    }
+  }
+})
+```
+
+If you need to define a configuration for all subgraphs at once, you can use the wildcard matcher
+`*`:
+
+```ts filename="gateway.config.ts"
+import { defineConfig } from '@graphql-hive/gateway'
+
+export const gatewayConfig = defineConfig({
+  transportEntries: {
+    '*': {
+      // configuration for all subgraph using the http transport.
+    }
+  }
+})
+```
+
+If a subgraph mathes multiple transport entries, the configurations are merged with priority for the
+most specific matcher (`subgraphName` > `*.transportKind` > `*`).
+
+#### `kind`
+
+The kind of transport to be used. This will be used by the `transports` loading mechanism to find
+the proper transport implementation.
+
+#### `location`
+
+The location of the subgraph. Can be either a absolute or a relative path. Defaults to the one
+defined in the subgraphs configuration.
+
+#### `headers`
+
+A list of headers entries to add (when applicable) to the upstream request. Values must be strings,
+and can be dynamic by including string interpolations.
+
+```ts filename="graphql.config.ts"
+import { defineConfig } from '@graphql-hive/gateway'
+
+export const gatewayConfig = defineConfig({
+  transportEntries: {
+    '*.http': {
+      headers: [
+        ['authorization', '{context.cookie.authorization}'],
+        ['correlation-id', '{context.header.correalation-id}']
+      ]
+    }
+  }
+})
+```
+
+#### `options`
+
+An additional option object specific to the transport kind. You can find the accepted option here in
+the specific documentation of each transport.
+
+#### `options.subscriptions`
+
+A special case of the `option` fields is `subcriptions`. It allows to override the transport options
+(including the kind) only for subscripions. Please see
+[Subscriptions page](/graphql/hive/docs/gateway/subscriptions) for more details.
+
 ### Subgraphs
 
 If you want to serve a single subgraph, you can provide the subgraph configuration as well. You can

--- a/packages/web/docs/src/pages/docs/gateway/subscriptions.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/subscriptions.mdx
@@ -312,7 +312,7 @@ import { defineConfig, type HTTPCallbackTransportOptions } from '@graphql-hive/g
 
 export const gatewayConfig = defineConfig({
   transportEntries: {
-    '*.http': { // <-- Will be applied to products, views and stocks subgraphs
+    '*.http': { // <-- Will be applied to products, views and stocks subgraphs, but not stores.
       options: {
         subscriptions: {
           kind: 'ws',

--- a/packages/web/docs/src/pages/docs/gateway/subscriptions.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/subscriptions.mdx
@@ -175,6 +175,11 @@ Downstream clients are still subscribing to Hive Gateway gateway through any sup
 protocol, but upstream Hive Gateway will use long-living WebSocket connections to the "products"
 service.
 
+<Callout>
+  WebSocket for communications between Hive Gateway and subgraphs are suboptimal compared to other
+  possible transports. We recommend using either SSE or HTTP Callbacks instead.
+</Callout>
+
 ### Propagation of authorization
 
 Hive Gateway can propagate the downstream client's `Authorization` header contents to the upstream

--- a/packages/web/docs/src/pages/docs/gateway/subscriptions.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/subscriptions.mdx
@@ -314,7 +314,7 @@ import { defineConfig, type HTTPCallbackTransportOptions } from '@graphql-hive/g
 export const gatewayConfig = defineConfig({
   transportEntries: {
     '*.http': {
-      // <-- Will be applied to products, views and stocks subgraphs, but not stores.
+      // Will be applied to products, views and stocks subgraphs, but not stores.
       options: {
         subscriptions: {
           kind: 'ws',
@@ -327,7 +327,7 @@ export const gatewayConfig = defineConfig({
       }
     },
     products: {
-      // <-- Will override the subscriptions configuration for products subgraph only
+      // Will override the subscriptions configuration for products subgraph only
       options: {
         subscriptions: {
           kind: 'http-callback',

--- a/packages/web/docs/src/pages/docs/gateway/subscriptions.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/subscriptions.mdx
@@ -295,6 +295,7 @@ The key of each entry determine which subgraph will be impacted:
  - `{subgraphName}`: a specific subgraph.
 
 Configuration are inherited and merged from the least specific to the most specific matcher.
+Only exception is the `headers` which is not inherited for the `ws` transport.
 
 ### Example
 

--- a/packages/web/docs/src/pages/docs/gateway/subscriptions.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/subscriptions.mdx
@@ -27,6 +27,9 @@ The example is somewhat similar to
 [Apollo's documentation](https://www.apollographql.com/docs/router/executing-operations/subscription-support/#example-execution),
 except for that we use GraphQL Yoga here and significantly reduce the setup requirements.
 
+You can find this example
+[source on GitHub](https://github.com/ardatan/graphql-mesh/tree/master/e2e/federation-subscriptions-passthrough).
+
 ### Install dependencies
 
 ```ssh npm2yarn

--- a/packages/web/docs/src/pages/docs/gateway/subscriptions.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/subscriptions.mdx
@@ -186,6 +186,13 @@ Hive Gateway can propagate the downstream client's `Authorization` header conten
 WebSocket connections through the
 [`ConnectionInit` message payload](https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverWebSocket.md#connectioninit).
 
+<Callout type="warning">
+  If either `connectionParams` or `headers` are used with dynamic values, it can drastically
+  increase the number of upstream WebSockets connections. <br />
+  Since `headers` and `connectionParams` can only be applied at connection time, a new connection is
+  required for each different set of values provided.
+</Callout>
+
 ```ts filename="gateway.config.ts"
 import { defineConfig, type WSTransportOptions } from '@graphql-hive/gateway'
 

--- a/packages/web/docs/src/pages/docs/gateway/subscriptions.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/subscriptions.mdx
@@ -235,9 +235,7 @@ export const gatewayConfig = defineConfig({
         subscriptions: {
           kind: 'ws',
           location: '/subscriptions',
-          headers: [
-            ['authorization', '{context.headers.authorization}']
-          ]
+          headers: [['authorization', '{context.headers.authorization}']]
         }
       }
     }
@@ -246,8 +244,8 @@ export const gatewayConfig = defineConfig({
 ```
 
 <Callout>
-The headers will be sent only with the upgrade request.
-They will not be sent again during the lifecycle of the subscription.
+  The headers will be sent only with the upgrade request. They will not be sent again during the
+  lifecycle of the subscription.
 </Callout>
 
 ## Subscriptions using HTTP Callback
@@ -290,20 +288,23 @@ By default, subscriptions will use the same transport than queries and mutation.
 using the `transportEntries` option.
 
 The key of each entry determine which subgraph will be impacted:
- - `*`: all subgraphs
- - `*.{transportKind}`: all subgraphs using `transportKind`. For example, `*.http` will impact all subgraph using the `http` transport.
- - `{subgraphName}`: a specific subgraph.
 
-Configuration are inherited and merged from the least specific to the most specific matcher.
-Only exception is the `headers` which is not inherited for the `ws` transport.
+- `*`: all subgraphs
+- `*.{transportKind}`: all subgraphs using `transportKind`. For example, `*.http` will impact all
+  subgraph using the `http` transport.
+- `{subgraphName}`: a specific subgraph.
+
+Configuration are inherited and merged from the least specific to the most specific matcher. Only
+exception is the `headers` which is not inherited for the `ws` transport.
 
 ### Example
 
 Let be 4 subgraphs:
- - products: using `http` transport for queries, and HTTP callbacks for subscriptions
- - views: using `http` transport for queries, and WS for subscriptions
- - stocks: using `http` transport for queries, and WS for subscriptions
- - stores: using `mysql` transport
+
+- products: using `http` transport for queries, and HTTP callbacks for subscriptions
+- views: using `http` transport for queries, and WS for subscriptions
+- stocks: using `http` transport for queries, and WS for subscriptions
+- stores: using `mysql` transport
 
 The configuration will be:
 
@@ -312,7 +313,8 @@ import { defineConfig, type HTTPCallbackTransportOptions } from '@graphql-hive/g
 
 export const gatewayConfig = defineConfig({
   transportEntries: {
-    '*.http': { // <-- Will be applied to products, views and stocks subgraphs, but not stores.
+    '*.http': {
+      // <-- Will be applied to products, views and stocks subgraphs, but not stores.
       options: {
         subscriptions: {
           kind: 'ws',
@@ -321,10 +323,11 @@ export const gatewayConfig = defineConfig({
               token: '{context.headers.authorization}'
             }
           }
-        },
+        }
       }
     },
-    'products': { // <-- Will override the subscriptions configuration for products subgraph only
+    products: {
+      // <-- Will override the subscriptions configuration for products subgraph only
       options: {
         subscriptions: {
           kind: 'http-callback',
@@ -332,7 +335,7 @@ export const gatewayConfig = defineConfig({
           headers: [['authorization', 'context.headers.authorization']]
         }
       }
-    },
+    }
   }
 })
 ```

--- a/packages/web/docs/src/pages/docs/gateway/subscriptions.mdx
+++ b/packages/web/docs/src/pages/docs/gateway/subscriptions.mdx
@@ -136,7 +136,7 @@ curl 'http://localhost:4000/graphql' \
   --data-raw '{"query":"subscription OnProductPriceChanged { productPriceChanged { name price reviews { score } } }","operationName":"OnProductPriceChanged"}'
 ```
 
-## Subgraphs using WebSockets
+## Subscriptions using WebSockets
 
 If your subgraph uses WebSockets for subscriptions support
 ([like with Apollo Server](https://www.apollographql.com/docs/apollo-server/data/subscriptions/)),
@@ -175,9 +175,9 @@ Downstream clients are still subscribing to Hive Gateway gateway through any sup
 protocol, but upstream Hive Gateway will use long-living WebSocket connections to the "products"
 service.
 
-### `Authorization` header
+### Propagation of authorization
 
-Hive Gatewayr can propagate the downstream client's `Authorization` header contents to the upstream
+Hive Gateway can propagate the downstream client's `Authorization` header contents to the upstream
 WebSocket connections through the
 [`ConnectionInit` message payload](https://github.com/graphql/graphql-over-http/blob/main/rfcs/GraphQLOverWebSocket.md#connectioninit).
 
@@ -220,6 +220,36 @@ The contents of the payload will be available in `graphql-ws` connectionParams:
   WebSockets](https://www.apollographql.com/docs/router/executing-operations/subscription-support/#websocket-auth-support).
 </Callout>
 
+It is also possible, but not recommended, to propagate HTTP headers by sending them alongside the
+WebSocket upgrade request.
+
+```ts filename="gateway.config.ts"
+import { defineConfig, type WSTransportOptions } from '@graphql-hive/gateway'
+
+export const gatewayConfig = defineConfig({
+  supergraph: 'supergraph.graphql',
+  transportEntries: {
+    // use "*.http" to apply options to all subgraphs with HTTP
+    '*.http': {
+      options: {
+        subscriptions: {
+          kind: 'ws',
+          location: '/subscriptions',
+          headers: [
+            ['authorization', '{context.headers.authorization}']
+          ]
+        }
+      }
+    }
+  }
+})
+```
+
+<Callout>
+The headers will be sent only with the upgrade request.
+They will not be sent again during the lifecycle of the subscription.
+</Callout>
+
 ## Subscriptions using HTTP Callback
 
 If your subgraph uses
@@ -250,6 +280,58 @@ export const gatewayConfig = defineConfig({
         }
       }
     }
+  }
+})
+```
+
+## Subscriptions transport configuration
+
+By default, subscriptions will use the same transport than queries and mutation. This can be change
+using the `transportEntries` option.
+
+The key of each entry determine which subgraph will be impacted:
+ - `*`: all subgraphs
+ - `*.{transportKind}`: all subgraphs using `transportKind`. For example, `*.http` will impact all subgraph using the `http` transport.
+ - `{subgraphName}`: a specific subgraph.
+
+Configuration are inherited and merged from the least specific to the most specific matcher.
+
+### Example
+
+Let be 4 subgraphs:
+ - products: using `http` transport for queries, and HTTP callbacks for subscriptions
+ - views: using `http` transport for queries, and WS for subscriptions
+ - stocks: using `http` transport for queries, and WS for subscriptions
+ - stores: using `mysql` transport
+
+The configuration will be:
+
+```ts filename="gateway.config.ts"
+import { defineConfig, type HTTPCallbackTransportOptions } from '@graphql-hive/gateway'
+
+export const gatewayConfig = defineConfig({
+  transportEntries: {
+    '*.http': { // <-- Will be applied to products, views and stocks subgraphs
+      options: {
+        subscriptions: {
+          kind: 'ws',
+          options: {
+            connectionParams: {
+              token: '{context.headers.authorization}'
+            }
+          }
+        },
+      }
+    },
+    'products': { // <-- Will override the subscriptions configuration for products subgraph only
+      options: {
+        subscriptions: {
+          kind: 'http-callback',
+          location: '/subscriptions',
+          headers: [['authorization', 'context.headers.authorization']]
+        }
+      }
+    },
   }
 })
 ```


### PR DESCRIPTION
### Background

Currently, there is no real explanation about how `transportEntries` works.

### Description

This PR adds explanation about `transportEntries` behaviour in the context of subscriptions.

It also show how to propagate headers when using WebSocket subscriptions.

### TODO
 - [x] `transportEntries` explanation in subscriptions
 - [x] HTTP headers propagation for WS transport
 - [x] `transportEntries` in API reference

