### PR TITLE
fix: new project label on empty state

### DIFF
--- a/packages/web/app/src/pages/organization.tsx
+++ b/packages/web/app/src/pages/organization.tsx
@@ -459,7 +459,7 @@ function OrganizationPageContent(
             projectsConnection.edges.length === 0 ? (
               <EmptyList
                 title="Hive is waiting for your first project"
-                description='You can create a project by clicking the "Create Project" button'
+                description='You can create a project by clicking the "New Project" button'
                 docsUrl="/management/projects#create-a-new-project"
               />
             ) : (


### PR DESCRIPTION
### Background

When trying to follow the tutorial in `docs/DEVELOPMENT.md`, I noticed a label on a button that could be improved.

### Description

Before:

<img width="600" height="auto" alt="Screenshot 2025-11-05 at 8 19 51" src="https://github.com/user-attachments/assets/dcf4d43e-4b9f-4566-b200-dcb86ed34923" />

After:

<img width="600" height="auto" alt="Screenshot 2025-11-05 at 8 20 33" src="https://github.com/user-attachments/assets/07528508-fbb5-462b-8f7f-ba4343745d31" />

### Checklist

- [ ] Testing

> [!NOTE]  
> I haven't run the test suite so not sure if this is covered by any kind of tests.
