### PR TITLE
fix: do not send 500 for invalid media type

### DIFF
--- a/packages/services/service-common/src/sentry.ts
+++ b/packages/services/service-common/src/sentry.ts
@@ -37,6 +37,15 @@ const plugin: FastifyPluginAsync = async server => {
         return;
       }
 
+      if (err.code === 'FST_ERR_CTP_INVALID_MEDIA_TYPE') {
+        req.log.warn('Invalid media type');
+        void reply.status(415).send({
+          error: 415,
+          message: 'Invalid media type',
+        });
+        return;
+      }
+
       req.log.warn('Replying with 500 Internal Server Error');
       void reply.status(500).send({
         error: 500,


### PR DESCRIPTION
### Background

CONSOLE-1600

### Description

415 error is swallowed and sent as a 500 instead.

Note: The whole error handling there is a bit off, as we will swallow most errors and expose them as 500. It might make sense to review this code and change the behaviour to be less strict.
