### PR TITLE
[OBSOLETE] feat: add redpanda buffering layer with split ingress/egress otel collectors

### DIFF
--- a/deployment/index.ts
+++ b/deployment/index.ts
@@ -21,6 +21,7 @@ import { deployPostgres } from './services/postgres';
 import { deployProxy } from './services/proxy';
 import { deployPublicGraphQLAPIGateway } from './services/public-graphql-api-gateway';
 import { deployRedis } from './services/redis';
+import { deployRedpanda } from './services/redpanda';
 import { deployS3, deployS3AuditLog, deployS3Mirror } from './services/s3';
 import { deploySchema } from './services/schema';
 import { configureSentry } from './services/sentry';
@@ -79,6 +80,7 @@ const clickhouse = deployClickhouse();
 const postgres = deployPostgres();
 const redis = deployRedis({ environment });
 const kafka = deployKafka();
+const redpanda = deployRedpanda({ environment });
 const s3 = deployS3();
 const s3Mirror = deployS3Mirror();
 const s3AuditLog = deployS3AuditLog();
@@ -290,6 +292,7 @@ const otelCollector = deployOTELCollector({
   graphql,
   dbMigrations,
   clickhouse,
+  redpanda,
   image: docker.factory.getImageId('otel-collector', imagesTag),
   docker,
 });
@@ -350,6 +353,8 @@ export const schemaApiServiceId = schema.service.id;
 export const webhooksApiServiceId = webhooks.service.id;
 
 export const appId = app.deployment.id;
-export const otelCollectorId = otelCollector.deployment.id;
+export const otelCollectorIngressId = otelCollector.ingress.deployment.id;
+export const otelCollectorEgressId = otelCollector.egress.deployment.id;
+export const redpandaStatefulSetId = redpanda.statefulSet.id;
 export const publicIp = proxy.get()!.status.loadBalancer.ingress[0].ip;
 export const awsLambdaArtifactsFunctionUrl = lambdaFunction;

--- a/deployment/services/environment.ts
+++ b/deployment/services/environment.ts
@@ -80,9 +80,15 @@ export function prepareEnvironment(input: {
         memoryLimit: isProduction ? '1000Mi' : '300Mi',
       },
       tracingCollector: {
-        cpuLimit: isProduction || isStaging ? '1000m' : '100m',
-        memoryLimit: isProduction || isStaging ? '1000Mi' : '512Mi',
-        maxReplicas: isProduction || isStaging ? 3 : 1,
+        cpuLimit: '500m',
+        memoryLimit: '512Mi',
+        maxReplicas: 3,
+      },
+      redpanda: {
+        replicas: 1,
+        cpuLimit: '500m',
+        memoryLimit: '1000Mi',
+        storageSize: '20Gi',
       },
     },
   };

