### PR TITLE
chore: allow skip schema and persisted app publish via environment variable

### DIFF
--- a/deployment/index.ts
+++ b/deployment/index.ts
@@ -244,7 +244,7 @@ const hiveConfigSecret = new ServiceSecret('hive-config-secret', {
 // You can change this to `false` in cases when you don't want to publish commands.
 // For example, if the entire env is down or if you are having SSL issues.
 // eslint-disable-next-line no-process-env
-const RUN_PUBLISH_COMMANDS: boolean = process.env.SKIP_PUBLISH_COMMANDS === '1';
+const RUN_PUBLISH_COMMANDS: boolean = process.env.SKIP_PUBLISH_COMMANDS !== '1';
 
 const publishGraphQLSchemaCommand = RUN_PUBLISH_COMMANDS
   ? publishGraphQLSchema({


### PR DESCRIPTION
Setting `SKIP_PUBLISH_COMMANDS` to `"1"`, now will skip commands that rely on performing actions against the public domain.