### PR TITLE
fix apollo-router-updater - extract first part of latest stable version

### DIFF
--- a/scripts/apollo-router-action.ts
+++ b/scripts/apollo-router-action.ts
@@ -51,7 +51,7 @@ async function fetchLatestVersion() {
   }
 
   const latest = await latestResponse.json();
-  const latestStableVersion = latest.name.replace('v', '');
+  const latestStableVersion = latest.name.replace('v', '').split(' ')[0];
 
   if (!latestStableVersion) {
     throw new Error('Failed to find latest stable version');


### PR DESCRIPTION
https://github.com/graphql-hive/console/actions/runs/20933252759/job/60149265833

```
$ pnpm tsx ./scripts/apollo-router-action.ts
Latest stable version: 2.10.0 (LTS)
Local version: 2.9.0
Local version is out of date
PR does not exist.

$ cargo update -p apollo-router --precise 2.10.0 (LTS)
```

It fails due to ` (LTS)` suffix, so I fixed it by splitting the version by space character and ignoring the rest.