### PR TITLE
fix: show selected operation counts if client is selected only

### DIFF
--- a/packages/web/app/src/components/target/insights/Filters.tsx
+++ b/packages/web/app/src/components/target/insights/Filters.tsx
@@ -121,7 +121,7 @@ function OperationsFilter({
           style={style}
           key={operation.id}
           operationStats={operation}
-          clientOperationStats={clientFilteredOperations === null ? false : clientOpStats}
+          clientOperationStats={clientFilteredOperations == null ? false : clientOpStats}
           selected={selectedItems.includes(operation.operationHash || '')}
           onSelect={onSelect}
         />


### PR DESCRIPTION
### Background

I noticed selected counts were showing for operations even if no client was selected.

### Description
<img width="528" height="251" alt="Screenshot 2025-10-20 at 2 39 38 PM" src="https://github.com/user-attachments/assets/959242e7-5057-49e9-b64d-817baf372678" />

If no client is selected, then we should hide these numbers to reduce noise.

No changeset because it's inconsequential.