### PR TITLE
fix: fully validate published graphql schema for single project

### DIFF
--- a/integration-tests/tests/api/schema/check.spec.ts
+++ b/integration-tests/tests/api/schema/check.spec.ts
@@ -1867,7 +1867,7 @@ describe.concurrent(
 );
 
 test.concurrent(
-  'checking an invalid schema fails due to validation errors (deprecated non-nullable input field',
+  'checking an invalid schema fails due to validation errors (deprecated non-nullable input field)',
   async () => {
     const { createOrg } = await initSeed().createOwner();
     const { createProject } = await createOrg();

--- a/integration-tests/tests/api/schema/check.spec.ts
+++ b/integration-tests/tests/api/schema/check.spec.ts
@@ -1,4 +1,6 @@
 import { ProjectType, RuleInstanceSeverityLevel, TargetAccessScope } from 'testkit/gql/graphql';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { createStorage } from '@hive/storage';
 import { graphql } from '../../../testkit/gql';
 import { execute } from '../../../testkit/graphql';
 import { initSeed } from '../../../testkit/seed';
@@ -1861,5 +1863,174 @@ describe.concurrent(
         });
       },
     );
+  },
+);
+
+test.concurrent(
+  'checking an invalid schema fails due to validation errors (deprecated non-nullable input field',
+  async () => {
+    const { createOrg } = await initSeed().createOwner();
+    const { createProject } = await createOrg();
+    const { createToken } = await createProject(ProjectType.Single);
+    const token = await createToken({
+      targetScopes: [
+        TargetAccessScope.Read,
+        TargetAccessScope.RegistryRead,
+        TargetAccessScope.RegistryWrite,
+        TargetAccessScope.Settings,
+      ],
+    });
+
+    const sdl = /* GraphQL */ `
+      type Query {
+        a(b: B!): String
+      }
+
+      input B {
+        a: String! @deprecated(reason: "This field is deprecated")
+        b: String!
+      }
+    `;
+
+    const result = await token.checkSchema(sdl).then(r => r.expectNoGraphQLErrors());
+
+    expect(result.schemaCheck).toEqual({
+      __typename: 'SchemaCheckError',
+      changes: {
+        nodes: [],
+        total: 0,
+      },
+      errors: {
+        nodes: [
+          {
+            message: 'Required input field B.a cannot be deprecated.',
+          },
+        ],
+        total: 1,
+      },
+      schemaCheck: {
+        id: expect.any(String),
+      },
+      valid: false,
+    });
+  },
+);
+
+function connectionString() {
+  const {
+    POSTGRES_USER = 'postgres',
+    POSTGRES_PASSWORD = 'postgres',
+    POSTGRES_HOST = 'localhost',
+    POSTGRES_PORT = 5432,
+    POSTGRES_DB = 'registry',
+    POSTGRES_SSL = null,
+    POSTGRES_CONNECTION_STRING = null,
+  } = process.env;
+  return (
+    POSTGRES_CONNECTION_STRING ||
+    `postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}${
+      POSTGRES_SSL ? '?sslmode=require' : '?sslmode=disable'
+    }`
+  );
+}
+
+test.concurrent(
+  'checking a valid schema onto a broken schema succeeds (prior schema has deprecated non-nullable input)',
+  async () => {
+    const { createOrg } = await initSeed().createOwner();
+    const { createProject, organization } = await createOrg();
+    const { createToken, project, target } = await createProject(ProjectType.Single);
+    const token = await createToken({
+      targetScopes: [
+        TargetAccessScope.Read,
+        TargetAccessScope.RegistryRead,
+        TargetAccessScope.RegistryWrite,
+        TargetAccessScope.Settings,
+      ],
+    });
+
+    const brokenSdl = /* GraphQL */ `
+      type Query {
+        a(b: B!): String
+      }
+
+      input B {
+        a: String! @deprecated(reason: "This field is deprecated")
+        b: String!
+      }
+    `;
+
+    // we need to manually insert a broken schema version into the database
+    // as we fixed the issue that allows publishing such a broken version
+
+    const conn = connectionString();
+    const storage = await createStorage(conn, 2);
+    await storage.createVersion({
+      schema: brokenSdl,
+      author: 'Jochen',
+      async actionFn() {},
+      base_schema: null,
+      commit: '123',
+      changes: [],
+      compositeSchemaSDL: null,
+      conditionalBreakingChangeMetadata: null,
+      contracts: null,
+      coordinatesDiff: null,
+      diffSchemaVersionId: null,
+      github: null,
+      metadata: null,
+      logIds: [],
+      project: project.id,
+      service: null,
+      organization: organization.id,
+      previousSchemaVersion: null,
+      valid: true,
+      schemaCompositionErrors: [],
+      supergraphSDL: null,
+      tags: null,
+      target: target.id,
+      url: null,
+    });
+    await storage.destroy();
+
+    const validSdl = /* GraphQL */ `
+      type Query {
+        a(b: B!): String
+      }
+
+      input B {
+        a: String @deprecated(reason: "This field is deprecated")
+        b: String!
+      }
+    `;
+
+    const sdl = /* GraphQL */ `
+      type Query {
+        a(b: B!): String
+      }
+
+      input B {
+        a: String @deprecated(reason: "This field is deprecated")
+        b: String!
+      }
+    `;
+
+    const result = await token.checkSchema(sdl).then(r => r.expectNoGraphQLErrors());
+    expect(result.schemaCheck).toEqual({
+      __typename: 'SchemaCheckSuccess',
+      changes: {
+        nodes: [
+          {
+            criticality: 'Safe',
+            message: "Input field 'B.a' changed type from 'String!' to 'String'",
+          },
+        ],
+        total: 1,
+      },
+      schemaCheck: {
+        id: expect.any(String),
+      },
+      valid: true,
+    });
   },
 );

