### PR TITLE
Remove icons from feature tabs

### DIFF
--- a/packages/web/docs/src/components/feature-tabs.tsx
+++ b/packages/web/docs/src/components/feature-tabs.tsx
@@ -155,7 +155,6 @@ export function FeatureTabs({ className }: { className?: string }) {
             <Tabs.Content value="Schema Registry" tabIndex={-1}>
               <Feature
                 title="Schema Registry"
-                icon={<SchemaRegistryIcon />}
                 documentationLink="/docs/schema-registry"
                 description="Publish schemas, compose federated services, and detect backward-incompatible changes with ease."
                 highlights={highlights['Schema Registry']}
@@ -165,7 +164,6 @@ export function FeatureTabs({ className }: { className?: string }) {
             <Tabs.Content value="GraphQL Observability" tabIndex={-1}>
               <Feature
                 title="GraphQL Observability"
-                icon={<GraphQLObservabilityIcon />}
                 documentationLink="/docs/schema-registry/usage-reporting"
                 description="Enhanced GraphQL Observability tools provide insights into API usage and user experience metrics."
                 highlights={highlights['GraphQL Observability']}
@@ -175,7 +173,6 @@ export function FeatureTabs({ className }: { className?: string }) {
             <Tabs.Content value="Schema Management" tabIndex={-1}>
               <Feature
                 title="Schema Management"
-                icon={<SchemaManagementIcon />}
                 description="Evolve your GraphQL API with confidence."
                 highlights={highlights['Schema Management']}
                 setActiveHighlight={setActiveHighlight}
@@ -233,19 +230,17 @@ function SchemaManagementIcon() {
 }
 
 function Feature(props: {
-  icon: ReactNode;
   title: string;
   description: string;
   highlights: Highlight[];
   documentationLink?: string;
   setActiveHighlight: (highlight: string) => void;
 }) {
-  const { icon, title, description, documentationLink, highlights } = props;
+  const { title, description, documentationLink, highlights } = props;
 
   return (
     <div className="flex flex-col gap-6 px-4 pb-4 md:gap-12 md:pb-12 md:pl-12 md:pr-16">
       <header className="flex flex-wrap items-center gap-4 md:flex-col md:items-start md:gap-6">
-        <Stud>{icon}</Stud>
         <Heading as="h2" size="md" className="text-green-1000 max-sm:text-2xl max-sm:leading-8">
           {title}
         </Heading>


### PR DESCRIPTION
Removed the icons.

BTW: Schema Management tab is missing a link to docs. We should one.

<img width="1331" alt="image" src="https://github.com/user-attachments/assets/006b3b9a-ae95-4a8b-aec1-aa6b72c507ae">
