### PR TITLE
Fix: Proper message for schema fields not used by clients

### DIFF
--- a/packages/web/app/src/components/target/explorer/common.tsx
+++ b/packages/web/app/src/components/target/explorer/common.tsx
@@ -156,7 +156,7 @@ export function SchemaExplorerUsageStats(props: {
             <>
               <div className="mb-1 text-lg font-bold">Client Usage</div>
 
-              {Array.isArray(usage.usedByClients) ? (
+              {Array.isArray(usage.usedByClients) && usage.usedByClients.length > 0 ? (
                 <>
                   <div className="mb-2">This field is used by the following clients:</div>
                   <ul>


### PR DESCRIPTION
### Background

#7075 

### Description

Add additional check for empty array of users in order to show proper message