### PR TITLE
set max width, add justify-between

### DIFF
--- a/packages/web/app/src/components/target/explorer/scalar-type.tsx
+++ b/packages/web/app/src/components/target/explorer/scalar-type.tsx
@@ -32,8 +32,8 @@ export function GraphQLScalarTypeComponent(props: {
       projectSlug={props.projectSlug}
       organizationSlug={props.organizationSlug}
     >
-      <div className="flex flex-row gap-4 p-4">
-        <div className="grow text-sm">
+      <div className="flex flex-row justify-between p-4">
+        <div className="max-w-2xl grow text-sm">
           {typeof ttype.description === 'string' ? <Markdown content={ttype.description} /> : null}
         </div>
         {typeof props.totalRequests === 'number' ? (


### PR DESCRIPTION
This PR simply adds a a couple of tailwind classes to restrict the max width and set `justify-content: space-between` for the description bit of `GraphQLScalarTypeComponent`. 

Closes #7220 

<img width="1596" height="402" alt="Screenshot 2025-11-10 at 6 37 08 PM" src="https://github.com/user-attachments/assets/b39dfab9-882d-4fc8-93da-f55c9743c7b8" />

