### PR TITLE
Cleanup disk before running Apollo Router integration tests

### DIFF
--- a/integration-tests/tests/apollo-router/apollo-router.test.ts
+++ b/integration-tests/tests/apollo-router/apollo-router.test.ts
@@ -21,97 +21,92 @@ describe('Apollo Router Integration', () => {
         }
       });
     });
-  it(
-    'fetches the supergraph and sends usage reports',
-    {
-      retry: 3,
-    },
-    async () => {
-      const routerConfigPath = join(tmpdir(), `apollo-router-config-${Date.now()}.yaml`);
-      const endpointBaseUrl = await getBaseEndpoint();
-      const { createOrg } = await initSeed().createOwner();
-      const { createProject } = await createOrg();
-      const { createTargetAccessToken, createCdnAccess, target, waitForOperationsCollected } =
-        await createProject(ProjectType.Federation);
-      const writeToken = await createTargetAccessToken({});
+  it('fetches the supergraph and sends usage reports', async () => {
+    const routerConfigPath = join(tmpdir(), `apollo-router-config-${Date.now()}.yaml`);
+    const endpointBaseUrl = await getBaseEndpoint();
+    const { createOrg } = await initSeed().createOwner();
+    const { createProject } = await createOrg();
+    const { createTargetAccessToken, createCdnAccess, target, waitForOperationsCollected } =
+      await createProject(ProjectType.Federation);
+    const writeToken = await createTargetAccessToken({});
 
-      // Publish Schema
-      const publishSchemaResult = await writeToken
-        .publishSchema({
-          author: 'Arda',
-          commit: 'abc123',
-          sdl: /* GraphQL */ `
-            type Query {
-              me: User
-            }
-            type User {
-              id: ID!
-              name: String!
-            }
-          `,
-          service: 'users',
-          url: 'https://federation-demo.theguild.workers.dev/users',
-        })
-        .then(r => r.expectNoGraphQLErrors());
+    // Publish Schema
+    const publishSchemaResult = await writeToken
+      .publishSchema({
+        author: 'Arda',
+        commit: 'abc123',
+        sdl: /* GraphQL */ `
+          type Query {
+            me: User
+          }
+          type User {
+            id: ID!
+            name: String!
+          }
+        `,
+        service: 'users',
+        url: 'https://federation-demo.theguild.workers.dev/users',
+      })
+      .then(r => r.expectNoGraphQLErrors());
 
-      expect(publishSchemaResult.schemaPublish.__typename).toBe('SchemaPublishSuccess');
-      const cdnAccessResult = await createCdnAccess();
+    expect(publishSchemaResult.schemaPublish.__typename).toBe('SchemaPublishSuccess');
+    const cdnAccessResult = await createCdnAccess();
 
-      const usageAddress = await getServiceHost('usage', 8081);
+    const usageAddress = await getServiceHost('usage', 8081);
 
-      const routerBinPath = join(__dirname, '../../../target/debug/router');
-      if (!existsSync(routerBinPath)) {
-        throw new Error(
-          `Apollo Router binary not found at path: ${routerBinPath}, make sure to build it first with 'cargo build'`,
-        );
-      }
-      const routerPort = await getAvailablePort();
-      const routerConfigContent = `
+    const routerBinPath = join(__dirname, '../../../target/debug/router');
+    if (!existsSync(routerBinPath)) {
+      throw new Error(
+        `Apollo Router binary not found at path: ${routerBinPath}, make sure to build it first with 'cargo build'`,
+      );
+    }
+    const routerPort = await getAvailablePort();
+    const routerConfigContent = `
 supergraph:
   listen: 0.0.0.0:${routerPort}
 plugins:
   hive.usage: {}
 `.trim();
-      writeFileSync(routerConfigPath, routerConfigContent, 'utf-8');
-      const routerProc = execa(routerBinPath, ['--dev', '--config', routerConfigPath], {
-        all: true,
-        env: {
-          HIVE_CDN_ENDPOINT: endpointBaseUrl + target.id,
-          HIVE_CDN_KEY: cdnAccessResult.secretAccessToken,
-          HIVE_ENDPOINT: `http://${usageAddress}`,
-          HIVE_TOKEN: writeToken.secret,
-          HIVE_TARGET_ID: target.id,
-        },
-      });
-      await new Promise((resolve, reject) => {
-        routerProc.catch(err => {
-          if (!err.isCanceled) {
-            reject(err);
-          }
-        });
-        const routerProcOut = routerProc.all;
-        if (!routerProcOut) {
-          return reject(new Error('No stdout from Apollo Router process'));
+    writeFileSync(routerConfigPath, routerConfigContent, 'utf-8');
+    const routerProc = execa(routerBinPath, ['--dev', '--config', routerConfigPath], {
+      all: true,
+      env: {
+        HIVE_CDN_ENDPOINT: endpointBaseUrl + target.id,
+        HIVE_CDN_KEY: cdnAccessResult.secretAccessToken,
+        HIVE_ENDPOINT: `http://${usageAddress}`,
+        HIVE_TOKEN: writeToken.secret,
+        HIVE_TARGET_ID: target.id,
+      },
+    });
+    await new Promise((resolve, reject) => {
+      routerProc.catch(err => {
+        if (!err.isCanceled) {
+          reject(err);
         }
-        let log = '';
-        routerProcOut.on('data', data => {
-          log += data.toString();
-          if (log.includes('GraphQL endpoint exposed at')) {
-            resolve(true);
-          }
-        });
       });
+      const routerProcOut = routerProc.all;
+      if (!routerProcOut) {
+        return reject(new Error('No stdout from Apollo Router process'));
+      }
+      let log = '';
+      routerProcOut.on('data', data => {
+        log += data.toString();
+        if (log.includes('GraphQL endpoint exposed at')) {
+          resolve(true);
+        }
+      });
+    });
 
-      try {
-        const url = `http://localhost:${routerPort}/`;
-        const response = await fetch(url, {
-          method: 'POST',
-          headers: {
-            accept: 'application/json',
-            'content-type': 'application/json',
-          },
-          body: JSON.stringify({
-            query: `
+    try {
+      const url = `http://localhost:${routerPort}/`;
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: `
                   query TestQuery {
                     me {
                         id
@@ -119,24 +114,23 @@ plugins:
                     }
                   }
                 `,
-          }),
-        });
+        }),
+      });
 
-        expect(response.status).toBe(200);
-        const result = await response.json();
-        expect(result).toEqual({
-          data: {
-            me: {
-              id: '1',
-              name: 'Ada Lovelace',
-            },
+      expect(response.status).toBe(200);
+      const result = await response.json();
+      expect(result).toEqual({
+        data: {
+          me: {
+            id: '1',
+            name: 'Ada Lovelace',
           },
-        });
-        await waitForOperationsCollected(1);
-      } finally {
-        routerProc.cancel();
-        rmSync(routerConfigPath);
-      }
-    },
-  );
+        },
+      });
+      await waitForOperationsCollected(1);
+    } finally {
+      routerProc.cancel();
+      rmSync(routerConfigPath);
+    }
+  });
 });


### PR DESCRIPTION
This PR adds a step to the integration test workflow that cleans up the disk by removing unused things on the disk before running Apollo Router integration tests;
https://carlosbecker.com/posts/github-actions-disk-space/

It seems building Apollo Router from the source takes a lot of space then, it causes S3 container fail while publishing the schema so we can't test fetching from CDN use case for Apollo Router. So saving some space from the disk gives us enough space for both S3 container to store the schema and Rust compiler to compile Apollo Router at the same time.
