### PR TITLE
fix(core): clear persisted documents caches on dispose to prevent memory leaks

### DIFF
--- a/.changeset/brave-foxes-hunt.md
+++ b/.changeset/brave-foxes-hunt.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/core': patch
+---
+
+Clear persisted documents caches on dispose to prevent memory leaks. The `dispose()` function now clears `persistedDocumentsCache` and `fetchCache` to allow proper garbage collection.

--- a/packages/libraries/core/src/client/persisted-documents.ts
+++ b/packages/libraries/core/src/client/persisted-documents.ts
@@ -344,6 +344,8 @@ export function createPersistedDocuments(
     resolve: loadPersistedDocument,
     dispose() {
       circuitBreakers.map(breaker => breaker.shutdown());
+      persistedDocumentsCache.clear();
+      fetchCache.clear();
     },
   };
 }


### PR DESCRIPTION
### Background
The `dispose()` function wasn't clearing `persistedDocumentsCache` or `fetchCache`, causing memory to accumulate when running tests with leak detection on Node 20

https://github.com/graphql-hive/gateway/actions/runs/21066002133/job/60583665971?pr=1834