--- a/deployment/services/redpanda.ts
+++ b/deployment/services/redpanda.ts
@@ -1,0 +1,194 @@
+import * as k8s from '@pulumi/kubernetes';
+import * as pulumi from '@pulumi/pulumi';
+import { Environment } from './environment';
+
+export type Redpanda = ReturnType<typeof deployRedpanda>;
+
+export function deployRedpanda(args: { environment: Environment }) {
+  const labels = { app: 'redpanda' };
+
+  // StatefulSet for Redpanda
+  const statefulSet = new k8s.apps.v1.StatefulSet('redpanda', {
+    metadata: {
+      name: 'redpanda',
+    },
+    spec: {
+      serviceName: 'redpanda',
+      replicas: args.environment.podsConfig.redpanda.replicas,
+      selector: {
+        matchLabels: labels,
+      },
+      template: {
+        metadata: {
+          labels,
+        },
+        spec: {
+          containers: [
+            {
+              name: 'redpanda',
+              image: 'redpandadata/redpanda:v25.3.1',
+              resources: {
+                limits: {
+                  cpu: args.environment.podsConfig.redpanda.cpuLimit,
+                  memory: args.environment.podsConfig.redpanda.memoryLimit,
+                },
+              },
+              args: [
+                'redpanda',
+                'start',
+                '--smp',
+                '1',
+                '--kafka-addr',
+                'PLAINTEXT://0.0.0.0:9092',
+                '--advertise-kafka-addr',
+                pulumi.interpolate`PLAINTEXT://\${HOSTNAME}.redpanda.default.svc.cluster.local:9092`,
+              ],
+              ports: [
+                { containerPort: 9092, name: 'kafka' },
+                { containerPort: 8082, name: 'http' },
+                { containerPort: 33145, name: 'rpc' },
+                { containerPort: 9644, name: 'admin' },
+              ],
+              volumeMounts: [
+                {
+                  name: 'datadir',
+                  mountPath: '/var/lib/redpanda/data',
+                },
+              ],
+              livenessProbe: {
+                httpGet: {
+                  path: '/ready',
+                  port: 9644,
+                },
+                initialDelaySeconds: 10,
+                terminationGracePeriodSeconds: 60,
+                periodSeconds: 10,
+                failureThreshold: 5,
+                timeoutSeconds: 5,
+              },
+              readinessProbe: {
+                httpGet: {
+                  path: '/ready',
+                  port: 9644,
+                },
+                initialDelaySeconds: 10,
+                periodSeconds: 15,
+                failureThreshold: 5,
+                timeoutSeconds: 5,
+              },
+            },
+          ],
+        },
+      },
+      volumeClaimTemplates: [
+        {
+          metadata: {
+            name: 'datadir',
+          },
+          spec: {
+            accessModes: ['ReadWriteOnce'],
+            resources: {
+              requests: {
+                storage: args.environment.podsConfig.redpanda.storageSize,
+              },
+            },
+          },
+        },
+      ],
+    },
+  });
+
+  // Headless Service for StatefulSet (used for internal cluster communication)
+  const headlessService = new k8s.core.v1.Service('redpanda-headless', {
+    metadata: {
+      name: 'redpanda',
+    },
+    spec: {
+      clusterIP: 'None',
+      selector: labels,
+      ports: [
+        { name: 'kafka', port: 9092, targetPort: 9092 },
+        { name: 'http', port: 8082, targetPort: 8082 },
+        { name: 'rpc', port: 33145, targetPort: 33145 },
+        { name: 'admin', port: 9644, targetPort: 9644 },
+      ],
+    },
+  });
+
+  // ClusterIP Service for clients (load balances across all pods)
+  const clientService = new k8s.core.v1.Service('redpanda-client-service', {
+    metadata: {
+      name: 'redpanda-client',
+    },
+    spec: {
+      type: 'ClusterIP',
+      selector: labels,
+      ports: [
+        { name: 'kafka', port: 9092, targetPort: 9092 },
+        { name: 'http', port: 8082, targetPort: 8082 },
+      ],
+    },
+  });
+
+  // Create otel-traces topic
+  const topicCreationJob = new k8s.batch.v1.Job(
+    'redpanda-topic-creation',
+    {
+      metadata: {
+        name: 'redpanda-topic-creation',
+      },
+      spec: {
+        template: {
+          spec: {
+            restartPolicy: 'OnFailure',
+            containers: [
+              {
+                name: 'rpk',
+                image: 'redpandadata/redpanda:v25.3.1',
+                imagePullPolicy: 'Always',
+                command: [
+                  '/bin/bash',
+                  '-c',
+                  `
+                # Wait for Redpanda to be ready
+                for i in {1..60}; do
+                  if rpk cluster health --brokers redpanda-0.redpanda:9092 2>/dev/null | grep -q 'Healthy'; then
+                    echo "Redpanda cluster is ready"
+                    break
+                  fi
+                  echo "Waiting for Redpanda cluster... ($i/60)"
+                  sleep 5
+                done
+
+                # Create topic with partitioning only (no replication)
+                rpk topic create otel-traces \\
+                  --brokers redpanda-0.redpanda:9092 \\
+                  --replicas 1 \\
+                  --partitions 10 \\
+                  --config retention.ms=2592000000 \\
+                  --config compression.type=snappy \\
+                  --config max.message.bytes=10485760 \\
+                  || echo "Topic may already exist"
+
+                # Verify topic creation
+                rpk topic describe otel-traces --brokers redpanda-0.redpanda:9092
+                `,
+                ],
+              },
+            ],
+          },
+        },
+      },
+    },
+    { dependsOn: [statefulSet, headlessService] },
+  );
+
+  return {
+    statefulSet,
+    headlessService,
+    clientService,
+    topicCreationJob,
+    // Client service endpoint - auto-discovers all brokers
+    brokerEndpoint: 'redpanda-client:9092',
+  };
+}

