### PR TITLE
fix integration test failing due to zero division

### DIFF
--- a/packages/services/api/src/modules/schema/providers/breaking-schema-changes-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/breaking-schema-changes-helper.ts
@@ -41,7 +41,7 @@ export class BreakingSchemaChangeUsageHelper {
         // causing a zero devision and GraphQL exception,
         // because we aggressively poll for the schema change after publishing usage data
         // it seems like clickhouse slighty lags behind for the materialized view here.
-        // since it only happens in contetx of an integration test (no production issues)
+        // since it only happens in context of an integration test (no production issues)
         // we can safely treat 0 as 1 request.
         const totalRequestCount = Math.max(1, metadata.usage.totalRequestCount);
         const percentage = (operation.count / totalRequestCount) * 100;
@@ -57,7 +57,7 @@ export class BreakingSchemaChangeUsageHelper {
         // causing a zero devision and GraphQL exception,
         // because we aggressively poll for the schema change after publishing usage data
         // it seems like clickhouse slighty lags behind for the materialized view here.
-        // since it only happens in contetx of an integration test (no production issues)
+        // since it only happens in context of an integration test (no production issues)
         // we can safely treat 0 as 1 request.
         const totalRequestCount = Math.max(1, metadata.usage.totalRequestCount);
         const percentage = (client.count / totalRequestCount) * 100;


### PR DESCRIPTION
### Background

There seems to be an edge case where, the materialised views are not in sync when a operation is executed, which results in  a zero devision causing a runtime exception in the GraphQL layer.

This often fails integration tests. In a real world scenario this does not seems to happen as there is much more traffic and a conditional breaking change is not checked 1 second after the first request for was done... No error was ever reported for this to sentry.

This is super annoying and occurs quite frequently. I am open for better solutions here...