### PR TITLE
Rename Azure Active Directory to Entra ID

### DIFF
--- a/packages/web/docs/src/pages/docs/management/sso-oidc-provider.mdx
+++ b/packages/web/docs/src/pages/docs/management/sso-oidc-provider.mdx
@@ -224,10 +224,10 @@ You can use the link provided in the modal right section to let your users login
   className="mt-8 max-w-xl rounded-lg drop-shadow-md"
 />
 
-### Azure AD
+### Azure
 
-After you're logged in to [Azure Portal](https://portal.azure.com/), find the **Azure Active
-Directory**. On the left sidebar, click on the **Enterprise applications** under the **Manage**
+After you're logged in to [Azure Portal](https://portal.azure.com/), find the **Azure Entra
+ID**. On the left sidebar, click on the **Enterprise applications** under the **Manage**
 section:
 
 <NextImage


### PR DESCRIPTION
### Background

Azure has renamed Active Directory to Entra ID.