--- a/docker/configs/otel-collector/builder-config-egress.yaml
+++ b/docker/configs/otel-collector/builder-config-egress.yaml
@@ -1,0 +1,21 @@
+dist:
+  version: 0.140.0
+  name: otelcol-custom
+  description: Custom OTel Collector distribution
+  output_path: ./otelcol-custom
+
+receivers:
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kafkareceiver v0.140.0
+
+processors:
+  - gomod: go.opentelemetry.io/collector/processor/batchprocessor v0.140.0
+
+exporters:
+  - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.140.0
+  - gomod:
+      github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter v0.140.0
+
+extensions:
+  - gomod:
+      github.com/open-telemetry/opentelemetry-collector-contrib/extension/healthcheckextension
+      v0.140.0

--- a/docker/configs/otel-collector/builder-config-ingress.yaml
+++ b/docker/configs/otel-collector/builder-config-ingress.yaml
@@ -18,8 +18,7 @@ processors:
 
 exporters:
   - gomod: go.opentelemetry.io/collector/exporter/debugexporter v0.140.0
-  - gomod:
-      github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter v0.140.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/kafkaexporter v0.140.0
 
 extensions:
   - gomod:

--- a/docker/configs/otel-collector/config-egress.yaml
+++ b/docker/configs/otel-collector/config-egress.yaml
@@ -1,0 +1,61 @@
+extensions:
+  health_check:
+    endpoint: '0.0.0.0:13133'
+receivers:
+  kafka:
+    brokers:
+      - ${KAFKA_BROKER}
+    topic: otel-traces
+    encoding: otlp_proto
+    group_id: otel-collector-egress
+    session_timeout: 30s
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 8000
+exporters:
+  debug:
+    verbosity: basic
+  clickhouse:
+    endpoint: ${CLICKHOUSE_PROTOCOL}://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}?dial_timeout=10s&compress=lz4&async_insert=1&wait_for_async_insert=0
+    database: default
+    async_insert: true
+    username: ${CLICKHOUSE_USERNAME}
+    password: ${CLICKHOUSE_PASSWORD}
+    create_schema: false
+    ttl: 720h
+    compress: lz4
+    logs_table_name: otel_logs
+    traces_table_name: otel_traces
+    metrics_table_name: otel_metrics
+    timeout: 5s
+    retry_on_failure:
+      enabled: true
+      initial_interval: 5s
+      max_interval: 30s
+      max_elapsed_time: 300s
+service:
+  extensions:
+    - health_check
+  telemetry:
+    logs:
+      level: INFO
+      encoding: json
+      output_paths: ['stdout']
+      error_output_paths: ['stderr']
+    metrics:
+      level: detailed
+      readers:
+        - pull:
+            exporter:
+              prometheus:
+                host: '0.0.0.0'
+                port: 10254
+  pipelines:
+    traces:
+      receivers: [kafka]
+      processors:
+        - batch
+      exporters:
+        - clickhouse
+        # - debug

--- a/docker/configs/otel-collector/config-ingress.yaml
+++ b/docker/configs/otel-collector/config-ingress.yaml
@@ -53,19 +53,15 @@ processors:
 exporters:
   debug:
     verbosity: basic
-  clickhouse:
-    endpoint: ${CLICKHOUSE_PROTOCOL}://${CLICKHOUSE_HOST}:${CLICKHOUSE_PORT}?dial_timeout=10s&compress=lz4&async_insert=1&wait_for_async_insert=0
-    database: default
-    async_insert: true
-    username: ${CLICKHOUSE_USERNAME}
-    password: ${CLICKHOUSE_PASSWORD}
-    create_schema: false
-    ttl: 720h
-    compress: lz4
-    logs_table_name: otel_logs
-    traces_table_name: otel_traces
-    metrics_table_name: otel_metrics
-    timeout: 5s
+  kafka:
+    brokers:
+      - ${KAFKA_BROKER}
+    topic: otel-traces
+    encoding: otlp_proto
+    producer:
+      compression: snappy
+      max_message_bytes: 10485760 # 10MB
+    timeout: 10s
     retry_on_failure:
       enabled: true
       initial_interval: 5s
@@ -86,7 +82,7 @@ service:
     - file_storage
   telemetry:
     logs:
-      level: DEBUG
+      level: INFO
       encoding: json
       output_paths: ['stdout']
       error_output_paths: ['stderr']
@@ -104,7 +100,6 @@ service:
       processors:
         - memory_limiter
         - attributes
-        - batch
       exporters:
-        - clickhouse
+        - kafka
         # - debug

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -93,7 +93,7 @@ services:
       - 'stack'
 
   broker:
-    image: redpandadata/redpanda:v23.3.21
+    image: redpandadata/redpanda:v25.2.11
     mem_limit: 300m
     mem_reservation: 100m
     hostname: broker
