### PR TITLE
chore: add missing `@hive/tokens#dev` to `dev:hive`

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -23,6 +23,7 @@
         "//#graphql:generate:watch",
         "@hive/server#dev",
         "@hive/app#dev",
+        "@hive/tokens#dev",
         "@hive/schema#dev",
         "@hive/policy#dev",
         "@hive/commerce#dev",


### PR DESCRIPTION
### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->
[The VSCode terminals configuration includes the tokens service](https://github.com/graphql-hive/console/blob/2cbdcedb79cfbe225dbdafe6122cdc12305d5aaf/.vscode/terminals.json#L33-L39) but the Turbo config for `dev:hive` didn't.

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
