### PR TITLE
enhance(sdk-rs): switch from `reqwest::blocking` to regular one

### DIFF
--- a/.changeset/wet-windows-walk.md
+++ b/.changeset/wet-windows-walk.md
@@ -1,0 +1,11 @@
+---
+'hive-console-sdk-rs': minor
+---
+
+- `SupergraphFetcher` no longer uses `reqwest::blocking::Client` internally, but instead uses `reqwest::Client`.
+- It now accepts `retry_count` parameter to specify how many times to retry fetching the supergraph in case of failures.
+
+Breaking;
+
+- `fetch_supergraph` is now `async fn` and needs to be awaited.
+

--- a/packages/libraries/router/src/registry.rs
+++ b/packages/libraries/router/src/registry.rs
@@ -1,12 +1,12 @@
 use crate::consts::PLUGIN_VERSION;
 use crate::registry_logger::Logger;
 use anyhow::{anyhow, Result};
+use futures::executor::block_on;
 use hive_console_sdk::supergraph_fetcher::SupergraphFetcher;
 use sha2::Digest;
 use sha2::Sha256;
 use std::env;
 use std::io::Write;
-use std::thread;
 use std::time::Duration;
 
 #[derive(Debug)]
@@ -130,6 +130,7 @@ impl HiveRegistry {
                 Duration::from_secs(5),
                 Duration::from_secs(60),
                 accept_invalid_certs,
+                3,
             )
             .map_err(|e| anyhow!("Failed to create SupergraphFetcher: {}", e))?,
             file_name,
@@ -148,9 +149,11 @@ impl HiveRegistry {
             }
         }
 
-        thread::spawn(move || loop {
-            thread::sleep(std::time::Duration::from_secs(poll_interval));
-            registry.poll()
+        tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(poll_interval)).await;
+                registry.poll().await;
+            }
         });
 
         Ok(())
@@ -158,7 +161,7 @@ impl HiveRegistry {
 
     fn initial_supergraph(&mut self) -> Result<(), String> {
         let mut file = std::fs::File::create(self.file_name.clone()).map_err(|e| e.to_string())?;
-        let resp = self.fetcher.fetch_supergraph()?;
+        let resp = block_on(self.fetcher.fetch_supergraph()).map_err(|e| e.to_string())?;
 
         match resp {
             Some(supergraph) => {
@@ -173,8 +176,8 @@ impl HiveRegistry {
         Ok(())
     }
 
-    fn poll(&mut self) {
-        match self.fetcher.fetch_supergraph() {
+    async fn poll(&mut self) {
+        match self.fetcher.fetch_supergraph().await {
             Ok(new_supergraph) => {
                 if let Some(new_supergraph) = new_supergraph {
                     let current_file = std::fs::read_to_string(self.file_name.clone())


### PR DESCRIPTION
- `SupergraphFetcher` no longer uses `reqwest::blocking::Client` internally, but instead uses `reqwest::Client`.
- It now accepts `retry_count` parameter to specify how many times to retry fetching the supergraph in case of failures.

Breaking;

- `fetch_supergraph` is now `async fn` and needs to be awaited.

So we can reuse it in Hive Router