### PR TITLE
Versioning of docker images

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/@changesets/config@2.1.0/schema.json",
+  "$schema": "https://unpkg.com/@changesets/config@2.2.0/schema.json",
   "changelog": ["@changesets/changelog-github", { "repo": "kamilkisiela/graphql-hive" }],
   "commit": false,
   "linked": [],
@@ -10,5 +10,9 @@
   "snapshot": {
     "useCalculatedVersion": true,
     "prereleaseTemplate": "{tag}-{datetime}-{commit}"
+  },
+  "privatePackages": {
+    "tag": true,
+    "version": true
   }
 }

--- a/.github/workflows/release-docker.yaml
+++ b/.github/workflows/release-docker.yaml
@@ -1,0 +1,39 @@
+name: 'Release Docker Images'
+
+# When a tag is pushed, it means a new release is being made.
+on:
+  push:
+    tags:
+      # "hive@1.2.3" is an example tag that will trigger this workflow.
+      # "hive" represents the docker images needed for self-hosting.
+      - hive@*
+
+jobs:
+  version:
+    runs-on: ubuntu-22.04
+
+    # Pass the version number to the next job
+    outputs:
+      number: ${{ steps.version.outputs.number }}
+
+    steps:
+      - name: extract version from tag
+        id: version
+        run: |
+          # hive@1.0.0
+          VERSION=${{ github.ref_name }}
+          # 1.0.0
+          VERSION_NUMBER=$(echo $VERSION | sed 's/[^0-9.]*//g')
+          echo "number=$VERSION_NUMBER" >> $GITHUB_OUTPUT
+
+  publish:
+    needs: [version]
+    if: ${{ contains(needs.version.outputs.number, '.') }}
+    uses: ./.github/workflows/build-and-dockerize.yaml
+    with:
+      imageTag: ${{ needs.version.outputs.number }}
+      publishLatest: true
+      publishSourceMaps: true
+      targets: build
+      uploadJavaScriptArtifacts: true
+    secrets: inherit

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -56,8 +56,8 @@ jobs:
         run: |
           echo '${{steps.changesets.outputs.publishedPackages}}' > cli-ver.json
           VERSION=`echo $(jq -r '.[] | select(.name | endswith("@graphql-hive/cli")).version' cli-ver.json)`
-          echo "cli_version=$VERSION" >> $GITHUB_OUTPUT
-          echo "cli_publish=true" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "publish=true" >> $GITHUB_OUTPUT
 
       - name: extract published hive version
         if:
@@ -67,8 +67,8 @@ jobs:
         run: |
           echo '${{steps.changesets.outputs.publishedPackages}}' > hive-ver.json
           VERSION=`echo $(jq -r '.[] | select(.name == "hive").version' hive-ver.json)`
-          echo "hive_version=$VERSION" >> $GITHUB_OUTPUT
-          echo "hive_publish=true" >> $GITHUB_OUTPUT
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "publish=true" >> $GITHUB_OUTPUT
 
       # Needed for `oclif pack win`
       - name: Install NSIS

--- a/.github/workflows/release-stable.yaml
+++ b/.github/workflows/release-stable.yaml
@@ -13,8 +13,10 @@ jobs:
       AWS_S3_ENDPOINT: https://6d5bc18cd8d13babe7ed321adba3d8ae.r2.cloudflarestorage.com
 
     outputs:
-      publish: ${{ steps.cli.outputs.publish }}
-      version: ${{ steps.cli.outputs.version }}
+      cli_publish: ${{ steps.cli.outputs.publish }}
+      cli_version: ${{ steps.cli.outputs.version }}
+      hive_publish: ${{ steps.hive.outputs.publish }}
+      hive_version: ${{ steps.hive.outputs.version }}
 
     steps:
       - name: checkout
@@ -46,7 +48,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GUILD_BOT_TOKEN }}
 
-      - name: extract published version
+      - name: extract published cli version
         if:
           steps.changesets.outputs.published && contains(steps.changesets.outputs.publishedPackages,
           '"@graphql-hive/cli"')
