### PR TITLE
Add small styleguide for Gemini

### DIFF
--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,23 @@
+Scope: UI code, both React + TypeScript and CSS \
+Focus: Correctness and Performance \
+Tone: In your review, be concise, direct and to the point.
+
+- DO NOT include a preamble or postamble.
+- DO NOT repeat the PR description. Assume other reviewers read the PR from the top and they've
+  already seen it.
+- DO NOT introduce yourself.
+
+Rules:
+
+- avoid setting state from useEffect instead of deriving it
+- prefer single long className over `cn/clsx` for non-conditional styles
+- be aware of modern React, but don't force it
+  - `useSyncExternalStore` for external state
+  - `useDeferredValue` for non-urgent updates
+  - Transition APIs for expensive renders
+- do not ponder on what's "generally best", analyze the codebase and PR as it is
+
+Guidelines:
+
+- keystroke cost: prefer uncontrolled inputs; make controlled loops cheap
+- preload wisely: preload only above-the-fold images; lazy-load the rest


### PR DESCRIPTION
### Background

as discussed on Slack

### Description

added a small style guide. I feel like the default setting is very focused on "best practices" and overly wordy, so it adds more friction than it helps