--- a/integration-tests/tests/api/schema/publish.spec.ts
+++ b/integration-tests/tests/api/schema/publish.spec.ts
@@ -4242,3 +4242,90 @@ test.concurrent(
     });
   },
 );
+
+test.concurrent(
+  'publishing a valid schema onto a broken schema succeeds (prior schema has deprecated non-nullable input)',
+  async () => {
+    const { createOrg } = await initSeed().createOwner();
+    const { createProject, organization } = await createOrg();
+    const { createToken, project, target } = await createProject(ProjectType.Single);
+    const token = await createToken({
+      targetScopes: [
+        TargetAccessScope.Read,
+        TargetAccessScope.RegistryRead,
+        TargetAccessScope.RegistryWrite,
+        TargetAccessScope.Settings,
+      ],
+    });
+
+    const brokenSdl = /* GraphQL */ `
+      type Query {
+        a(b: B!): String
+      }
+
+      input B {
+        a: String! @deprecated(reason: "This field is deprecated")
+        b: String!
+      }
+    `;
+
+    // we need to manually insert a broken schema version into the database
+    // as we fixed the issue that allows publishing such a broken version
+
+    const conn = connectionString();
+    const storage = await createStorage(conn, 2);
+    await storage.createVersion({
+      schema: brokenSdl,
+      author: 'Jochen',
+      async actionFn() {},
+      base_schema: null,
+      commit: '123',
+      changes: [],
+      compositeSchemaSDL: null,
+      conditionalBreakingChangeMetadata: null,
+      contracts: null,
+      coordinatesDiff: null,
+      diffSchemaVersionId: null,
+      github: null,
+      metadata: null,
+      logIds: [],
+      project: project.id,
+      service: null,
+      organization: organization.id,
+      previousSchemaVersion: null,
+      valid: true,
+      schemaCompositionErrors: [],
+      supergraphSDL: null,
+      tags: null,
+      target: target.id,
+      url: null,
+    });
+    await storage.destroy();
+
+    const validSdl = /* GraphQL */ `
+      type Query {
+        a(b: B!): String
+      }
+
+      input B {
+        a: String @deprecated(reason: "This field is deprecated")
+        b: String!
+      }
+    `;
+
+    const result = await token
+      .publishSchema({
+        sdl: validSdl,
+      })
+      .then(r => r.expectNoGraphQLErrors());
+
+    expect(result.schemaPublish).toEqual({
+      __typename: 'SchemaPublishSuccess',
+      changes: null,
+      initial: false,
+      linkToWebsite: expect.any(String),
+      message: '',
+      valid: true,
+    });
+  },
+);


### PR DESCRIPTION
### Background

A customer reported that publishing app deployments failed with an unexpected error. After some digging, it turns out the customer published an invalid GraphQL schema.

### Description

This PR adds a test to reproduce the issue and fixes the publish of single schemas to do all necessary additional validations.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
