### PR TITLE
fix: schema type filter when latest schema version is broken

### DIFF
--- a/packages/web/app/src/components/target/explorer/filter.tsx
+++ b/packages/web/app/src/components/target/explorer/filter.tsx
@@ -27,7 +27,7 @@ const TypeFilter_AllTypes = graphql(`
     target(selector: { organization: $organization, project: $project, target: $target }) {
       __typename
       id
-      latestSchemaVersion {
+      latestValidSchemaVersion {
         __typename
         id
         valid
@@ -81,7 +81,7 @@ export function TypeFilter(props: {
     requestPolicy: 'cache-first',
   });
 
-  const allNamedTypes = query.data?.target?.latestSchemaVersion?.explorer?.types;
+  const allNamedTypes = query.data?.target?.latestValidSchemaVersion?.explorer?.types;
   const types = useMemo(
     () =>
       allNamedTypes?.map(t => ({


### PR DESCRIPTION
### Background

Closes https://github.com/kamilkisiela/graphql-hive/issues/5398

### Description

We need to query the latest valid schema version instead of the latest schema version.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
