### PR TITLE
fix(ui): handle escaped single-quoted strings in schema changes

### DIFF
--- a/.changeset/beige-chicken-wonder.md
+++ b/.changeset/beige-chicken-wonder.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+handle escaped single-quoted strings in schema changes

--- a/packages/web/app/src/components/target/history/errors-and-changes.tsx
+++ b/packages/web/app/src/components/target/history/errors-and-changes.tsx
@@ -31,11 +31,10 @@ import { CheckCircledIcon, InfoCircledIcon } from '@radix-ui/react-icons';
 import { Link } from '@tanstack/react-router';
 
 export function labelize(message: string) {
-  // Turn " into '
-  // Replace '...' with <Label>...</Label>
-  return reactStringReplace(message.replace(/"/g, "'"), /'([^']+)'/gim, (match, i) => {
-    return <Label key={i}>{match}</Label>;
-  });
+  // Replace '...' and "..." with <Label>...</Label>
+  return reactStringReplace(message.replace(/"/g, "'"), /'((?:[^'\\]|\\.)+?)'/g, (match, i) => (
+    <Label key={i}>{match.replace(/\\'/g, "'")}</Label>
+  ));
 }
 
 const severityLevelMapping = {


### PR DESCRIPTION
Closes #6692

Fixes the formatting of deprecation changes on the schema version view by improving the labelize function to properly handle both single and double-quoted identifiers in schema change messages.

<img width="1504" height="531" alt="Screenshot 2025-11-10 at 19 14 07" src="https://github.com/user-attachments/assets/192e048d-a365-4996-a3ff-2c323362f114" />


Note: this issue is still persistent in CLI output. 
the root cause of this issue lies in [graphql-inspector](https://github.com/graphql-hive/graphql-inspector), which a follow up PR will address.

PR fixes/feat for graphql-inspector: https://github.com/graphql-hive/graphql-inspector/pull/2904