@@ -122,7 +122,6 @@ services:
       - --advertise-rpc-addr redpanda-1:33145
     volumes:
       - ./.hive-dev/broker/db:/var/lib/kafka/data
-
   supertokens:
     image: registry.supertokens.io/supertokens/supertokens-postgresql:9.3
     mem_limit: 300m
@@ -176,31 +175,52 @@ services:
     networks:
       - 'stack'
 
-  otel-collector:
+  broker_provision_otel_traces_topic:
+    image: redpandadata/redpanda:v25.2.11
+    depends_on:
+      - broker
+    restart: 'no'
+    networks:
+      - 'stack'
+    entrypoint: >
+      /bin/sh -c " sleep 5; rpk topic create otel-traces --brokers broker:29092 || true; exit 0"
+
+  otel-collector-ingress:
+    depends_on:
+      broker_provision_otel_traces_topic:
+        condition: service_completed_successfully
+    build:
+      context: ./configs/otel-collector
+      dockerfile: ./../../otel-collector-ingress.dockerfile
+    environment:
+      HIVE_OTEL_AUTH_ENDPOINT: 'http://host.docker.internal:3001/otel-auth'
+      KAFKA_BROKER: 'broker:29092'
+    ports:
+      - '4317:4317'
+      - '4318:4318'
+      - '10254:10254'
+    networks:
+      - 'stack'
+
+  otel-collector-egress:
     depends_on:
       clickhouse:
         condition: service_healthy
+      broker_provision_otel_traces_topic:
+        condition: service_completed_successfully
     build:
       context: ./configs/otel-collector
-      dockerfile: ./../../otel-collector.dockerfile
-    mem_limit: 1000m
+      dockerfile: ./../../otel-collector-egress.dockerfile
+    mem_limit: 512m
     environment:
-      HIVE_OTEL_AUTH_ENDPOINT: 'http://host.docker.internal:3001/otel-auth'
+      KAFKA_BROKER: 'broker:29092'
       CLICKHOUSE_PROTOCOL: 'http'
       CLICKHOUSE_HOST: clickhouse
       CLICKHOUSE_PORT: 8123
       CLICKHOUSE_USERNAME: test
       CLICKHOUSE_PASSWORD: test
-    volumes:
-      - ./configs/otel-collector/builder-config.yaml:/builder-config.yaml
-      - ./configs/otel-collector/config.yaml:/etc/otel-config.yaml
     ports:
-      - '4317:4317'
-      - '4318:4318'
       - '10254:10254'
-      - '1777:1777'
-      - '8081:8081'
-      - '55679:55679'
     networks:
       - 'stack'
 

--- a/docker/docker.hcl
+++ b/docker/docker.hcl
@@ -82,8 +82,15 @@ target "router-base" {
   }
 }
 
-target "otel-collector-base" {
-  dockerfile = "${PWD}/docker/otel-collector.dockerfile"
+target "otel-collector-ingress-base" {
+  dockerfile = "${PWD}/docker/otel-collector-ingress.dockerfile"
+  args = {
+    RELEASE = "${RELEASE}"
+  }
+}
+
+target "otel-collector-egress-base" {
+  dockerfile = "${PWD}/docker/otel-collector-egress.dockerfile"
   args = {
     RELEASE = "${RELEASE}"
   }
@@ -378,18 +385,33 @@ target "apollo-router" {
   ]
 }
 
-target "otel-collector" {
-  inherits = ["otel-collector-base", get_target()]
+target "otel-collector-ingress" {
+  inherits = ["otel-collector-ingress-base", get_target()]
   context = "${PWD}/docker/configs/otel-collector"
   args = {
-    IMAGE_TITLE = "graphql-hive/otel-collector"
-    IMAGE_DESCRIPTION = "OTEL Collector for GraphQL Hive."
+    IMAGE_TITLE = "graphql-hive/otel-collector-ingress"
+    IMAGE_DESCRIPTION = "OTEL Collector Ingress for GraphQL Hive."
   }
   tags = [
-    local_image_tag("otel-collector"),
-    stable_image_tag("otel-collector"),
-    image_tag("otel-collector", COMMIT_SHA),
-    image_tag("otel-collector", BRANCH_NAME)
+    local_image_tag("otel-collector-ingress"),
+    stable_image_tag("otel-collector-ingress"),
+    image_tag("otel-collector-ingress", COMMIT_SHA),
+    image_tag("otel-collector-ingress", BRANCH_NAME)
+  ]
+}
+
+target "otel-collector-egress" {
+  inherits = ["otel-collector-egress-base", get_target()]
+  context = "${PWD}/docker/configs/otel-collector"
+  args = {
+    IMAGE_TITLE = "graphql-hive/otel-collector-egress"
+    IMAGE_DESCRIPTION = "OTEL Collector Egress for GraphQL Hive."
+  }
+  tags = [
+    local_image_tag("otel-collector-egress"),
+    stable_image_tag("otel-collector-egress"),
+    image_tag("otel-collector-egress", COMMIT_SHA),
+    image_tag("otel-collector-egress", BRANCH_NAME)
   ]
 }
 
@@ -424,7 +446,8 @@ group "build" {
     "commerce",
     "composition-federation-2",
     "app",
-    "otel-collector"
+    "otel-collector-ingress",
+    "otel-collector-egress"
   ]
 }
 
@@ -441,7 +464,8 @@ group "integration-tests" {
     "webhooks",
     "server",
     "composition-federation-2",
-    "otel-collector"
+    "otel-collector-ingress",
+    "otel-collector-egress"
   ]
 }
 

