### PR TITLE
Reduce proposal diff view text size and spacing

### DIFF
--- a/packages/web/app/src/components/target/proposals/schema-diff/components.tsx
+++ b/packages/web/app/src/components/target/proposals/schema-diff/components.tsx
@@ -69,7 +69,7 @@ export function ChangeDocument(props: { children: ReactNode; className?: string 
       <table
         aria-label="change-document"
         className={cn(
-          'min-w-full cursor-default whitespace-pre font-mono text-white',
+          'min-w-full cursor-default whitespace-pre font-mono text-sm text-white',
           props.className,
         )}
         style={{ counterReset: 'olddoc newdoc' }}
@@ -125,7 +125,7 @@ export function ChangeRow(props: {
       <tr style={{ counterIncrement: incrementCounter }}>
         <td
           className={cn(
-            'schema-doc-row-old w-[42px] min-w-fit select-none bg-gray-900 p-1 pr-3 text-right text-gray-600',
+            'schema-doc-row-old w-[42px] min-w-fit select-none bg-gray-900 pr-3 text-right text-gray-600',
             props.className,
             props.type === 'removal' && 'bg-red-900/30',
             props.type === 'addition' && 'invisible',
@@ -133,7 +133,7 @@ export function ChangeRow(props: {
         />
         <td
           className={cn(
-            'schema-doc-row-new w-[42px] min-w-fit select-none bg-gray-900 p-1 pr-3 text-right text-gray-600',
+            'schema-doc-row-new w-[42px] min-w-fit select-none bg-gray-900 pr-3 text-right text-gray-600',
             props.className,
             props.type === 'removal' && 'invisible',
             props.type === 'addition' && 'bg-green-900/30',


### PR DESCRIPTION
### Background

A piece of feedback on the proposals work was that the diff view feels very large.
This reduces the size and spacing of the text.

<img width="625" height="626" alt="Screenshot 2026-01-06 at 11 57 30 AM" src="https://github.com/user-attachments/assets/9b439ac6-8df1-43a4-b1b1-a4b25a3ebed7" />


<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

<img width="545" height="461" alt="Screenshot 2026-01-06 at 11 57 11 AM" src="https://github.com/user-attachments/assets/ec15e608-e9a9-4d93-8fa1-90dcb7b27ce5" />


<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
