### PR TITLE
fix: oidc login failed message before redirect

### DIFF
--- a/packages/web/app/src/pages/auth-oidc.tsx
+++ b/packages/web/app/src/pages/auth-oidc.tsx
@@ -14,8 +14,9 @@ function AuthOIDC(props: { oidcId: string; redirectToPath: string }) {
       if (!env.auth.oidc) {
         throw new Error('OIDC provider is not configured');
       }
-
       await startAuthFlowForOIDCProvider(props.oidcId);
+      // we need to return something, otherwise react-query will throw an error
+      return true;
     },
   });
 

--- a/packages/web/app/src/pages/auth-sso.tsx
+++ b/packages/web/app/src/pages/auth-sso.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { CircleHelpIcon } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { useSessionContext } from 'supertokens-auth-react/recipe/session';
@@ -102,11 +102,14 @@ export function AuthSSOPage(props: { redirectToPath: string }) {
     },
     disabled: sso.isPending,
   });
+
+  useEffect(() => {
+    form.setFocus('slug', { shouldSelect: true });
+  }, [sso.isPending]);
   const { toast } = useToast();
 
   const onSubmit = useCallback(
     (data: SSOFormValues) => {
-      sso.reset();
       sso.mutate({
         slug: data.slug,
       });
@@ -143,7 +146,7 @@ export function AuthSSOPage(props: { redirectToPath: string }) {
                 <FormField
                   control={form.control}
                   name="slug"
-                  render={({ field }) => (
+                  render={() => (
                     <FormItem>
                       <FormLabel className="flex flex-row items-center gap-x-2">
                         Organization slug{' '}
@@ -163,7 +166,7 @@ export function AuthSSOPage(props: { redirectToPath: string }) {
                         </TooltipProvider>
                       </FormLabel>
                       <FormControl>
-                        <Input placeholder="acme" {...field} />
+                        <Input placeholder="acme" {...form.register('slug')} />
                       </FormControl>
                       <FormMessage />
                     </FormItem>


### PR DESCRIPTION
### Background

When people log in with OIDC, they can briefly see a "oidc" login failed message before they get redirected to their provider.


https://github.com/user-attachments/assets/1fe37337-a440-450d-acec-d76c0ae4dae0



### Description

This error was caused by react query. This issue is resolved by simply returning a dummy value from the mutate function. As a bonus, we also auto-focus the input field!

Closes https://github.com/kamilkisiela/graphql-hive/issues/5536

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
