### PR TITLE
Add MIT license to docker labels

### DIFF
--- a/docker/cli.dockerfile
+++ b/docker/cli.dockerfile
@@ -8,6 +8,7 @@ WORKDIR /usr/src/app
 
 RUN npm install --global @graphql-hive/cli@${CLI_VERSION}
 
+LABEL org.opencontainers.image.licenses=MIT
 LABEL org.opencontainers.image.title=$IMAGE_TITLE
 LABEL org.opencontainers.image.version=$RELEASE
 LABEL org.opencontainers.image.description=$IMAGE_DESCRIPTION

--- a/docker/migrations.dockerfile
+++ b/docker/migrations.dockerfile
@@ -11,6 +11,7 @@ ENV ENVIRONMENT production
 ENV NODE_ENV production
 ENV RELEASE $RELEASE
 
+LABEL org.opencontainers.image.licenses=MIT
 LABEL org.opencontainers.image.title=$IMAGE_TITLE
 LABEL org.opencontainers.image.version=$RELEASE
 LABEL org.opencontainers.image.description=$IMAGE_DESCRIPTION

--- a/docker/services.dockerfile
+++ b/docker/services.dockerfile
@@ -8,6 +8,7 @@ WORKDIR /usr/src/app/$SERVICE_DIR_NAME
 COPY --from=dist . /usr/src/app/$SERVICE_DIR_NAME/
 COPY --from=shared . /
 
+LABEL org.opencontainers.image.licenses=MIT
 LABEL org.opencontainers.image.title=$IMAGE_TITLE
 LABEL org.opencontainers.image.version=$RELEASE
 LABEL org.opencontainers.image.description=$IMAGE_DESCRIPTION


### PR DESCRIPTION
Github Container Registry supports:
- org.opencontainers.image.source ✅ 
- org.opencontainers.image.description ✅ 
- org.opencontainers.image.licenses - the PR adds this label and MIT as a value

