### PR TITLE
Update graphql-modules to latest

### DIFF
--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -51,7 +51,7 @@
     "fast-json-stable-stringify": "2.1.0",
     "got": "14.4.7",
     "graphql": "16.9.0",
-    "graphql-modules": "3.0.0",
+    "graphql-modules": "3.1.1",
     "graphql-parse-resolve-info": "4.13.0",
     "graphql-scalars": "1.24.2",
     "graphql-yoga": "5.13.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -861,8 +861,8 @@ importers:
         specifier: 16.9.0
         version: 16.9.0
       graphql-modules:
-        specifier: 3.0.0
-        version: 3.0.0(graphql@16.9.0)
+        specifier: 3.1.1
+        version: 3.1.1(graphql@16.9.0)
       graphql-parse-resolve-info:
         specifier: 4.13.0
         version: 4.13.0(graphql@16.9.0)
@@ -1214,7 +1214,7 @@ importers:
         version: 8.0.3(@envelop/core@5.0.2)(graphql@16.9.0)
       '@envelop/graphql-modules':
         specifier: 7.0.1
-        version: 7.0.1(@envelop/core@5.0.2)(graphql-modules@3.0.0(graphql@16.9.0))(graphql@16.9.0)
+        version: 7.0.1(@envelop/core@5.0.2)(graphql-modules@3.1.1(graphql@16.9.0))(graphql@16.9.0)
       '@envelop/opentelemetry':
         specifier: 6.3.1
         version: 6.3.1(@envelop/core@5.0.2)(graphql@16.9.0)
