### PR TITLE
Link to Wealthsimple case study

### DIFF
--- a/packages/web/docs/src/components/company-testimonials/index.tsx
+++ b/packages/web/docs/src/components/company-testimonials/index.tsx
@@ -62,6 +62,7 @@ const testimonials: Testimonial[] = [
     picture: {
       img: wealthsimplePicture,
     },
+    caseStudyHref: '/case-studies/wealthsimple',
   },
   {
     company: 'Prodigy',
@@ -206,7 +207,7 @@ export function CompanyTestimonialsSection({ className }: { className?: string }
                           href={caseStudyHref}
                           className="absolute bottom-0 w-full md:w-fit"
                         >
-                          Read Case Study
+                          Read the case study
                           <ArrowIcon />
                         </CallToAction>
                       )}


### PR DESCRIPTION
### Background

<img width="1620" height="792" alt="image" src="https://github.com/user-attachments/assets/3b665d1d-4d40-40f3-9af9-67a3fe7b18f5" />

Kamil raised that case studies are not linked to from the landing page and proposed adding a section similar to testimonials.

The initial design of testimonials section assumed they'll link to case studies.

### Description

As a first step, I added a link to the only case study that overlaps with testimonials.

@saihaj how hard would you expect it to be to get testimonial-like quotes from all the companies we have case studies for? Then we could use the same section, it's already scrollable and has these little dots, so we could feet like ~7 of them without any additional design work.

<img width="102" height="57" alt="image" src="https://github.com/user-attachments/assets/064b11c6-d9f2-4ce7-8c2f-c1c9097ed0bd" />

alternatively, @kamilkisiela if you think it deserves an entirely new section, how do you imagine it?


