### PR TITLE
chore(clickhouse): add size-based compression config for docker-compose.dev.yml

### DIFF
--- a/docker/configs/clickhouse/compression.xml
+++ b/docker/configs/clickhouse/compression.xml
@@ -1,0 +1,15 @@
+<clickhouse>
+  <compression>
+    <!-- Use ZSTD for large parts to save space. -->
+    <case>
+      <min_part_size>1073741824</min_part_size> <!-- 1GB -->
+      <min_part_size_ratio>0.01</min_part_size_ratio>
+      <method>zstd</method>
+      <level>1</level>
+    </case>
+    <!-- Use LZ4 compression for better performance -->
+    <case>
+      <method>lz4</method>
+    </case>
+  </compression>
+</clickhouse>


### PR DESCRIPTION
#### Description
Adds a ClickHouse compression configuration file for the local development environment. The configuration uses a size-based compression strategy where ZSTD compression is applied to large data parts (over 1GB) to optimize storage space, while LZ4 compression is used for smaller parts to prioritize read/write performance.