### PR TITLE
Make js consistent with rust implementation by tracking non nullable …

### DIFF
--- a/.changeset/plain-oranges-add.md
+++ b/.changeset/plain-oranges-add.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/core': patch
+---
+
+Track required inputs as provided even if no variable was sent

--- a/packages/libraries/core/src/client/collect-schema-coordinates.ts
+++ b/packages/libraries/core/src/client/collect-schema-coordinates.ts
@@ -13,6 +13,7 @@ import {
   GraphQLUnionType,
   isEnumType,
   isInputObjectType,
+  isNullableType,
   isScalarType,
   Kind,
   NameNode,
@@ -234,7 +235,6 @@ export function collectSchemaCoordinates(args: {
           const variableName = node.variable.name.value;
           const variableValue = variables[variableName];
           const namedType = getNamedType(inputType);
-
           collectVariable(namedType, variableValue);
         } else {
           // Collect the entire type without processing the variables
@@ -283,7 +283,7 @@ export function collectSchemaCoordinates(args: {
         }
 
         // check whether the value for this type is actually provided
-        if (valueNodeHasValue(node.value)) {
+        if (!isNullableType(arg.type) || valueNodeHasValue(node.value)) {
           countInputValueProvided(makeId(parent.name, field.name, arg.name));
         }
 

--- a/packages/libraries/core/tests/usage-collector.spec.ts
+++ b/packages/libraries/core/tests/usage-collector.spec.ts
@@ -101,6 +101,7 @@ test('collect fields', async () => {
   expect(info.fields).toMatchInlineSnapshot(`
     [
       Mutation.deleteProject,
+      Mutation.deleteProject.selector!,
       Mutation.deleteProject.selector,
       DeleteProjectPayload.selector,
       ProjectSelector.organization,
@@ -131,6 +132,7 @@ test('collect input object types', async () => {
   expect(info.fields).toMatchInlineSnapshot(`
     [
       Mutation.deleteProject,
+      Mutation.deleteProject.selector!,
       Mutation.deleteProject.selector,
       DeleteProjectPayload.selector,
       ProjectSelector.organization,

--- a/packages/libraries/core/tests/usage.spec.ts
+++ b/packages/libraries/core/tests/usage.spec.ts
@@ -192,6 +192,7 @@ test('should send data to Hive', async () => {
   expect(record.fields).toMatchInlineSnapshot(`
     [
       Mutation.deleteProject,
+      Mutation.deleteProject.selector!,
       Mutation.deleteProject.selector,
       DeleteProjectPayload.selector,
       ProjectSelector.organization,
@@ -302,6 +303,7 @@ test('should send data to Hive (deprecated endpoint)', async () => {
   expect(record.fields).toMatchInlineSnapshot(`
     [
       Mutation.deleteProject,
+      Mutation.deleteProject.selector!,
       Mutation.deleteProject.selector,
       DeleteProjectPayload.selector,
       ProjectSelector.organization,
@@ -667,6 +669,7 @@ test('should not send excluded operation name data to Hive', async () => {
   expect(record.fields).toMatchInlineSnapshot(`
     [
       Mutation.deleteProject,
+      Mutation.deleteProject.selector!,
       Mutation.deleteProject.selector,
       DeleteProjectPayload.selector,
       ProjectSelector.organization,


### PR DESCRIPTION
…arguments as being provided

### Background

Closes https://github.com/graphql-hive/console/issues/7365

### Description

Modifies the JS usage implementation to track non-nullable input types as having been provided by the client without checking if the variable was set or not.
