### PR TITLE
Fix broken links on Router Introduction

### DIFF
--- a/packages/web/docs/src/content/router/index.mdx
+++ b/packages/web/docs/src/content/router/index.mdx
@@ -44,6 +44,7 @@ Check out our compliance testing:
 
 ## Getting Started
 
-- **[Getting Started](./getting-started)** - Install and run the router in just a few minutes.
-- **[Configuration Reference](./configuration)** - Explore all the ways you can customize the router
-  for your needs.
+- **[Getting Started](/docs/router/getting-started)** - Install and run the router in just a few
+  minutes.
+- **[Configuration Reference](/docs/router/configuration)** - Explore all the ways you can customize
+  the router for your needs.


### PR DESCRIPTION
Fix broken links under `Getting Started`
https://the-guild.dev/graphql/hive/docs/router