### PR TITLE
fix: make query work on clickhouse cloud

### DIFF
--- a/packages/services/api/src/modules/operations/providers/traces.ts
+++ b/packages/services/api/src/modules/operations/providers/traces.ts
@@ -343,7 +343,7 @@ export class TraceBreakdownLoader {
       const statements: SqlValue[] = [];
       const arrJoinColumnAlias = 'arr_join_column_value';
 
-      const (let { key, columnExpression, limit, arrayJoinColumn } of inputs) {
+      for (const { key, columnExpression, limit, arrayJoinColumn } of inputs) {
         statements.push(sql`
           SELECT
             '${sql.raw(key)}' AS "key"


### PR DESCRIPTION
### Background

```
Duplicate alias in ARRAY JOIN: value: While processing SELECT 'errorCode' AS key, toString(value) AS value, count() AS count FROM otel_traces_normalized ARRAY JOIN graphql_error_codes AS value WHERE target_id = ???
```

The solution is to simply give the `ARRAY JOIN` column different name.

The annoying thing is that this issue does not occur with the local clickhouse docker container. 😢 

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
