### PR TITLE
Display a shorter success message and proper color

### DIFF
--- a/packages/web/docs/src/app/blog/components/newsletter-form-card.tsx
+++ b/packages/web/docs/src/app/blog/components/newsletter-form-card.tsx
@@ -51,7 +51,7 @@ export function NewsletterFormCard(props: React.HTMLAttributes<HTMLElement>) {
 
           setState(s => ({
             status: 'pending',
-            message: s?.status === 'error' ? s.message : undefined,
+            message: s?.status === 'error' ? 'Retrying...' : undefined,
           }));
 
           try {
@@ -81,6 +81,9 @@ export function NewsletterFormCard(props: React.HTMLAttributes<HTMLElement>) {
 
             setState({ status: 'error', message: 'Something went wrong. Please let us know.' });
           }
+        }}
+        onReset={() => {
+          setState(undefined);
         }}
       >
         <Input
@@ -113,13 +116,6 @@ export function NewsletterFormCard(props: React.HTMLAttributes<HTMLElement>) {
             type="reset"
             variant="secondary-inverted"
             className="group/button mt-2 !w-full before:absolute"
-            onClick={() => {
-              // the default behavior of <button type="reset"> doesn't work here
-              // because it gets unmounted too fast
-              setTimeout(() => {
-                setState(undefined);
-              }, 0);
-            }}
           >
             <span className="group-hover/button:hidden group-focus/button:hidden">Subscribed</span>
             <span aria-hidden className="hidden group-hover/button:block group-focus/button:block">


### PR DESCRIPTION
### Description

I tested the "feature-flagged 😅" form and it seems that I broke the color of the message in one of the latest commits (I wanted to reduce layout shift during retries because it looked off).

#### Before

<img width="343" alt="image" src="https://github.com/user-attachments/assets/ee477755-af05-498b-8fcd-d6cbc9a84df8" />

#### After

<img width="359" alt="image" src="https://github.com/user-attachments/assets/3dd3ee54-d3f8-4a10-ae78-49bb012a6dca" />