### PR TITLE
feat: complete --forceSafe implementation to auto-approve breaking changes

### DIFF
--- a/.changeset/calm-berries-build.md
+++ b/.changeset/calm-berries-build.md
@@ -1,0 +1,6 @@
+---
+'hive': patch
+'@graphql-hive/cli': patch
+---
+
+`schema:check --forceSafe` now properly approves breaking schema changes in Hive (requires write permission registry token)

--- a/integration-tests/tests/cli/schema.spec.ts
+++ b/integration-tests/tests/cli/schema.spec.ts
@@ -1,11 +1,12 @@
 /* eslint-disable no-process-env */
 import { createHash } from 'node:crypto';
-import { ProjectType } from 'testkit/gql/graphql';
+import { ProjectType, RuleInstanceSeverityLevel } from 'testkit/gql/graphql';
 import * as GraphQLSchema from 'testkit/gql/graphql';
 import type { CompositeSchema } from '@hive/api/__generated__/types';
 import { createCLI, schemaCheck, schemaPublish } from '../../testkit/cli';
 import { cliOutputSnapshotSerializer } from '../../testkit/cli-snapshot-serializer';
 import { initSeed } from '../../testkit/seed';
+import { createPolicy } from '../api/policy/policy-check.spec';
 
 expect.addSnapshotSerializer(cliOutputSnapshotSerializer);
 
