### PR TITLE
Remove `@types/react` devDependency from Hive Docs

### DIFF
--- a/packages/web/docs/package.json
+++ b/packages/web/docs/package.json
@@ -39,7 +39,6 @@
     "@next/bundle-analyzer": "^16.0.0",
     "@tailwindcss/typography": "0.5.16",
     "@theguild/tailwind-config": "0.6.3",
-    "@types/react": "18.3.18",
     "next-sitemap": "4.2.3",
     "pagefind": "^1.2.0",
     "postcss": "8.4.49",

--- a/packages/web/docs/src/app/narrow-pages.tsx
+++ b/packages/web/docs/src/app/narrow-pages.tsx
@@ -9,7 +9,7 @@ import { HiveLayoutConfig } from '@theguild/components';
  */
 export function NarrowPages({ pages }: { pages: string[] }) {
   const pathname = usePathname();
-  const isLightOnlyPage = pages.includes(pathname);
+  const isLightOnlyPage = (pages as Array<string | null>).includes(pathname);
 
   return isLightOnlyPage ? (
     <div className="absolute size-0">

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2240,9 +2240,6 @@ importers:
       '@theguild/tailwind-config':
         specifier: 0.6.3
         version: 0.6.3(postcss-import@16.1.0(postcss@8.4.49))(postcss-lightningcss@1.0.1(postcss@8.4.49))(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.10.1)(typescript@5.7.3)))
-      '@types/react':
-        specifier: 18.3.18
-        version: 18.3.18
       next-sitemap:
         specifier: 4.2.3
         version: 4.2.3(next@15.5.8(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(react-dom@19.2.2(react@19.2.2))(react@19.2.2))


### PR DESCRIPTION
### Background

React 19 carries its types rendering the `@types/react` dev dep redundant.
Also, Gemini yelled that it's "Critical" :)

### Description

I removed the dependency and fixed the only type error.