@@ -4611,12 +4611,6 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
-  '@graphql-tools/batch-execute@9.0.11':
-    resolution: {integrity: sha512-v9b618cj3hIrRGTDrOotYzpK+ZigvNcKdXK3LNBM4g/uA7pND0d4GOnuOSBQGKKN6kT/1nsz4ZpUxCoUvWPbzg==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
   '@graphql-tools/batch-execute@9.0.19':
     resolution: {integrity: sha512-VGamgY4PLzSx48IHPoblRw0oTaBa7S26RpZXt0Y4NN90ytoE0LutlpB2484RbkfcTjv9wa64QD474+YP1kEgGA==}
     engines: {node: '>=18.0.0'}
@@ -4666,12 +4660,6 @@ packages:
 
   '@graphql-tools/delegate@10.2.23':
     resolution: {integrity: sha512-xrPtl7f1LxS+B6o+W7ueuQh67CwRkfl+UKJncaslnqYdkxKmNBB4wnzVcW8ZsRdwbsla/v43PtwAvSlzxCzq2w==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
-  '@graphql-tools/delegate@10.2.9':
-    resolution: {integrity: sha512-JlD/IdC26tyqopYvgXo48XwlDnpYPVs523dq5tg/u8kxJe3PtBmEUoE6EQ4CEMk0mB/r5ck+ZXTHt/wiOCWKhw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -5139,12 +5127,6 @@ packages:
   '@graphql-tools/wrap@10.0.16':
     resolution: {integrity: sha512-O/sOoPCnG2tWfhfIeWLQMPS7ipzjMiVOxwhjOUD9DaQd39XFBD4Al/MmKNc2343ua7NyqMwdfgXQjqGH1LFlPA==}
     engines: {node: '>=16.0.0'}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
-
-  '@graphql-tools/wrap@10.0.27':
-    resolution: {integrity: sha512-UikYBknzYgJKhzIXrzA58EO8IZ+jlX/iPmfUactK6aypc7iKCJzGD31Ha8rDI9GiHPn1F8PUAB4cTlGJ1qRh3w==}
-    engines: {node: '>=18.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
@@ -13137,8 +13119,8 @@ packages:
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0 || ^17.0.0
 
-  graphql-modules@3.0.0:
-    resolution: {integrity: sha512-ADQRySHp7SMqLHsv/NMkEBqOcyAC5bT6bTYuQemjmvSsF+gj1iQbzNF1pjy1lsE6UWxvRRzZN+sovp85Z6c3Vw==}
+  graphql-modules@3.1.1:
+    resolution: {integrity: sha512-T87Z7V99LG5KU+w15VJ+M8KwRAXMCMB6n7mv+iEBuJMiH6fC6snXr83yAPrcKCzSbiHstildq5SqUcvFfj7ymw==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
 
@@ -21601,11 +21583,11 @@ snapshots:
       tslib: 2.8.1
       value-or-promise: 1.0.12
 
-  '@envelop/graphql-modules@7.0.1(@envelop/core@5.0.2)(graphql-modules@3.0.0(graphql@16.9.0))(graphql@16.9.0)':
+  '@envelop/graphql-modules@7.0.1(@envelop/core@5.0.2)(graphql-modules@3.1.1(graphql@16.9.0))(graphql@16.9.0)':
     dependencies:
       '@envelop/core': 5.0.2
       graphql: 16.9.0
-      graphql-modules: 3.0.0(graphql@16.9.0)
+      graphql-modules: 3.1.1(graphql@16.9.0)
       tslib: 2.8.1
 
   '@envelop/instrumentation@1.0.0':
@@ -23824,13 +23806,6 @@ snapshots:
       tslib: 2.8.1
       value-or-promise: 1.0.12
 
-  '@graphql-tools/batch-execute@9.0.11(graphql@16.9.0)':
-    dependencies:
-      '@graphql-tools/utils': 10.9.1(graphql@16.9.0)
-      dataloader: 2.2.3
-      graphql: 16.9.0
-      tslib: 2.8.1
-
   '@graphql-tools/batch-execute@9.0.19(graphql@16.9.0)':
     dependencies:
       '@graphql-tools/utils': 10.9.1(graphql@16.9.0)
@@ -23923,18 +23898,6 @@ snapshots:
       '@graphql-tools/utils': 10.9.1(graphql@16.9.0)
       '@repeaterjs/repeater': 3.0.6
       '@whatwg-node/promise-helpers': 1.3.1
-      dataloader: 2.2.3
-      dset: 3.1.4
-      graphql: 16.9.0
-      tslib: 2.8.1
-
-  '@graphql-tools/delegate@10.2.9(graphql@16.9.0)':
-    dependencies:
-      '@graphql-tools/batch-execute': 9.0.11(graphql@16.9.0)
-      '@graphql-tools/executor': 1.4.7(graphql@16.9.0)
-      '@graphql-tools/schema': 10.0.25(graphql@16.9.0)
-      '@graphql-tools/utils': 10.9.1(graphql@16.9.0)
-      '@repeaterjs/repeater': 3.0.6
       dataloader: 2.2.3
       dset: 3.1.4
       graphql: 16.9.0
@@ -25077,14 +25040,6 @@ snapshots:
       graphql: 16.9.0
       tslib: 2.8.1
       value-or-promise: 1.0.12
-
-  '@graphql-tools/wrap@10.0.27(graphql@16.9.0)':
-    dependencies:
-      '@graphql-tools/delegate': 10.2.9(graphql@16.9.0)
-      '@graphql-tools/schema': 10.0.25(graphql@16.9.0)
-      '@graphql-tools/utils': 10.9.1(graphql@16.9.0)
-      graphql: 16.9.0
-      tslib: 2.8.1
 
   '@graphql-tools/wrap@10.1.4(graphql@16.9.0)':
     dependencies:
@@ -35383,10 +35338,10 @@ snapshots:
       nullthrows: 1.1.1
       vscode-languageserver-types: 3.17.5
 
-  graphql-modules@3.0.0(graphql@16.9.0):
+  graphql-modules@3.1.1(graphql@16.9.0):
     dependencies:
       '@graphql-tools/schema': 10.0.25(graphql@16.9.0)
-      '@graphql-tools/wrap': 10.0.27(graphql@16.9.0)
+      '@graphql-tools/wrap': 10.1.4(graphql@16.9.0)
       '@graphql-typed-document-node/core': 3.2.0(graphql@16.9.0)
       graphql: 16.9.0
       ramda: 0.30.1


### PR DESCRIPTION
In light of https://github.com/graphql-hive/graphql-modules/security/advisories/GHSA-53wg-r69p-v3r7.

The api service should not have been affected since it does not rely on the `@ExecutionContext` decorator.