### PR TITLE
fix: make previously reverted migration optional

### DIFF
--- a/packages/migrations/src/actions/2025.11.12T00-00-00.granular-oidc-role-permissions.ts
+++ b/packages/migrations/src/actions/2025.11.12T00-00-00.granular-oidc-role-permissions.ts
@@ -4,11 +4,11 @@ export default {
   name: '2025.11.12T00-00-00.granular-oidc-role-permissions.ts',
   run: ({ sql }) => sql`
     ALTER TABLE "oidc_integrations"
-      ADD COLUMN "default_assigned_resources" JSONB
+      ADD COLUMN IF NOT EXISTS "default_assigned_resources" JSONB
     ;
 
     ALTER TABLE "organization_invitations"
-      ADD COLUMN "assigned_resources" JSONB
+      ADD COLUMN IF NOT EXISTS "assigned_resources" JSONB
     ;
   `,
 } satisfies MigrationExecutor;


### PR DESCRIPTION

### Description

One of the columns has been added before to our staging environment, then the PR was reverted. 😅 Now the migration fails because it already exists. This will make it run successfully!

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
