### PR TITLE
fix: Improve support priority descriptions

### DIFF
--- a/packages/web/app/src/components/organization/support.tsx
+++ b/packages/web/app/src/components/organization/support.tsx
@@ -53,9 +53,12 @@ const priorityVariants = cva(
 );
 
 export const priorityDescription: Record<SupportTicketPriority, string> = {
-  [SupportTicketPriority.Normal]: 'Minor business impact or general questions',
-  [SupportTicketPriority.High]: 'Major business impact',
-  [SupportTicketPriority.Urgent]: 'Critical business impact',
+  [SupportTicketPriority.Normal]:
+    'Minor problems or general questions with little to no impact on functionality, often involving small nuisances or easily bypassed errors.',
+  [SupportTicketPriority.High]:
+    'Problems that significantly hinder functionality, resulting in severe performance degradation while the platform remains operational.',
+  [SupportTicketPriority.Urgent]:
+    'Problems that halt essential functionality, preventing critical business operations with no workarounds available.',
 };
 
 export function Priority({


### PR DESCRIPTION
Make the descriptions bit more descriptive based on the SLA we have for Free/Pro accounts

![CleanShot 2024-10-08 at 11 58 55@2x](https://github.com/user-attachments/assets/3f12d769-19cc-4646-8dbe-510fc7ae7122)
