### PR TITLE
feat(app): separate composition settings as a subpage

### DIFF
--- a/packages/web/app/src/pages/project-settings.tsx
+++ b/packages/web/app/src/pages/project-settings.tsx
@@ -548,6 +548,13 @@ function ProjectSettingsContent(props: {
       title: 'Policy',
     });
 
+    if (project?.type === ProjectType.Federation) {
+      pages.push({
+        key: 'composition',
+        title: 'Composition',
+      });
+    }
+
     return pages;
   }, [project]);
 
@@ -609,10 +616,6 @@ function ProjectSettingsContent(props: {
                 />
               ) : null}
 
-              {project.type === ProjectType.Federation ? (
-                <CompositionSettings project={project} organization={organization} />
-              ) : null}
-
               {project.viewerCanDelete ? (
                 <ProjectDelete projectSlug={project.slug} organizationSlug={organization.slug} />
               ) : null}
@@ -621,13 +624,16 @@ function ProjectSettingsContent(props: {
           {resolvedPage.key === 'policy' ? (
             <ProjectPolicySettings organizationSlug={organization.slug} project={project} />
           ) : null}
+          {resolvedPage.key === 'composition' ? (
+            <CompositionSettings project={project} organization={organization} />
+          ) : null}
         </div>
       </PageLayoutContent>
     </PageLayout>
   );
 }
 
-export const ProjectSettingsPageEnum = z.enum(['general', 'policy']);
+export const ProjectSettingsPageEnum = z.enum(['general', 'policy', 'composition']);
 
 export type ProjectSettingsSubPage = z.TypeOf<typeof ProjectSettingsPageEnum>;
 


### PR DESCRIPTION
### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->
Closes #7127
Followup of #7107

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
Not sure this looks better though 😅 Maybe we should adjust the spacings of the subpage layout at some point 🤔

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
