### PR TITLE
test(integration): use api server endpoint for auth

### DIFF
--- a/integration-tests/testkit/seed.ts
+++ b/integration-tests/testkit/seed.ts
@@ -101,8 +101,8 @@ export function initSeed() {
     async createOwner() {
       const ownerEmail = userEmail(generateUnique());
       const auth = await authenticate(ownerEmail);
-      const ownerRefreshToken = auth.refresh_token;
-      const ownerToken = auth.access_token;
+      const ownerRefreshToken = auth.refreshToken;
+      const ownerToken = auth.accessToken;
 
       return {
         ownerEmail,
@@ -895,7 +895,7 @@ export function initSeed() {
               resources: GraphQLSchema.ResourceAssignmentInput | undefined = undefined,
             ) {
               const memberEmail = userEmail(generateUnique());
-              const memberToken = await authenticate(memberEmail).then(r => r.access_token);
+              const memberToken = await authenticate(memberEmail).then(r => r.accessToken);
 
               const invitationResult = await inviteToOrganization(
                 {

--- a/integration-tests/tests/api/oidc-integrations/crud.spec.ts
+++ b/integration-tests/tests/api/oidc-integrations/crud.spec.ts
@@ -573,7 +573,7 @@ describe('delete', () => {
           }
         `);
 
-        const { access_token: memberAccessToken } = await seed.authenticate(
+        const { accessToken: memberAccessToken } = await seed.authenticate(
           seed.generateEmail(),
           oidcIntegrationId,
         );
@@ -805,7 +805,7 @@ describe('restrictions', () => {
     }
 
     const nonOidcAccount = await seed.authenticate(userEmail('non-oidc-user'));
-    const joinResult = await joinMemberUsingCode(invitationCode, nonOidcAccount.access_token).then(
+    const joinResult = await joinMemberUsingCode(invitationCode, nonOidcAccount.accessToken).then(
       r => r.expectNoGraphQLErrors(),
     );
 
@@ -872,7 +872,7 @@ describe('restrictions', () => {
     }
 
     const nonOidcAccount = await seed.authenticate(userEmail('non-oidc-user'));
-    const joinResult = await joinMemberUsingCode(invitationCode, nonOidcAccount.access_token).then(
+    const joinResult = await joinMemberUsingCode(invitationCode, nonOidcAccount.accessToken).then(
       r => r.expectNoGraphQLErrors(),
     );
 
@@ -894,10 +894,9 @@ describe('restrictions', () => {
       }
 
       const nonOidcAccount = await seed.authenticate(userEmail('non-oidc-user'));
-      const joinResult = await joinMemberUsingCode(
-        invitationCode,
-        nonOidcAccount.access_token,
-      ).then(r => r.expectNoGraphQLErrors());
+      const joinResult = await joinMemberUsingCode(invitationCode, nonOidcAccount.accessToken).then(
+        r => r.expectNoGraphQLErrors(),
+      );
 
       expect(joinResult.joinOrganization.__typename).toEqual('OrganizationPayload');
 

--- a/integration-tests/tests/api/organization/members.spec.ts
+++ b/integration-tests/tests/api/organization/members.spec.ts
@@ -188,7 +188,7 @@ test.concurrent(
 
     // Join
     const extra = seed.generateEmail();
-    const { access_token: member_access_token } = await seed.authenticate(extra);
+    const { accessToken: member_access_token } = await seed.authenticate(extra);
     const joinResult = await (
       await joinMemberUsingCode(inviteCode, member_access_token)
     ).expectNoGraphQLErrors();
@@ -200,7 +200,7 @@ test.concurrent(
     }
 
     const other = seed.generateEmail();
-    const { access_token: other_access_token } = await seed.authenticate(other);
+    const { accessToken: other_access_token } = await seed.authenticate(other);
     const otherJoinResult = await (
       await joinMemberUsingCode(inviteCode, other_access_token)
     ).expectNoGraphQLErrors();


### PR DESCRIPTION
### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->
Currently, integration tests are directly invoking SuperTokens API for auth, instead of going through the API server. This makes the tests less realistic.

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
- Auth through the API server instead of the SuperTokens server

### Checklist

<!---
We are following the OWASP Secure Coding Practices for develpoing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [x] Authentication management
- [x] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [x] Testing
