### PR TITLE
CLI documentation points to wrong anchor in readme

### DIFF
--- a/packages/web/docs/src/content/api-reference/cli.mdx
+++ b/packages/web/docs/src/content/api-reference/cli.mdx
@@ -177,7 +177,7 @@ hive schema:publish \
 **Further reading:**
 
 - [Publishing a schema to the Schema Registry](/docs/schema-registry#publish-a-schema)
-- [`schema:publish` API Reference](https://github.com/graphql-hive/console/blob/main/packages/libraries/cli/README.md#hive-apppublish)
+- [`schema:publish` API Reference](https://github.com/graphql-hive/console/blob/main/packages/libraries/cli/README.md#hive-schemapublish-file)
 - [Apollo Router integration](/docs/other-integrations/apollo-router)
 - [Apollo-Server integration](/docs/other-integrations/apollo-server)
 


### PR DESCRIPTION
Fixes anchor to schema publish instead of apppublish