### PR TITLE
fix: disable generate token button while submitting on create access token form

### DIFF
--- a/packages/web/app/src/components/target/settings/registry-access-token.tsx
+++ b/packages/web/app/src/components/target/settings/registry-access-token.tsx
@@ -267,7 +267,11 @@ export function GenerateTokenContent(props: {
             <Button
               type="submit"
               data-cy="submit"
-              disabled={!props.form.formState.isValid || props.noPermissionsSelected}
+              disabled={
+                !props.form.formState.isValid ||
+                props.noPermissionsSelected ||
+                props.form.formState.isSubmitting
+              }
             >
               Generate Token
             </Button>


### PR DESCRIPTION
### Background

Fix #7211 
Closes https://github.com/graphql-hive/console/pull/7226

### Description

It guarantees that each operation, while creating the registry token, won't "n-plicate" the tokens while clicking in the button. As an example of the current behavior, there's a video in the original issue showing it.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [x] Input validation
