### PR TITLE
fix(cli): handle escaped single-quoted strings in schema change

### DIFF
--- a/.changeset/brave-tigers-dance.md
+++ b/.changeset/brave-tigers-dance.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/cli': patch
+---
+
+handle escaped single-quoted strings in schema changes

--- a/integration-tests/fixtures/enum-with-deprecation-change.graphql
+++ b/integration-tests/fixtures/enum-with-deprecation-change.graphql
@@ -1,0 +1,10 @@
+type Query {
+  status: Status
+}
+
+enum Status {
+  ACTIVE
+  INACTIVE @deprecated(reason: "Use 'DISABLED' instead, it's clearer")
+  PENDING
+  DISABLED
+}

--- a/integration-tests/fixtures/enum-with-deprecation-init.graphql
+++ b/integration-tests/fixtures/enum-with-deprecation-init.graphql
@@ -1,0 +1,9 @@
+type Query {
+  status: Status
+}
+
+enum Status {
+  ACTIVE
+  INACTIVE
+  PENDING
+}

--- a/integration-tests/tests/cli/texture.spec.ts
+++ b/integration-tests/tests/cli/texture.spec.ts
@@ -1,0 +1,46 @@
+import colors from 'colors';
+import { boldQuotedWords } from '../../../packages/libraries/cli/src/helpers/texture/texture';
+
+describe('boldQuotedWords', () => {
+  test('handles simple single-quoted strings', () => {
+    const input = "Changed value for 'foo'";
+    const expected = `Changed value for ${colors.bold('foo')}`;
+    expect(boldQuotedWords(input)).toBe(expected);
+  });
+
+  test('handles simple double-quoted strings', () => {
+    const input = 'Changed value for "foo"';
+    const expected = `Changed value for ${colors.bold('foo')}`;
+    expect(boldQuotedWords(input)).toBe(expected);
+  });
+
+  test('handles multiple quoted strings', () => {
+    const input = "Field 'name' on type 'User' was changed";
+    const expected = `Field ${colors.bold('name')} on type ${colors.bold('User')} was changed`;
+    expect(boldQuotedWords(input)).toBe(expected);
+  });
+
+  test('handles string with no quotes', () => {
+    const input = 'No quotes here';
+    expect(boldQuotedWords(input)).toBe(input);
+  });
+
+  test('handles escaped single quotes within single-quoted strings', () => {
+    const input =
+      "Enum value 'Status.INACTIVE' has deprecation reason 'Use \\'DISABLED\\' instead'";
+    const expected = `Enum value ${colors.bold('Status.INACTIVE')} has deprecation reason ${colors.bold("Use 'DISABLED' instead")}`;
+    expect(boldQuotedWords(input)).toBe(expected);
+  });
+
+  test('handles escaped double quotes within double-quoted strings', () => {
+    const input = 'Default value changed from "\\"test\\"" to "other"';
+    const expected = `Default value changed from ${colors.bold('"test"')} to ${colors.bold('other')}`;
+    expect(boldQuotedWords(input)).toBe(expected);
+  });
+
+  test('handles apostrophes when quotes are escaped', () => {
+    const input = "Reason 'Use \\'DISABLED\\' instead, it\\'s clearer'";
+    const expected = `Reason ${colors.bold("Use 'DISABLED' instead, it's clearer")}`;
+    expect(boldQuotedWords(input)).toBe(expected);
+  });
+});

--- a/packages/libraries/cli/src/helpers/texture/texture.ts
+++ b/packages/libraries/cli/src/helpers/texture/texture.ts
@@ -21,11 +21,15 @@ export const trimEnd = (value: string) => value.replace(/\s+$/g, '');
  * Convert quoted text to bolded text. Quotes are stripped.
  */
 export const boldQuotedWords = (value: string) => {
-  const singleQuotedTextRegex = /'([^']+)'/gim;
-  const doubleQuotedTextRegex = /"([^"]+)"/gim;
+  const singleQuotedTextRegex = /'((?:[^'\\]|\\.)+?)'/g;
+  const doubleQuotedTextRegex = /"((?:[^"\\]|\\.)+?)"/g;
   return value
-    .replace(singleQuotedTextRegex, (_, capturedValue: string) => colors.bold(capturedValue))
-    .replace(doubleQuotedTextRegex, (_, capturedValue: string) => colors.bold(capturedValue));
+    .replace(singleQuotedTextRegex, (_, capturedValue: string) =>
+      colors.bold(capturedValue.replace(/\\'/g, "'")),
+    )
+    .replace(doubleQuotedTextRegex, (_, capturedValue: string) =>
+      colors.bold(capturedValue.replace(/\\"/g, '"')),
+    );
 };
 
 export const prefixedInspect =


### PR DESCRIPTION
### Description
Similar to https://github.com/graphql-hive/console/pull/7203, CLI also had the same issue.