@@ -903,3 +904,73 @@ test('schema:publish with `--target` flag succeeds for organization access token
     ℹ Available at http://__URL__
   `);
 });
+
+test.concurrent(
+  'schema:check --forceSafe auto-approves breaking changes using target access token',
+  async ({ expect }) => {
+    const { createOrg } = await initSeed().createOwner();
+    const { createProject, organization } = await createOrg();
+    const { createTargetAccessToken, project, target } = await createProject(ProjectType.Single);
+
+    const writeToken = await createTargetAccessToken({
+      mode: 'readWrite',
+    });
+
+    await schemaPublish([
+      '--registry.accessToken',
+      writeToken.secret,
+      '--commit',
+      'abc123',
+      'fixtures/init-schema.graphql',
+    ]);
+
+    await expect(
+      schemaCheck([
+        '--registry.accessToken',
+        writeToken.secret,
+        '--commit',
+        'def456',
+        '--forceSafe',
+        '--target',
+        `${organization.slug}/${project.slug}/${target.slug}`,
+        'fixtures/breaking-schema.graphql',
+      ]),
+    ).resolves.toContain('Breaking changes were expected (forced)');
+  },
+);
+
+test.concurrent(
+  'schema:check --forceSafe fails when schema policy errors prevent approval',
+  async ({ expect }) => {
+    const { createOrg } = await initSeed().createOwner();
+    const { createProject, organization } = await createOrg();
+    const { createTargetAccessToken, setProjectSchemaPolicy, project, target } =
+      await createProject(ProjectType.Single);
+    await setProjectSchemaPolicy(createPolicy(RuleInstanceSeverityLevel.Error));
+
+    const writeToken = await createTargetAccessToken({
+      mode: 'readWrite',
+    });
+
+    await schemaPublish([
+      '--registry.accessToken',
+      writeToken.secret,
+      '--commit',
+      'abc123',
+      'fixtures/init-schema.graphql',
+    ]);
+
+    await expect(
+      schemaCheck([
+        '--registry.accessToken',
+        writeToken.secret,
+        '--commit',
+        'def456',
+        '--forceSafe',
+        '--target',
+        `${organization.slug}/${project.slug}/${target.slug}`,
+        'fixtures/breaking-schema.graphql',
+      ]),
+    ).rejects.toThrow('Failed to auto-approve: Schema check has schema policy errors');
+  },
+);

--- a/packages/libraries/cli/src/commands/schema/check.ts
+++ b/packages/libraries/cli/src/commands/schema/check.ts
@@ -25,6 +25,21 @@ import {
 } from '../../helpers/schema';
 import * as TargetInput from '../../helpers/target-input';
 
+const approveFailedSchemaCheckMutation = graphql(/* GraphQL */ `
+  mutation approveFailedSchemaCheck($input: ApproveFailedSchemaCheckInput!) {
+    approveFailedSchemaCheck(input: $input) {
+      ok {
+        schemaCheck {
+          id
+        }
+      }
+      error {
+        message
+      }
+    }
+  }
+`);
+
 const schemaCheckMutation = graphql(/* GraphQL */ `
   mutation schemaCheck($input: SchemaCheckInput!) {
     schemaCheck(input: $input) {
@@ -48,6 +63,7 @@ const schemaCheckMutation = graphql(/* GraphQL */ `
           ...RenderChanges_schemaChanges
         }
         schemaCheck {
+          id
           webUrl
         }
       }
@@ -72,6 +88,7 @@ const schemaCheckMutation = graphql(/* GraphQL */ `
           ...RenderErrors_SchemaErrorConnectionFragment
         }
         schemaCheck {
+          id
           webUrl
         }
       }
@@ -310,7 +327,39 @@ export default class SchemaCheck extends Command<typeof SchemaCheck> {
         this.log('');
 
         if (forceSafe) {
-          this.logSuccess('Breaking changes were expected (forced)');
+          if (!target?.bySelector) {
+            throw new Errors.CLIError(
+              'The `--forceSafe` flag requires the `--target` flag to be specified by its slug ("organization/project/target"), not its ID.',
+            );
+          }
+
+          if (result.schemaCheck.schemaCheck?.id) {
+            let approvalResult: GraphQLSchema.ApproveFailedSchemaCheckMutation;
+            try {
+              approvalResult = await this.registryApi(endpoint, accessToken).request({
+                operation: approveFailedSchemaCheckMutation,
+                variables: {
+                  input: {
+                    organizationSlug: target.bySelector.organizationSlug,
+                    projectSlug: target.bySelector.projectSlug,
+                    targetSlug: target.bySelector.targetSlug,
+                    schemaCheckId: result.schemaCheck.schemaCheck.id,
+                    comment: 'Check force approved automatically via CLI --forceSafe flag',
+                    author: author ?? '',
+                  },
+                },
+              });
+            } catch (error) {
+              throw new UnexpectedError(error);
+            }
+            if (approvalResult.approveFailedSchemaCheck.error) {
+              this.logFailure(
+                `Failed to auto-approve: ${approvalResult.approveFailedSchemaCheck.error.message}`,
+              );
+              this.exit(1);
+            }
+            this.logSuccess('Breaking changes were expected (forced)');
+          }
         } else {
           this.exit(1);
         }

--- a/packages/migrations/test/2024.01.26T00.00.01.schema-check-purging.test.ts
+++ b/packages/migrations/test/2024.01.26T00.00.01.schema-check-purging.test.ts
@@ -437,6 +437,7 @@ describe('schema check purging', async () => {
         schemaCheckId: failedSchemaCheck.id,
         userId: user.id,
         comment: null,
+        author: null,
         contracts: {
           approveContractChecksForSchemaCheckId() {
             return Promise.resolve(false);
@@ -611,6 +612,7 @@ describe('schema check purging', async () => {
         schemaCheckId: failedSchemaCheck.id,
         userId: user.id,
         comment: null,
+        author: null,
         contracts: {
           approveContractChecksForSchemaCheckId() {
             return Promise.resolve(false);
@@ -870,6 +872,7 @@ describe('schema check purging', async () => {
         userId: user.id,
         contracts,
         comment: null,
+        author: null,
       });
 
       schemaChangeApprovalCount = await db.oneFirst<number>(
@@ -1072,6 +1075,7 @@ describe('schema check purging', async () => {
         userId: user.id,
         contracts,
         comment: null,
+        author: null,
       });
 
       schemaChangeApprovalCount = await db.oneFirst<number>(

--- a/packages/services/api/src/modules/auth/lib/target-access-token-strategy.ts
+++ b/packages/services/api/src/modules/auth/lib/target-access-token-strategy.ts
@@ -182,6 +182,7 @@ function transformAccessTokenLegacyScopes(args: {
               'schemaVersion:publish',
               'schemaVersion:deleteService',
               'schemaVersion:publish',
+              'schemaCheck:approve',
             ],
             resource: [`hrn:${args.organizationId}:target/${args.targetId}`],
           },

--- a/packages/services/api/src/modules/schema/lib/parse-cli-author.ts
+++ b/packages/services/api/src/modules/schema/lib/parse-cli-author.ts
@@ -1,0 +1,36 @@
+/**
+ * Parses CLI author string into name and email components.
+ * Supports multiple formats:
+ * - Git standard: "John Doe <john@example.com>"
+ * - Email only: "john@example.com"
+ * - Name only: "John Doe"
+ */
+export function parseCliAuthor(author: string): { displayName: string; email: string } {
+  const trimmed = author.trim();
+
+  // Try to parse "Name <email>" format (git standard)
+  const standardMatch = trimmed.match(/^([^<]+)\s+<([^>]+)>$/);
+  if (standardMatch) {
+    const [, name, email] = standardMatch;
+    return {
+      displayName: name.trim(),
+      email: email.trim(),
+    };
+  }
+
+  // Check if it's just an email address
+  const emailOnlyMatch = trimmed.match(/^[^\s@]+@[^\s@]+\.[^\s@]+$/);
+  if (emailOnlyMatch) {
+    return {
+      displayName: trimmed,
+      email: trimmed,
+    };
+  }
+
+  // If no format matches, use the whole string as display name
+  // Use a placeholder email since GraphQL User type requires it
+  return {
+    displayName: trimmed,
+    email: '<no email provided>',
+  };
+}

--- a/packages/services/api/src/modules/schema/module.graphql.ts
+++ b/packages/services/api/src/modules/schema/module.graphql.ts
@@ -554,6 +554,10 @@ export default gql`
     """
     approvedBy: User
     """
+    CLI approval metadata when approved via CLI (mutually exclusive with approvedBy).
+    """
+    cliApprovalMetadata: CLIApprovalMetadata
+    """
     Date of the schema change approval.
     """
     approvedAt: DateTime!
@@ -561,6 +565,24 @@ export default gql`
     ID of the schema check in which this change was first approved.
     """
     schemaCheckId: ID!
+  }
+
+  """
+  Metadata for approvals made via CLI.
+  """
+  type CLIApprovalMetadata {
+    """
+    Raw author string from the CLI.
+    """
+    author: String!
+    """
+    Parsed display name from the author string.
+    """
+    displayName: String!
+    """
+    Parsed email from the author string (if available).
+    """
+    email: String
   }
 
   type SchemaError {
@@ -1418,6 +1440,10 @@ export default gql`
     """
     approvedBy: User
     """
+    CLI approval metadata when approved via CLI (mutually exclusive with approvedBy).
+    """
+    cliApprovalMetadata: CLIApprovalMetadata
+    """
     Comment given when the schema check was approved.
     """
     approvalComment: String
@@ -1536,6 +1562,7 @@ export default gql`
     Give a reason why the schema check was approved.
     """
     comment: String
+    author: String
   }
 
   type ApproveFailedSchemaCheckResult {

--- a/packages/services/api/src/modules/schema/resolvers/Mutation/approveFailedSchemaCheck.ts
+++ b/packages/services/api/src/modules/schema/resolvers/Mutation/approveFailedSchemaCheck.ts
@@ -18,6 +18,7 @@ export const approveFailedSchemaCheck: NonNullable<
     targetId,
     schemaCheckId: input.schemaCheckId,
     comment: input.comment,
+    author: input.author,
   });
 
   if (result.type === 'error') {

--- a/packages/services/api/src/modules/schema/resolvers/SchemaChangeApproval.ts
+++ b/packages/services/api/src/modules/schema/resolvers/SchemaChangeApproval.ts
@@ -1,8 +1,22 @@
+import { parseCliAuthor } from '../lib/parse-cli-author';
 import { SchemaManager } from '../providers/schema-manager';
 import type { SchemaChangeApprovalResolvers } from './../../../__generated__/types';
 
 export const SchemaChangeApproval: SchemaChangeApprovalResolvers = {
   approvedBy: (approval, _, { injector }) =>
-    injector.get(SchemaManager).getUserForSchemaChangeById({ userId: approval.userId }),
+    approval.userId
+      ? injector.get(SchemaManager).getUserForSchemaChangeById({ userId: approval.userId })
+      : null,
+  cliApprovalMetadata: approval => {
+    if (!approval.author) {
+      return null;
+    }
+    const { displayName, email } = parseCliAuthor(approval.author);
+    return {
+      author: approval.author,
+      displayName,
+      email,
+    } as const;
+  },
   approvedAt: approval => approval.date,
 };

--- a/packages/services/api/src/modules/schema/resolvers/SuccessfulSchemaCheck.ts
+++ b/packages/services/api/src/modules/schema/resolvers/SuccessfulSchemaCheck.ts
@@ -1,3 +1,4 @@
+import { parseCliAuthor } from '../lib/parse-cli-author';
 import { ContractsManager } from '../providers/contracts-manager';
 import { SchemaCheckManager } from '../providers/schema-check-manager';
 import { SchemaManager } from '../providers/schema-manager';
@@ -38,6 +39,24 @@ export const SuccessfulSchemaCheck: SuccessfulSchemaCheckResolvers = {
           userId: schemaCheck.manualApprovalUserId,
         })
       : null;
+  },
+  cliApprovalMetadata: schemaCheck => {
+    if (!schemaCheck.isManuallyApproved || schemaCheck.manualApprovalUserId) {
+      return null;
+    }
+    if (schemaCheck.breakingSchemaChanges) {
+      for (const change of schemaCheck.breakingSchemaChanges) {
+        if (change.approvalMetadata?.author) {
+          const { displayName, email } = parseCliAuthor(change.approvalMetadata.author);
+          return {
+            author: change.approvalMetadata.author,
+            displayName,
+            email,
+          } as const;
+        }
+      }
+    }
+    return null;
   },
   approvalComment: schemaCheck => {
     return schemaCheck.isManuallyApproved ? schemaCheck.manualApprovalComment : null;

--- a/packages/services/api/src/modules/shared/providers/storage.ts
+++ b/packages/services/api/src/modules/shared/providers/storage.ts
@@ -789,8 +789,9 @@ export interface Storage {
     /** We inject this here as a dirty way to avoid chicken egg issues :) */
     contracts: Contracts;
     schemaCheckId: string;
-    userId: string;
+    userId: string | null;
     comment: string | null | undefined;
+    author: string | null | undefined;
   }): Promise<SchemaCheck | null>;
 
   /**

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -3993,6 +3993,7 @@ export async function createStorage(
         userId: args.userId,
         date: new Date().toISOString(),
         schemaCheckId: schemaCheck.id,
+        author: args.author ?? undefined,
       };
 
       if (schemaCheck.contextId !== null && !!schemaCheck.breakingSchemaChanges) {
@@ -5097,9 +5098,10 @@ export function toSerializableSchemaChange(change: SchemaChangeType): {
   type: string;
   meta: Record<string, SerializableValue>;
   approvalMetadata: null | {
-    userId: string;
+    userId: string | null;
     date: string;
     schemaCheckId: string;
+    author?: string;
   };
   isSafeBasedOnUsage: boolean;
   usageStatistics: null | {

--- a/packages/services/storage/src/schema-change-model.ts
+++ b/packages/services/storage/src/schema-change-model.ts
@@ -810,9 +810,10 @@ function createSchemaChangeId(change: { type: string; meta: Record<string, unkno
 }
 
 const ApprovalMetadataModel = z.object({
-  userId: z.string().uuid(),
+  userId: z.string().uuid().nullable(),
   schemaCheckId: z.string(),
   date: z.string(),
+  author: z.string().optional(),
 });
 
 export type SchemaCheckApprovalMetadata = z.TypeOf<typeof ApprovalMetadataModel>;

--- a/packages/web/app/src/components/target/history/errors-and-changes.tsx
+++ b/packages/web/app/src/components/target/history/errors-and-changes.tsx
@@ -64,6 +64,10 @@ const ChangesBlock_SchemaChangeApprovalFragment = graphql(`
       id
       displayName
     }
+    cliApprovalMetadata {
+      displayName
+      email
+    }
     approvedAt
     schemaCheckId
   }
@@ -389,7 +393,8 @@ function ApprovedByBadge(props: {
   approval: FragmentType<typeof ChangesBlock_SchemaChangeApprovalFragment>;
 }) {
   const approval = useFragment(ChangesBlock_SchemaChangeApprovalFragment, props.approval);
-  const approvalName = approval.approvedBy?.displayName ?? '<unknown>';
+  const approvalName =
+    approval.approvedBy?.displayName ?? approval.cliApprovalMetadata?.displayName ?? '<unknown>';
 
   return (
     <span className="cursor-pointer text-green-500">
@@ -406,7 +411,8 @@ function SchemaChangeApproval(props: {
   schemaCheckId: string;
 }) {
   const approval = useFragment(ChangesBlock_SchemaChangeApprovalFragment, props.approval);
-  const approvalName = approval.approvedBy?.displayName ?? '<unknown>';
+  const approvalName =
+    approval.approvedBy?.displayName ?? approval.cliApprovalMetadata?.displayName ?? '<unknown>';
   const approvalDate = format(new Date(approval.approvedAt), 'do MMMM yyyy');
   const schemaCheckPath =
     '/' +

--- a/packages/web/app/src/pages/target-checks-single.tsx
+++ b/packages/web/app/src/pages/target-checks-single.tsx
@@ -997,6 +997,10 @@ const ActiveSchemaCheck_SchemaCheckFragment = graphql(`
         displayName
         email
       }
+      cliApprovalMetadata {
+        displayName
+        email
+      }
       approvalComment
     }
     contractChecks {
@@ -1181,17 +1185,24 @@ const ActiveSchemaCheck = (props: {
                     </TooltipTrigger>
                     <TooltipContent>
                       Schema Check was manually approved by{' '}
-                      {schemaCheck.approvedBy?.displayName ?? 'unknown'}.
+                      {schemaCheck.approvedBy?.displayName ??
+                        schemaCheck.cliApprovalMetadata?.displayName ??
+                        'unknown'}
+                      .
                     </TooltipContent>
                   </Tooltip>
                 </TooltipProvider>
               </div>
               <div>
                 <p className="text-sm font-medium leading-none">
-                  {schemaCheck.approvedBy?.displayName ?? 'unknown'}
+                  {schemaCheck.approvedBy?.displayName ??
+                    schemaCheck.cliApprovalMetadata?.displayName ??
+                    'unknown'}
                 </p>
                 <p className="text-muted-foreground text-sm">
-                  {schemaCheck.approvedBy?.email ?? 'unknown'}
+                  {schemaCheck.approvedBy?.email ??
+                    schemaCheck.cliApprovalMetadata?.email ??
+                    'unknown'}
                 </p>
               </div>
               {schemaCheck.approvalComment ? (


### PR DESCRIPTION
Closes #6902

Completes the implementation of the `--forceSafe` CLI flag to actually auto-approve breaking schema changes in Hive, rather than just suppressing the error exit code.