### PR TITLE
docs: adjust navbar root page titles

### DIFF
--- a/packages/web/docs/src/content/_meta.ts
+++ b/packages/web/docs/src/content/_meta.ts
@@ -1,10 +1,10 @@
 export default {
   index: 'Introduction',
-  'schema-registry': 'Console',
-  gateway: 'Gateway',
-  logger: 'Logger',
-  'other-integrations': 'Other Integrations',
-  'api-reference': 'CLI/API Reference',
+  'schema-registry': 'Hive Console',
+  gateway: 'Hive Gateway',
+  logger: 'Hive Logger',
+  'other-integrations': 'Integrations',
+  'api-reference': 'API Reference',
   'use-cases': 'Use Cases',
   'migration-guides': 'Migration Guides',
 };


### PR DESCRIPTION
### Background

Trying to make docs more clear

### Description

Modifies just the page titles on the navbar to avoid having to redirect etc
