### PR TITLE
Fix callout component styles for light mode

### DIFF
--- a/packages/web/docs/src/components/callout.tsx
+++ b/packages/web/docs/src/components/callout.tsx
@@ -1,5 +1,3 @@
-import { cn } from '../lib/utils';
-
 type CalloutType = 'note' | 'tip' | 'warning' | 'critical' | 'info' | 'success';
 
 interface CalloutProps {
@@ -63,10 +61,10 @@ export function Callout({ type, children, title }: CalloutProps) {
   }
 
   return (
-    <div className={cn(config.bgColor, config.borderColor, 'mt-6 rounded-r-lg border-l-2 p-4')}>
+    <div className={`${config.bgColor} ${config.borderColor} mt-6 rounded-r-lg border-l-2 p-4`}>
       <div className="min-w-0 flex-1 dark:text-white">
         <div
-          className={cn('mb-2 font-mono text-sm font-medium uppercase', config.titleColor)}
+          className={`mb-2 font-mono text-sm font-medium uppercase ${config.titleColor}`}
           style={{
             letterSpacing: '0.05em',
           }}
@@ -74,7 +72,7 @@ export function Callout({ type, children, title }: CalloutProps) {
           {title ?? config.title}
         </div>
         {/* I used [&_*]:!leading-[inherit] to override line-height forced by nextra */}
-        <div className={cn('[&_*]:!leading-[inherit]')}>{children}</div>
+        <div className="[&_*]:!leading-[inherit]">{children}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
Updates the callout component to support light mode. It also adds a check for unknown callout types and a rounded corner to the right side.

<img width="1095" height="440" alt="Screenshot 2025-11-28 at 17 39 04" src="https://github.com/user-attachments/assets/2ca6369d-4dd8-457a-9955-d98a0cb3bb64" />
<img width="1095" height="440" alt="Screenshot 2025-11-28 at 17 38 58" src="https://github.com/user-attachments/assets/9e8a3980-f664-4e44-8f64-818cecb66fb5" />
