### PR TITLE
Fix typo in logging and error handling documentation

### DIFF
--- a/packages/web/docs/src/content/gateway/logging-and-error-handling.mdx
+++ b/packages/web/docs/src/content/gateway/logging-and-error-handling.mdx
@@ -162,7 +162,7 @@ export const gateway = createGatewayRuntime({
 
 ##### Change Dynamically
 
-A powerful ability of Hive Logger is allowinh you to change the log level dynamically at runtime.
+A powerful ability of Hive Logger is allowing you to change the log level dynamically at runtime.
 This is useful for debugging and testing purposes. You can change the log level by calling the
 `setLogLevel` method on the logger instance.
 


### PR DESCRIPTION
### Background

Typo fix in the docs.

