### PR TITLE
adjust local clickhouse configuration

### DIFF
--- a/docker/configs/clickhouse/memory-optimizations.xml
+++ b/docker/configs/clickhouse/memory-optimizations.xml
@@ -1,0 +1,14 @@
+<clickhouse>
+  <default>
+    <max_threads>3</max_threads>
+    <max_insert_threads>2</max_insert_threads>
+    <max_block_size>8192</max_block_size>
+    <max_download_threads>1</max_download_threads>
+    <input_format_parallel_parsing>0</input_format_parallel_parsing>
+    <output_format_parallel_formatting>0</output_format_parallel_formatting>
+    <concurrent_threads_soft_limit_num>2</concurrent_threads_soft_limit_num>
+    <max_bytes_before_external_group_by>10000000</max_bytes_before_external_group_by>
+    <aggregation_memory_efficient_merge_threads>1</aggregation_memory_efficient_merge_threads>
+    <max_server_memory_usage_to_ram_ratio>1.2</max_server_memory_usage_to_ram_ratio>
+  </default>
+</clickhouse>

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -75,7 +75,7 @@ services:
 
   clickhouse:
     image: clickhouse/clickhouse-server:24.8-alpine
-    mem_limit: 2048m
+    mem_limit: 4096m
     environment:
       CLICKHOUSE_USER: test
       CLICKHOUSE_PASSWORD: test


### PR DESCRIPTION
### Background

When running clickhouse through docker locally, I frequently encounter out of memory errors. 

### Description

This is an attempt to reduce the memory usage as well as increase the available memory.

Looking at the way we've set up our docker images, I believe this should only impact the dev instance.