### PR TITLE
docs: fix typo in URL for fetching persisted documents

### DIFF
--- a/packages/web/docs/src/content/schema-registry/app-deployments.mdx
+++ b/packages/web/docs/src/content/schema-registry/app-deployments.mdx
@@ -318,7 +318,7 @@ const yoga = createYoga({
       experimental__persistedDocuments: {
         cdn: {
           // replace <target_id> and <cdn_access_token> with your values
-          endpoint: 'https://cdn.graphql-hive.com/<target_id>',
+          endpoint: 'https://cdn.graphql-hive.com/artifacts/v1/<target_id>',
           accessToken: '<cdn_access_token>'
         }
       }
@@ -354,7 +354,7 @@ const server = new ApolloServer({
       experimental__persistedDocuments: {
         cdn: {
           // replace <target_id> and <cdn_access_token> with your values
-          endpoint: 'https://cdn.graphql-hive.com/<target_id>',
+          endpoint: 'https://cdn.graphql-hive.com/artifacts/v1/<target_id>',
           accessToken: '<cdn_access_token>'
         }
       }
@@ -421,7 +421,7 @@ GET https://cdn.graphql-hive.com/artifacts/v1/<target_id>/apps/<app_name>/<app_v
 curl \
   -L \
   -H 'X-Hive-CDN-Key: CDN_ACCESS_TOKEN' \
-  https://cdn.graphql-hive.com/<target_id>/apps/<app_name>/<app_version>/<document_hash>
+  https://cdn.graphql-hive.com/artifacts/v1/<target_id>/apps/<app_name>/<app_version>/<document_hash>
 ```
 
 **Expected responses:**


### PR DESCRIPTION
Updated the URL for fetching persisted documents from the Hive CDN to include the 'artifacts/v1' path.

### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
