### PR TITLE
use webhooks config for workflows heartbeats

### DIFF
--- a/deployment/index.ts
+++ b/deployment/index.ts
@@ -144,7 +144,7 @@ deployWorkflows({
   postmarkSecret,
   observability,
   sentry,
-  heartbeat: heartbeatsConfig.get('workflows'),
+  heartbeat: heartbeatsConfig.get('webhooks'),
 });
 
 const commerce = deployCommerce({


### PR DESCRIPTION
### Background

We already have the webhook heartbeat endpoint set up, we do not want to stop pinning it.

### Description

Previous deployment caused a wrong incident report. Since we removed the webhooks service, we can now re-use the existing heartbeat endpoint for the workflows instead.


