### PR TITLE
ci: optimize workflow caching and add concurrency controls

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -34,7 +34,7 @@ runs:
         if [ ${{ inputs.installDependencies }} = true ]; then
           echo "cache=pnpm" >> $GITHUB_OUTPUT
         else
-          echo "cache=" >> "$GITHUB_ENV"
+          echo "cache=" >> $GITHUB_OUTPUT
         fi
 
     - name: install pnpm

--- a/.github/workflows/build-and-dockerize.yaml
+++ b/.github/workflows/build-and-dockerize.yaml
@@ -169,6 +169,7 @@ jobs:
           source: .
           set: |
             *.cache-from=type=gha,ignore-error=true,scope=${{ steps.docker_cache_key.outputs.replaced }}
+            *.cache-from=type=gha,ignore-error=true,scope=refs_heads_main-${{ inputs.targets }}-${{ matrix.platform == 'linux/amd64' && 'linux_amd64' || 'linux_arm64' }}
             *.cache-to=type=gha,mode=max,ignore-error=true,scope=${{ steps.docker_cache_key.outputs.replaced }}
 
       - name: docker details pr comment

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -27,7 +27,7 @@ jobs:
             node_modules/.cache/prettier
           key:
             lint-cache-${{ hashFiles('**/pnpm-lock.yaml', 'packages/web/*/tailwind.config.ts',
-            'tsconfig.eslint.json', 'packages/web/app/tsconfig.json') }}-${{github.sha}}
+            'tsconfig.eslint.json', 'packages/web/app/tsconfig.json') }}
           restore-keys: |
             lint-cache-${{ hashFiles('**/pnpm-lock.yaml', 'packages/web/*/tailwind.config.ts',
             'tsconfig.eslint.json', 'packages/web/app/tsconfig.json') }}-

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ci-main
+  cancel-in-progress: false
+
 jobs:
   # Release NPM packages and tarballs
   package:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -2,6 +2,10 @@ name: pr
 on:
   pull_request: {}
 
+concurrency:
+  group: pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 env:
   HIVE_TOKEN: ${{ secrets.HIVE_TOKEN }}
 

--- a/.github/workflows/prettier.yaml
+++ b/.github/workflows/prettier.yaml
@@ -32,7 +32,7 @@ jobs:
           path: |
             .eslintcache
             node_modules/.cache/prettier
-          key: lint-cache-${{ hashFiles('**/pnpm-lock.yaml') }}-${{ github.sha }}
+          key: lint-cache-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             lint-cache-${{ hashFiles('**/pnpm-lock.yaml') }}-
 


### PR DESCRIPTION
### Summary

- Improve cache hit rates by removing github.sha from lint/prettier cache keys
   - ```.github/workflows/lint.yaml```
   - ```.github/workflows/prettier.yaml```
- Add concurrency controls to prevent redundant workflow runs (reduces wasted minutes, green energy 🍃)
   - `.github/workflows/pr.yaml` - cancels in-progress runs on same PR
   - `.github/workflows/main.yaml` - prevents overlapping deployments
- Fix setup action bug that breaks cache propagation
   - `.github/actions/setup/action.yml`
- Add Docker cache fallback to main branch for faster branch builds
   - `.github/workflows/build-and-dockerize.yaml`