### PR TITLE
feat(api): expose Project.createdAt via public GraphQL API

### DIFF
--- a/.changeset/brave-falcons-glow.md
+++ b/.changeset/brave-falcons-glow.md
@@ -1,0 +1,5 @@
+---
+'@hive/api': patch
+---
+
+Expose `Project.createdAt` field via the public GraphQL API.

--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -396,6 +396,7 @@ export function createProject(input: CreateProjectInput, authToken: string) {
               id
               slug
               name
+              createdAt
             }
             createdTargets {
               id
@@ -672,6 +673,7 @@ export function readProjectInfo(
         project(reference: { bySelector: $selector }) {
           id
           slug
+          createdAt
         }
       }
     `),

--- a/packages/services/api/src/modules/project/module.graphql.ts
+++ b/packages/services/api/src/modules/project/module.graphql.ts
@@ -100,6 +100,7 @@ export default gql`
     cleanId: ID! @deprecated(reason: "Use the 'slug' field instead.")
     name: String! @deprecated(reason: "Use the 'slug' field instead.")
     type: ProjectType! @tag(name: "public")
+    createdAt: DateTime! @tag(name: "public")
     buildUrl: String
     validationUrl: String
     experimental_nativeCompositionPerTarget: Boolean!

--- a/packages/services/api/src/modules/project/resolvers/Project.ts
+++ b/packages/services/api/src/modules/project/resolvers/Project.ts
@@ -6,6 +6,7 @@ export const Project: Pick<
   ProjectResolvers,
   | 'buildUrl'
   | 'cleanId'
+  | 'createdAt'
   | 'experimental_nativeCompositionPerTarget'
   | 'id'
   | 'name'

--- a/packages/services/api/src/shared/entities.ts
+++ b/packages/services/api/src/shared/entities.ts
@@ -301,6 +301,7 @@ export interface Project {
   orgId: string;
   name: string;
   type: ProjectType;
+  createdAt: string;
   buildUrl?: string | null;
   validationUrl?: string | null;
   /**

--- a/packages/services/storage/src/index.ts
+++ b/packages/services/storage/src/index.ts
@@ -244,6 +244,7 @@ export async function createStorage(
       orgId: project.org_id,
       name: project.name,
       type: project.type as ProjectType,
+      createdAt: new Date(project.created_at).toISOString(),
       buildUrl: project.build_url,
       validationUrl: project.validation_url,
       gitRepository: project.git_repository as `${string}/${string}` | null,


### PR DESCRIPTION
### Description
Expose the existing database `created_at` column on the Project type through the GraphQL API.

CONSOLE-1571