### PR TITLE
fix: reorder render to fix project error --  Rendered fewer hooks tha…

### DIFF
--- a/packages/web/app/src/pages/organization.tsx
+++ b/packages/web/app/src/pages/organization.tsx
@@ -348,10 +348,6 @@ function OrganizationPageContent(
       });
   }, [projectsConnection, props.search, sortKey, sortOrder]);
 
-  if (query.error) {
-    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
-  }
-
   const onSearchChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       void router.navigate({
@@ -391,6 +387,10 @@ function OrganizationPageContent(
       },
     });
   }, [router, props.sortOrder]);
+
+  if (query.error) {
+    return <QueryError organizationSlug={props.organizationSlug} error={query.error} />;
+  }
 
   return (
     <OrganizationLayout

--- a/packages/web/app/src/pages/project.tsx
+++ b/packages/web/app/src/pages/project.tsx
@@ -304,16 +304,6 @@ const ProjectsPageContent = (
     return 100;
   }, [targetConnection?.edges]);
 
-  if (query.error) {
-    return (
-      <QueryError
-        organizationSlug={props.organizationSlug}
-        error={query.error}
-        showLogoutButton={false}
-      />
-    );
-  }
-
   const onSearchChange = useCallback(
     (event: ChangeEvent<HTMLInputElement>) => {
       void router.navigate({
@@ -353,6 +343,16 @@ const ProjectsPageContent = (
       },
     });
   }, [router, props.sortOrder]);
+
+  if (query.error) {
+    return (
+      <QueryError
+        organizationSlug={props.organizationSlug}
+        error={query.error}
+        showLogoutButton={false}
+      />
+    );
+  }
 
   return (
     <div className="grow">


### PR DESCRIPTION
…n expected

### Background

Recently adjusted project and org pages which added more hooks.
We've seen a new error since: http://the-guild-z4.sentry.io/issues/6918059571/?alert_rule_id=5155401&alert_type=issue&notification_uuid=072e0ad1-27b7-4fd3-b98b-7484df1ca8f7&project=5691450&referrer=slack

### Description

This PR puts the error render block after the hooks, so that the hooks run every time.
