### PR TITLE
fix(pnpm): remove emails dev task from turbo root

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -28,7 +28,6 @@
         "@hive/policy#dev",
         "@hive/commerce#dev",
         "@hive/cdn-script#dev",
-        "@hive/emails#dev",
         "@hive/usage#dev",
         "@hive/usage-ingestor#dev",
         "@graphql-hive/external-composition#example",


### PR DESCRIPTION
### Description
Removes `@hive/emails#dev` from the `turbo.json` dev dependency list to fix `pnpm dev:hive` startup.