### PR TITLE
ci: remove metadata output causing docker build fail 'Argument list too long'

### DIFF
--- a/.github/workflows/build-and-dockerize.yaml
+++ b/.github/workflows/build-and-dockerize.yaml
@@ -186,14 +186,6 @@ jobs:
 
             **Image Tag**: `${{ inputs.imageTag }}`
 
-            <details>
-              <summary>Docker Bake metadata</summary>
-
-              ```json
-              ${{ steps.docker-bake.outputs.metadata }}
-              ```
-            </details>
-
       - name: upload sourcemaps to Sentry
         if: ${{ inputs.publishSourceMaps }}
         env:


### PR DESCRIPTION
https://github.com/graphql-hive/console/actions/runs/19961618914/job/57243181240#step:15:9034