### PR TITLE
Track proposal diff row numbers using state

### DIFF
--- a/packages/web/app/src/index.css
+++ b/packages/web/app/src/index.css
@@ -232,13 +232,6 @@
   input::-webkit-inner-spin-button {
     -webkit-appearance: none;
   }
-
-  .schema-doc-row-old::before {
-    content: counter(olddoc);
-  }
-  .schema-doc-row-new::before {
-    content: counter(newdoc);
-  }
 }
 
 .hive-badge-is-changed:after {

--- a/packages/web/app/src/pages/target-proposal-supergraph.tsx
+++ b/packages/web/app/src/pages/target-proposal-supergraph.tsx
@@ -1,6 +1,7 @@
 import { buildSchema } from 'graphql';
 import { useQuery } from 'urql';
 import { ProposalOverview_ChangeFragment, toUpperSnakeCase } from '@/components/target/proposals';
+import { AnnotatedProvider } from '@/components/target/proposals/schema-diff/components';
 import { SchemaDiff } from '@/components/target/proposals/schema-diff/schema-diff';
 import { Spinner } from '@/components/ui/spinner';
 import { FragmentType, graphql, useFragment } from '@/gql';
@@ -120,7 +121,11 @@ function SupergraphDiff(props: {
       }
     }
     const after = patchSchema(before, changes, { onError: errors.looseErrorHandler });
-    return <SchemaDiff before={before} after={after} annotations={() => null} />;
+    return (
+      <AnnotatedProvider>
+        <SchemaDiff before={before} after={after} annotations={() => null} />
+      </AnnotatedProvider>
+    );
   } catch (e: unknown) {
     return (
       <>


### PR DESCRIPTION
### Background

We want to be able to collapse unchanged rows to reduce noise on schema proposal diff. The current way of adding row numbers is by counting the classes using css. This doesn't work when rows get hidden.

### Description

This adds logic to count the rows using context instead of relying on css. this allows us to show the row numbers even if rows are collapsed.

This may still yet change again depending on how rows are hidden.