### PR TITLE
No security sane defaults in Hive Gateway

### DIFF
--- a/packages/web/docs/src/content/gateway/other-features/security/index.mdx
+++ b/packages/web/docs/src/content/gateway/other-features/security/index.mdx
@@ -82,10 +82,6 @@ perform requesting signing and verification.
 
 ## Query Depth Limiting
 
-<Callout type="info">
-  Query Depth Limiting is enabled by default in Hive Gateway and set to 7.
-</Callout>
-
 Attackers can send operations with deeply nested selection sets that could block other requests
 being processed. Fortunately, infinite loops are not possible by design as a fragment cannot
 self-reference itself; however, that still does not prevent possible attackers from sending
@@ -145,21 +141,6 @@ query {
 malicious API users executing GraphQL operations with deeply nested selection sets. You need to
 tweak the maximum depth an operation selection set is allowed to have based on your schema and
 needs, as it could vary between users.
-
-## Query Token Limiting
-
-<Callout type="info">
-  Query Token Limiting is enabled by default in Hive Gateway and set to 1000.
-</Callout>
-
-Malicious queries can contain a great number of tokens, which can lead to performance issues when
-processing them. Attackers can send these operations over and over to degrade the performance of the
-Hive Gateway using the DDoS attack.
-
-[Configuring the `maxTokens` option](/docs/gateway/other-features/security/max-tokens) can prevent
-malicious API users executing GraphQL operations with high token counts. You need to tweak the
-maximum token count an operation is allowed to have based on your schema and needs, as it could vary
-between users.
 
 ## Rate Limiting
 

--- a/packages/web/docs/src/content/migration-guides/gateway-v1-v2.mdx
+++ b/packages/web/docs/src/content/migration-guides/gateway-v1-v2.mdx
@@ -12,7 +12,6 @@ v2 includes several breaking changes and improvements over v1. The most signific
 - [Multipart Requests are Disabled by Default](#multipart-requests-are-disabled-by-default)
 - [Remove Mocking Plugin from built-ins](#remove-mocking-plugin-from-built-ins)
 - [Disabled Automatic Forking](#disabled-automatic-forking)
-- [Sane Security Defaults](#sane-security-defaults)
 - [Load Schema on CLI Start](#load-schema-on-cli-start)
 - [Inflight Request Deduplication](#inflight-request-deduplication)
 - [Hive Logger](#hive-logger)
@@ -121,25 +120,6 @@ request or during the readiness check because the runtime is simply a request ha
 However, the CLI is a complete program that gets ran by the user; meaning, we do not have to load
 the schema on-demand, we can load the schema on start! This helps catch schema issues early and
 provides a better developer experience.
-
-## Sane Security Defaults
-
-Hive Gateway v2 comes with improved security defaults to help protect your GraphQL API from common
-vulnerabilities. The following security measures are now enabled by default:
-
-- [Maximum query depth](/docs/gateway/other-features/security/max-depth) is set to 7
-- [Maximum query tokens](/docs/gateway/other-features/security/max-tokens) is set to 1000
-
-If you want to keep the v1 behavior, you can set these options to `false` in your configuration:
-
-```ts filename="gateway.config.ts"
-import { defineConfig } from '@graphql-hive/gateway'
-
-export const gatewayConfig = defineConfig({
-  maxDepth: false,
-  maxTokens: false
-})
-```
 
 ## Disabled Automatic Forking
 


### PR DESCRIPTION
In light of https://github.com/graphql-hive/gateway/pull/1441. Because not sane.