### PR TITLE
fix(apollo-router-fork): use correct apollo-router-plugin version instead of commit

### DIFF
--- a/.changeset/brown-ghosts-teach.md
+++ b/.changeset/brown-ghosts-teach.md
@@ -1,0 +1,5 @@
+---
+'hive-apollo-router-plugin': patch
+---
+
+Use the correct plugin version in the User-Agent header used for Console requests

--- a/packages/libraries/router/src/agent.rs
+++ b/packages/libraries/router/src/agent.rs
@@ -1,3 +1,5 @@
+use crate::consts::PLUGIN_VERSION;
+
 use super::graphql::OperationProcessor;
 use graphql_parser::schema::{parse_schema, Document};
 use reqwest::Client;
@@ -9,8 +11,6 @@ use std::{
 };
 use thiserror::Error;
 use tokio::sync::Mutex as AsyncMutex;
-
-static COMMIT: Option<&'static str> = option_env!("GITHUB_SHA");
 
 #[derive(Serialize, Debug)]
 pub struct Report {
@@ -299,7 +299,7 @@ impl UsageAgent {
                 )
                 .header(
                     reqwest::header::USER_AGENT,
-                    format!("hive-apollo-router/{}", COMMIT.unwrap_or("local")),
+                    format!("hive-apollo-router/{}", PLUGIN_VERSION),
                 )
                 .json(&report)
                 .send()

--- a/packages/libraries/router/src/consts.rs
+++ b/packages/libraries/router/src/consts.rs
@@ -1,0 +1,1 @@
+pub const PLUGIN_VERSION: &str = env!("CARGO_PKG_VERSION");

--- a/packages/libraries/router/src/lib.rs
+++ b/packages/libraries/router/src/lib.rs
@@ -1,4 +1,5 @@
 mod agent;
+pub mod consts;
 mod graphql;
 pub mod persisted_documents;
 pub mod registry;

--- a/packages/libraries/router/src/main.rs
+++ b/packages/libraries/router/src/main.rs
@@ -1,5 +1,6 @@
 // Specify the modules our binary should include -- https://twitter.com/YassinEldeeb7/status/1468680104243077128
 mod agent;
+mod consts;
 mod graphql;
 mod persisted_documents;
 mod registry;

--- a/packages/libraries/router/src/registry.rs
+++ b/packages/libraries/router/src/registry.rs
@@ -1,3 +1,4 @@
+use crate::consts::PLUGIN_VERSION;
 use crate::registry_logger::Logger;
 use anyhow::{anyhow, Result};
 use sha2::Digest;
@@ -23,8 +24,6 @@ pub struct HiveRegistryConfig {
     accept_invalid_certs: Option<bool>,
     schema_file_path: Option<String>,
 }
-
-static COMMIT: Option<&'static str> = option_env!("GITHUB_SHA");
 
 impl HiveRegistry {
     #[allow(clippy::new_ret_no_self)]
@@ -171,7 +170,7 @@ impl HiveRegistry {
         headers.insert(
             reqwest::header::USER_AGENT,
             reqwest::header::HeaderValue::from_str(
-                format!("hive-apollo-router/{}", COMMIT.unwrap_or("local")).as_str(),
+                format!("hive-apollo-router/{}", PLUGIN_VERSION).as_str(),
             )
             .unwrap(),
         );


### PR DESCRIPTION
Closes https://github.com/graphql-hive/console/issues/6946 

`env!` resolved the env var at built time, and Cargo is in charge of setting it during `cargo build`, so the version will be "burned" as static into the compiled service.  