### PR TITLE
Use `latest` tag only on stable docker releases

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ jobs:
     with:
       imageTag: ${{ github.sha }}
       publishSourceMaps: true
-      publishLatest: true
+      publishLatest: false
       targets: build
       uploadJavaScriptArtifacts: true
     secrets: inherit


### PR DESCRIPTION
Instead of using `latest` for every merged commit, use it only when a new stable version is released.