### PR TITLE
fix(app): don't show the edit base schema option on federation projects

### DIFF
--- a/.changeset/warm-pans-approve.md
+++ b/.changeset/warm-pans-approve.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Prevent editing the base schema showing up for federation projects.

--- a/packages/web/app/src/pages/target-settings.tsx
+++ b/packages/web/app/src/pages/target-settings.tsx
@@ -1334,20 +1334,23 @@ function TargetSettingsContent(props: {
     }> = [];
 
     if (currentTarget?.viewerCanModifySettings) {
-      pages.push(
-        {
-          key: 'general',
-          title: 'General',
-        },
-        {
+      pages.push({
+        key: 'general',
+        title: 'General',
+      });
+
+      if (currentProject?.type !== ProjectType.Federation) {
+        pages.push({
           key: 'base-schema',
           title: 'Base Schema',
-        },
-        {
-          key: 'breaking-changes',
-          title: 'Breaking Changes',
-        },
-      );
+        });
+      }
+
+      pages.push({
+        key: 'breaking-changes',
+        title: 'Breaking Changes',
+      });
+
       if (currentProject?.type === ProjectType.Federation) {
         pages.push({
           key: 'schema-contracts',


### PR DESCRIPTION
### Background

Federation projects never supported editing the base schema, the option to edit it showing up in the target settings is a bug.

See https://github.com/graphql-hive/gateway/issues/1427#issuecomment-3284453558

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
