### PR TITLE
bring back Nextra 2 default focus on landing page

### DIFF
--- a/packages/web/docs/src/focus-styles.css
+++ b/packages/web/docs/src/focus-styles.css
@@ -1,0 +1,18 @@
+/* same as in Nextra 2 */
+
+a,
+summary,
+button,
+input,
+[tabindex]:not([tabindex='-1']) {
+  @apply outline-none;
+
+  &:focus-visible {
+    @apply ring-2 ring-[hsl(var(--nextra-primary-hue)_var(--nextra-primary-saturation)_86%)] ring-offset-1 ring-offset-[hsl(var(--nextra-primary-hue)_var(--nextra-primary-saturation)_77%)] dark:ring-[hsl(var(--nextra-primary-hue)_var(--nextra-primary-saturation)_32%)] dark:ring-offset-[hsl(var(--nextra-primary-hue)_var(--nextra-primary-saturation)_39%)];
+  }
+}
+
+a,
+summary {
+  @apply rounded;
+}

--- a/packages/web/docs/src/pages/_app.tsx
+++ b/packages/web/docs/src/pages/_app.tsx
@@ -4,6 +4,7 @@ import '@theguild/components/style.css';
 import localFont from 'next/font/local';
 import '../components/navigation-menu/navbar-global-styles.css';
 import '../selection-styles.css';
+import '../focus-styles.css';
 
 const neueMontreal = localFont({
   // TODO: Swap to variable version.


### PR DESCRIPTION
### Background

<img width="698" alt="image" src="https://github.com/user-attachments/assets/72553936-a539-464d-b010-23b8b94eb781">

### Description

I like the change to explicitly use `.nextra-focus` in Nextra 3 conceptually. It's clean.

But I also really enjoy having a consistent focus style for landing pages, so I brought back the old default (and inlined its colors).

I might refactor it with Cascade Layers in a bit to make it easier to override, but this PR fixed the regression.

