### PR TITLE
add policy test for eslint-disable-next-line

### DIFF
--- a/packages/services/policy/__tests__/policy.spec.ts
+++ b/packages/services/policy/__tests__/policy.spec.ts
@@ -104,4 +104,25 @@ describe('policy checks', () => {
       ]
     `);
   });
+
+  test('errors can be ignored using eslint-disable-next-line', async () => {
+    const result = await schemaPolicyApiRouter
+      .createCaller({ req: { log: console } as any })
+      .checkPolicy({
+        source: `
+        """
+        The root query type
+        """
+        # eslint-disable-next-line
+        type Query { foo: String! }
+        `,
+        schema: 'type Query { foo: String! }',
+        target: '1',
+        policy: {
+          'require-nullable-result-in-root': ['error'],
+        },
+      });
+
+    expect(result.length).toBe(0);
+  });
 });


### PR DESCRIPTION
### Background

We received a report that our linter is not using the "eslint-disable-next-line" feature.

### Description

This adds a test to verify the behavior.