### PR TITLE
fix getSchemaVersionByActionId where clause

### DIFF
--- a/integration-tests/tests/api/schema/schema-version.spec.ts
+++ b/integration-tests/tests/api/schema/schema-version.spec.ts
@@ -49,9 +49,6 @@ test.concurrent(
       })
       .then(r => r.expectNoGraphQLErrors());
 
-    // note: there's a race condition in the publishSchema resolver if we repeatedly publish too quickly
-    waitFor(200);
-
     await token
       .publishSchema({
         sdl: latestSchema,

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -4473,7 +4473,7 @@ export async function createStorage(
         FROM
           "schema_versions"
         WHERE
-          "action_id" = ANY(
+          "action_id" = (
             SELECT
               "id"
             FROM
@@ -4483,6 +4483,7 @@ export async function createStorage(
               AND "schema_log"."target_id" = ${args.targetId}
               AND "schema_log"."commit" = ${args.actionId}
             ORDER BY "schema_log"."created_at" DESC
+            LIMIT 1
           )
         LIMIT 1
       `);


### PR DESCRIPTION
### Background

ANY is unordered

### Description

Limits selection inside where clause to ensure only the first record is returned. Removed ANY since it's no longer necessary.