--- a/docker/otel-collector-egress.dockerfile
+++ b/docker/otel-collector-egress.dockerfile
@@ -1,0 +1,28 @@
+FROM golang:1.25-bookworm AS builder
+
+ARG OTEL_VERSION=0.140.0
+
+WORKDIR /build
+
+RUN go install go.opentelemetry.io/collector/cmd/builder@v${OTEL_VERSION}
+
+# Copy the manifest file
+COPY builder-config-egress.yaml builder-config.yaml
+
+# Build the custom collector
+RUN CGO_ENABLED=0 builder --config=/build/builder-config.yaml
+
+# Stage 2: Final Image
+FROM alpine:3.14
+
+WORKDIR /app
+
+# Copy the generated collector binary from the builder stage
+COPY --from=builder /build/otelcol-custom .
+COPY config-egress.yaml /etc/otel-config.yaml
+
+# Expose necessary ports
+EXPOSE 4317/tcp 4318/tcp 13133/tcp
+
+# Set the default command
+CMD ["./otelcol-custom", "--config=/etc/otel-config.yaml"]

--- a/docker/otel-collector-ingress.dockerfile
+++ b/docker/otel-collector-ingress.dockerfile
@@ -1,6 +1,6 @@
 FROM scratch AS config
 
-COPY builder-config.yaml .
+COPY builder-config-ingress.yaml .
 COPY extension-hiveauth/ ./extension-hiveauth/
 COPY extension-statsviz/ ./extension-statsviz/
 
@@ -13,7 +13,7 @@ WORKDIR /build
 RUN go install go.opentelemetry.io/collector/cmd/builder@v${OTEL_VERSION}
 
 # Copy the manifest file and other necessary files
-COPY --from=config builder-config.yaml .
+COPY --from=config builder-config-ingress.yaml builder-config.yaml
 COPY --from=config extension-hiveauth/ ./extension-hiveauth/
 COPY --from=config extension-statsviz/ ./extension-statsviz/
 
@@ -27,7 +27,7 @@ WORKDIR /app
 
 # Copy the generated collector binary from the builder stage
 COPY --from=builder /build/otelcol-custom .
-COPY config.yaml /etc/otel-config.yaml
+COPY config-ingress.yaml /etc/otel-config.yaml
 
 # Create directory for queue storage
 RUN mkdir -p /var/lib/otelcol/file_storage


### PR DESCRIPTION
### Description

Implements a resilient OTLP trace pipeline architecture by splitting the monolithic OTEL collector into separate ingress and egress components with Redpanda as a buffering layer. This provides better scalability, fault tolerance, and performance isolation.

### Architecture Changes
- **Before:** Client -> OTEL Collector -> ClickHouse
- **After:** Client -> Ingress Collectors -> Redpanda -> Egress Collectors -> ClickHouse

### What's New
#### Split Collector Architecture
  - Ingress Collectors: Handle authentication, receive OTLP data, forward to Redpanda
    - Includes HiveAuth extension for authentication
    - Processes attributes and applies memory limits
    - Exports to Kafka with Snappy compression
  - Egress Collectors: Consume from Redpanda, batch, send to ClickHouse
    - No authentication needed (internal only)
    - Batch processing for efficient ClickHouse inserts
    - Dedicated to ClickHouse export operations

#### Redpanda Message Buffer
  - Acts as durable buffer between ingress and egress
  - Provides backpressure handling and fault tolerance
  - 10 partitions for parallel processing
  - 30-day retention for trace replay capability
  - 10MB max message size for large traces