### PR TITLE
fix compilation with router 2.7.0

### DIFF
--- a/configs/cargo/Cargo.lock
+++ b/configs/cargo/Cargo.lock
@@ -2692,7 +2692,7 @@ dependencies = [
  "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
- "schemars 0.8.22",
+ "schemars 1.0.4",
  "serde",
  "serde_json",
  "sha2",
@@ -5271,19 +5271,6 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "schemars_derive 0.8.22",
- "serde",
- "serde_json",
- "url",
-]
-
-[[package]]
-name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -5302,22 +5289,10 @@ checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
 dependencies = [
  "dyn-clone",
  "ref-cast",
- "schemars_derive 1.0.4",
+ "schemars_derive",
  "serde",
  "serde_json",
  "url",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn 2.0.104",
 ]
 
 [[package]]

--- a/packages/libraries/router/Cargo.toml
+++ b/packages/libraries/router/Cargo.toml
@@ -33,7 +33,7 @@ tracing = "0.1"
 hyper = { version = "1", features = ["server", "client"] }
 async-trait = "0.1.77"
 futures = { version = "0.3.30", features = ["thread-pool"] }
-schemars = { version = "0.8", features = ["url"] }
+schemars = { version = "1.0.0", features = ["url2"] }
 serde = "1"
 serde_json = "1"
 tokio = { version = "1.36.0", features = ["full"] }


### PR DESCRIPTION
fix compilation with federation-router >= 2.7.0

This is the new dependency: https://github.com/apollographql/router/blob/84439adfb61ef3773bacc204c534fb96c34fb410/Cargo.toml#L66