### PR TITLE
feat: auto-focus form input when visiting login and sign up page

### DIFF
--- a/packages/web/app/src/pages/auth-sign-in.tsx
+++ b/packages/web/app/src/pages/auth-sign-in.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { FaRegUserCircle } from 'react-icons/fa';
 import { SiGithub, SiGoogle, SiOkta } from 'react-icons/si';
@@ -81,6 +81,7 @@ export function AuthSignInPage(props: { redirectToPath: string }) {
   const [lastAuthMethod, setLastAuthMethod] = useLastAuthMethod();
   const router = useRouter();
   const { toast } = useToast();
+
   const emailPasswordSignIn = useMutation({
     mutationFn: superEmailPasswordSignIn,
     onSuccess(data) {
@@ -133,6 +134,7 @@ export function AuthSignInPage(props: { redirectToPath: string }) {
       });
     },
   });
+
   const thirdPartySignIn = useMutation({
     async mutationFn(provider: 'github' | 'google' | 'okta') {
       await startAuthFlowForProvider(provider, props.redirectToPath);
@@ -146,7 +148,9 @@ export function AuthSignInPage(props: { redirectToPath: string }) {
       });
     },
   });
+
   const isPending = emailPasswordSignIn.isPending || thirdPartySignIn.isPending;
+
   const form = useForm({
     mode: 'onSubmit',
     resolver: zodResolver(SignInFormSchema),
@@ -156,6 +160,12 @@ export function AuthSignInPage(props: { redirectToPath: string }) {
     },
     disabled: isPending,
   });
+
+  useEffect(() => {
+    if (emailPasswordSignIn.isPending === false) {
+      form.setFocus('email', { shouldSelect: true });
+    }
+  }, [emailPasswordSignIn.isPending]);
 
   const onSubmit = useCallback(
     (data: SignInFormValues) => {
@@ -199,11 +209,15 @@ export function AuthSignInPage(props: { redirectToPath: string }) {
                   <FormField
                     control={form.control}
                     name="email"
-                    render={({ field }) => (
+                    render={() => (
                       <FormItem>
                         <FormLabel>Email</FormLabel>
                         <FormControl>
-                          <Input placeholder="m@example.com" type="email" {...field} />
+                          <Input
+                            placeholder="m@example.com"
+                            type="email"
+                            {...form.register('email')}
+                          />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -212,7 +226,7 @@ export function AuthSignInPage(props: { redirectToPath: string }) {
                   <FormField
                     control={form.control}
                     name="password"
-                    render={({ field }) => (
+                    render={() => (
                       <FormItem>
                         <div className="flex items-center">
                           <FormLabel>Password</FormLabel>
@@ -229,7 +243,7 @@ export function AuthSignInPage(props: { redirectToPath: string }) {
                           </Link>
                         </div>
                         <FormControl>
-                          <Input type="password" {...field} />
+                          <Input type="password" {...form.register('password')} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>

--- a/packages/web/app/src/pages/auth-sign-up.tsx
+++ b/packages/web/app/src/pages/auth-sign-up.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { FaRegUserCircle } from 'react-icons/fa';
 import { SiGithub, SiGoogle, SiOkta } from 'react-icons/si';
@@ -150,6 +150,11 @@ export function AuthSignUpPage(props: { redirectToPath: string }) {
     },
     disabled: isPending,
   });
+
+  useEffect(() => {
+    form.setFocus('firstName', { shouldSelect: true });
+  }, [signUp.isPending]);
+
   const { toast } = useToast();
 
   const onSubmit = useCallback(
@@ -210,11 +215,11 @@ export function AuthSignUpPage(props: { redirectToPath: string }) {
                     <FormField
                       control={form.control}
                       name="firstName"
-                      render={({ field }) => (
+                      render={() => (
                         <FormItem>
                           <FormLabel>First name</FormLabel>
                           <FormControl>
-                            <Input placeholder="Max" {...field} />
+                            <Input placeholder="Max" {...form.register('firstName')} />
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -223,11 +228,11 @@ export function AuthSignUpPage(props: { redirectToPath: string }) {
                     <FormField
                       control={form.control}
                       name="lastName"
-                      render={({ field }) => (
+                      render={() => (
                         <FormItem>
                           <FormLabel>Last name</FormLabel>
                           <FormControl>
-                            <Input placeholder="Robinson" {...field} />
+                            <Input placeholder="Robinson" {...form.register('lastName')} />
                           </FormControl>
                           <FormMessage />
                         </FormItem>
@@ -237,11 +242,15 @@ export function AuthSignUpPage(props: { redirectToPath: string }) {
                   <FormField
                     control={form.control}
                     name="email"
-                    render={({ field }) => (
+                    render={() => (
                       <FormItem>
                         <FormLabel>Email</FormLabel>
                         <FormControl>
-                          <Input placeholder="m@example.com" type="email" {...field} />
+                          <Input
+                            placeholder="m@example.com"
+                            type="email"
+                            {...form.register('email')}
+                          />
                         </FormControl>
                         <FormMessage />
                       </FormItem>
@@ -250,11 +259,11 @@ export function AuthSignUpPage(props: { redirectToPath: string }) {
                   <FormField
                     control={form.control}
                     name="password"
-                    render={({ field }) => (
+                    render={() => (
                       <FormItem>
                         <FormLabel>Password</FormLabel>
                         <FormControl>
-                          <Input type="password" {...field} />
+                          <Input type="password" {...form.register('password')} />
                         </FormControl>
                         <FormMessage />
                       </FormItem>


### PR DESCRIPTION
### Description


When visiting the login/sign up page, we automatically focus the first input field.

When a sign up/sign in fails, we automatically focus the first input field.

This makes editing invalid values a bit more convenient.


https://github.com/user-attachments/assets/f6874d4e-8764-4db3-8585-90ad333f0c5b



### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