@@ -54,8 +56,19 @@ jobs:
         run: |
           echo '${{steps.changesets.outputs.publishedPackages}}' > cli-ver.json
           VERSION=`echo $(jq -r '.[] | select(.name | endswith("@graphql-hive/cli")).version' cli-ver.json)`
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "publish=true" >> $GITHUB_OUTPUT
+          echo "cli_version=$VERSION" >> $GITHUB_OUTPUT
+          echo "cli_publish=true" >> $GITHUB_OUTPUT
+
+      - name: extract published hive version
+        if:
+          steps.changesets.outputs.published && contains(steps.changesets.outputs.publishedPackages,
+          '"hive"')
+        id: hive
+        run: |
+          echo '${{steps.changesets.outputs.publishedPackages}}' > hive-ver.json
+          VERSION=`echo $(jq -r '.[] | select(.name == "hive").version' hive-ver.json)`
+          echo "hive_version=$VERSION" >> $GITHUB_OUTPUT
+          echo "hive_publish=true" >> $GITHUB_OUTPUT
 
       # Needed for `oclif pack win`
       - name: Install NSIS
@@ -79,10 +92,22 @@ jobs:
           VERSION: ${{ steps.cli.outputs.version }}
         run: pnpm oclif promote --no-xz --sha ${GITHUB_SHA:0:7} --version $VERSION
 
-  publish_docker:
+  publish_docker_cli:
     needs: [publish]
     uses: ./.github/workflows/dockerize-cli.yaml
-    if: ${{ needs.publish.outputs.publish == 'true' }}
+    if: ${{ needs.publish.outputs.cli_publish == 'true' }}
     with:
-      cliVersion: ${{ needs.publish.outputs.version }}
+      cliVersion: ${{ needs.publish.outputs.cli_version }}
+    secrets: inherit
+
+  publish_docker:
+    needs: [publish]
+    if: ${{ needs.publish.outputs.hive_publish == 'true' }}
+    uses: ./.github/workflows/build-and-dockerize.yaml
+    with:
+      imageTag: ${{ needs.publish.outputs.hive_version }}
+      publishSourceMaps: true
+      publishLatest: true
+      targets: build
+      uploadJavaScriptArtifacts: true
     secrets: inherit

--- a/.github/workflows/typescript-typecheck.yaml
+++ b/.github/workflows/typescript-typecheck.yaml
@@ -29,7 +29,7 @@ jobs:
         run: helm plugin install https://github.com/losisin/helm-values-schema-json.git
 
       - name: generate pulumi deps
