### PR TITLE
dockerfile for cli needs to include git

### DIFF
--- a/docker/cli.dockerfile
+++ b/docker/cli.dockerfile
@@ -1,6 +1,6 @@
 FROM node:22.13.0-slim
 
-RUN apt-get update && apt-get install -y ca-certificates git
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates git && rm -rf /var/lib/apt/lists/*
 
 ARG CLI_VERSION
 


### PR DESCRIPTION
### Background

Closes https://github.com/graphql-hive/console/pull/7393

While the schema check is ignoring missing git information: https://github.com/graphql-hive/console/blob/main/packages/libraries/cli/src/commands/schema/check.ts#L232

Schema publish does not. Thus our pipelines fail due to missing git and stating author/commit cannot be found.  https://github.com/graphql-hive/console/blob/main/packages/libraries/cli/src/commands/schema/publish.ts#L234

So if you do not provide an author nor a commit this will otherwise fail.

### Description

Adding git to docker image