### PR TITLE
fix(docs/gateway): schema transforms are supported in Rust QP

### DIFF
--- a/packages/web/docs/src/content/gateway/other-features/rust-query-planner.mdx
+++ b/packages/web/docs/src/content/gateway/other-features/rust-query-planner.mdx
@@ -116,7 +116,7 @@ The following table provides a comprehensive comparison between the two query pl
 | Feature                      | JavaScript | Rust                  | Notes                                                                                                   |
 | ---------------------------- | ---------- | --------------------- | ------------------------------------------------------------------------------------------------------- |
 | Additional resolvers         | ✅         | ❌                    | Additional type resolvers not supported                                                                 |
-| Schema transforms            | ✅         | ❌                    | Schema transformation pipeline not available in router runtime                                          |
+| Schema transforms            | ✅         | ✅                    | Schema transformation pipeline is available in router runtime                                           |
 | Progressive Override         | ✅         | ❌                    | Apollo Federation's `@override` directive not supported at the moment                                   |
 | Rate limiting                | ✅         | ❌                    | Field-level and global rate limiting not supported                                                      |
 | EDFS                         | ✅         | ❌                    | Event-Driven Federation Subscriptions are not supported because it uses additional resolvers            |


### PR DESCRIPTION
Transforms are supported since https://github.com/graphql-hive/gateway/pull/1708