-        run: pnpm --filter @hive/deployment generate
+        run: pnpm --filter hive generate
 
       - name: typecheck
         run: pnpm run --workspace-concurrency ${{ steps.cpu-cores.outputs.count }} -r typecheck

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ from standalone APIs to composed schemas (Federation, Stitching).
   ([status page](https://status.graphql-hive.com))
 - [Read the announcement blog post](https://the-guild.dev/blog/announcing-graphql-hive-public)
 - [Read the docs](https://the-guild.dev/graphql/hive/docs)
+- [View the changelog for self-hosting](./deployments/CHANGELOG.md)
 
 ## Built for the community, for all GraphQL APIs
 
@@ -49,6 +50,8 @@ experience of its final users**.
 
 GraphQL Hive is completely open-source under the MIT license, meaning that you are free to host on
 your own infrastructure.
+
+- [Changelog](./deployments/CHANGELOG.md)
 
 GraphQL Hive helps you get a global overview of the usage of your GraphQL API with:
 

--- a/deployment/CHANGELOG.md
+++ b/deployment/CHANGELOG.md
@@ -1,0 +1,7 @@
+# hive
+
+## 1.0.0
+
+**This is the first officially versioned release of Hive.**
+
+While it has been available and in use for some time, this marks the introduction of formal versioning and a changelog to track future updates and improvements.

--- a/deployment/package.json
+++ b/deployment/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hive",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "private": true,
   "scripts": {
     "generate": "tsx generate.ts",

--- a/deployment/package.json
+++ b/deployment/package.json
@@ -1,8 +1,10 @@
 {
-  "name": "@hive/deployment",
+  "name": "hive",
+  "version": "0.0.0",
   "private": true,
   "scripts": {
     "generate": "tsx generate.ts",
+    "publish": "echo 'Publish is done through the CD pipeline - see .github/workflows/release-stable.yaml'",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "test": "vitest",
     "test:e2e": "CYPRESS_BASE_URL=$HIVE_APP_BASE_URL cypress run",
     "test:integration": "cd integration-tests && pnpm test:integration",
-    "typecheck": "pnpm run -r --filter '!@hive/deployment' typecheck",
+    "typecheck": "pnpm run -r --filter '!hive' typecheck",
     "upload-sourcemaps": "./scripts/upload-sourcemaps.sh",
     "workspace": "pnpm run --filter $1 $2"
   },

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "ts-node": "10.9.2",
     "tsup": "8.2.4",
     "tsx": "4.18.0",
-    "turbo": "1.13.4",
+    "turbo": "2.1.3",
     "typescript": "5.5.4",
     "vite-tsconfig-paths": "5.0.1",
     "vitest": "2.0.5"

--- a/packages/services/server/turbo.json
+++ b/packages/services/server/turbo.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": ["dist/**"],
+      "inputs": ["../../web/app/src/gql/persisted-documents.json"]
+    }
+  }
+}

--- a/packages/web/docs/turbo.json
+++ b/packages/web/docs/turbo.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://turborepo.org/schema.json",
+  "extends": ["//"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", "!.next/cache/**"]
+    }
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -179,8 +179,8 @@ importers:
         specifier: 4.18.0
         version: 4.18.0
       turbo:
-        specifier: 1.13.4
-        version: 1.13.4
+        specifier: 2.1.3
+        version: 2.1.3
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -16192,38 +16192,38 @@ packages:
     resolution: {integrity: sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==}
     engines: {node: '>=0.6.11 <=0.7.0 || >=0.7.3'}
 
-  turbo-darwin-64@1.13.4:
-    resolution: {integrity: sha512-A0eKd73R7CGnRinTiS7txkMElg+R5rKFp9HV7baDiEL4xTG1FIg/56Vm7A5RVgg8UNgG2qNnrfatJtb+dRmNdw==}
+  turbo-darwin-64@2.1.3:
+    resolution: {integrity: sha512-ouJOm0g0YyoBuhmikEujVCBGo3Zr0lbSOWFIsQtWUTItC88F2w2byhjtsYGPXQwMlTbXwmoBU2lOCfWNkeEwHQ==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@1.13.4:
-    resolution: {integrity: sha512-eG769Q0NF6/Vyjsr3mKCnkG/eW6dKMBZk6dxWOdrHfrg6QgfkBUk0WUUujzdtVPiUIvsh4l46vQrNVd9EOtbyA==}
+  turbo-darwin-arm64@2.1.3:
+    resolution: {integrity: sha512-j2FOJsK4LAOtHQlb3Oom0yWB/Vi0nF1ljInr311mVzHoFAJRZtfW2fRvdZRb/lBUwjSp8be58qWHzANIcrA0OA==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@1.13.4:
-    resolution: {integrity: sha512-Bq0JphDeNw3XEi+Xb/e4xoKhs1DHN7OoLVUbTIQz+gazYjigVZvtwCvgrZI7eW9Xo1eOXM2zw2u1DGLLUfmGkQ==}
+  turbo-linux-64@2.1.3:
+    resolution: {integrity: sha512-ubRHkI1gSel7H7wsmxKK8C9UlLWqg/2dkCC88LFupaK6TKgvBKqDqA0Z1M9C/escK0Jsle2k0H8bybV9OYIl4Q==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@1.13.4:
-    resolution: {integrity: sha512-BJcXw1DDiHO/okYbaNdcWN6szjXyHWx9d460v6fCHY65G8CyqGU3y2uUTPK89o8lq/b2C8NK0yZD+Vp0f9VoIg==}
+  turbo-linux-arm64@2.1.3:
+    resolution: {integrity: sha512-LffUL+e5wv7BtD6DgnM2kKOlDkMo2eRjhbAjVnrCD3wi2ug0tl6NDzajnHHjtaMyOnIf4AvzSKdLWsBxafGBQA==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@1.13.4:
-    resolution: {integrity: sha512-OFFhXHOFLN7A78vD/dlVuuSSVEB3s9ZBj18Tm1hk3aW1HTWTuAw0ReN6ZNlVObZUHvGy8d57OAGGxf2bT3etQw==}
+  turbo-windows-64@2.1.3:
+    resolution: {integrity: sha512-S9SvcZZoaq5jKr6kA6eF7/xgQhVn8Vh7PVy5lono9zybvhyL4eY++y2PaLToIgL8G9IcbLmgOC73ExNjFBg9XQ==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@1.13.4:
-    resolution: {integrity: sha512-u5A+VOKHswJJmJ8o8rcilBfU5U3Y1TTAfP9wX8bFh8teYF1ghP0EhtMRLjhtp6RPa+XCxHHVA2CiC3gbh5eg5g==}
+  turbo-windows-arm64@2.1.3:
+    resolution: {integrity: sha512-twlEo8lRrGbrR6T/ZklUIquW3IlFCEtywklgVA81aIrSBm56+GEVpSrHhIlsx1hiYeSNrs+GpDwZGe+V7fvEVQ==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@1.13.4:
-    resolution: {integrity: sha512-1q7+9UJABuBAHrcC4Sxp5lOqYS5mvxRrwa33wpIyM18hlOCpRD/fTJNxZ0vhbMcJmz15o9kkVm743mPn7p6jpQ==}
+  turbo@2.1.3:
+    resolution: {integrity: sha512-lY0yj2GH2a2a3NExZ3rGe+rHUVeFE2aXuRAue57n+08E7Z7N7YCmynju0kPC1grAQzERmoLpKrmzmWd+PNiADw==}
     hasBin: true
 
   tweetnacl@0.14.5:
@@ -35378,32 +35378,32 @@ snapshots:
 
   tunnel@0.0.6: {}
 
-  turbo-darwin-64@1.13.4:
+  turbo-darwin-64@2.1.3:
     optional: true
 
-  turbo-darwin-arm64@1.13.4:
+  turbo-darwin-arm64@2.1.3:
     optional: true
 
-  turbo-linux-64@1.13.4:
+  turbo-linux-64@2.1.3:
     optional: true
 
-  turbo-linux-arm64@1.13.4:
+  turbo-linux-arm64@2.1.3:
     optional: true
 
-  turbo-windows-64@1.13.4:
+  turbo-windows-64@2.1.3:
     optional: true
 
-  turbo-windows-arm64@1.13.4:
+  turbo-windows-arm64@2.1.3:
     optional: true
 
-  turbo@1.13.4:
+  turbo@2.1.3:
     optionalDependencies:
-      turbo-darwin-64: 1.13.4
-      turbo-darwin-arm64: 1.13.4
-      turbo-linux-64: 1.13.4
-      turbo-linux-arm64: 1.13.4
-      turbo-windows-64: 1.13.4
-      turbo-windows-arm64: 1.13.4
+      turbo-darwin-64: 2.1.3
+      turbo-darwin-arm64: 2.1.3
+      turbo-linux-64: 2.1.3
+      turbo-linux-arm64: 2.1.3
+      turbo-windows-64: 2.1.3
+      turbo-windows-arm64: 2.1.3
 
   tweetnacl@0.14.5: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -11,51 +11,10 @@
     "scripts/templates/runify-next.ts",
     "patches/*"
   ],
-  "pipeline": {
+  "tasks": {
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**"]
-    },
-    "@hive/libraries/core#build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
-    },
-    "@hive/libraries/apollo#build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
-    },
-    "@hive/libraries/yoga#build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
-    },
-    "@hive/libraries/envelop#build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
-    },
-    "@hive/cdn-script#build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
-    },
-    "@hive/broker-script#build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
-    },
-    "@hive/app#build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
-    },
-    "@hive/docs#build": {
-      "dependsOn": ["^build"],
-      "outputs": [".next/**", "!.next/cache/**"]
-    },
-    "@hive/migrations#build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
-    },
-    "@hive/server#build": {
-      "dependsOn": ["^build"],
-      "outputs": ["dist/**"],
-      "inputs": ["../../web/app/src/gql/persisted-documents.json"]
     },
     "check:build": {
       "outputs": [""]


### PR DESCRIPTION
Related document: https://www.notion.so/theguildoss/Publishing-new-version-of-Hive-11ab6b71848a80078762ec951188be8e?pvs=4

#2995 

1. `pnpm changeset` 
2. Select `hive`
3. Pick a level
4. Describe changes
5. Merge a Pull Request to release a new version

All changes will be visible under `hive@` prefix ([an example](https://github.com/kamilkisiela/graphql-hive/releases?q=%40graphql-hive%2Fyoga&expanded=true)), but also in `deployment/changelog.md`.

## Background

In order to use `changesets` for publishing hive's docker images with proper version tag, it has to be part of the "packages" (of the workspace).
Using root package.json was not an option due to [this issue](https://github.com/changesets/changesets/issues/1137#issuecomment-2312752530). The next good candidate was `deployment` directory.

According to https://github.com/changesets/changesets/blob/main/docs/versioning-apps.md\#managing-applications-or-non-npm-packages tags are not created by default, that's why `privatePackages` option is adjusted in changeset's config file.

