### PR TITLE
feat(api): increase default users returned by Organization.members field

### DIFF
--- a/.changeset/perfect-dolls-rescue.md
+++ b/.changeset/perfect-dolls-rescue.md
@@ -1,0 +1,5 @@
+---
+'hive': minor
+---
+
+Increase the amount of organization users returned by default from 100 to 200.

--- a/packages/services/api/src/modules/organization/providers/organization-members.ts
+++ b/packages/services/api/src/modules/organization/providers/organization-members.ts
@@ -172,7 +172,7 @@ export class OrganizationMembers {
       organization.id,
     );
 
-    const first = args.first ?? 100;
+    const first = args.first ?? 200;
     const cursor = args.after ? decodeCreatedAtAndUUIDIdBasedCursor(args.after) : null;
 
     const query = sql`


### PR DESCRIPTION
### Background

Increase the amount to unblock customers with large user base, until we add pagination on the frontend.

### Description

Increases the default value of members to fetch from 100 to 200.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
