### PR TITLE
Disable project and target cards during loading

### DIFF
--- a/.changeset/little-frogs-fix.md
+++ b/.changeset/little-frogs-fix.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Disable project and target cards during loading

--- a/packages/web/app/src/pages/organization.tsx
+++ b/packages/web/app/src/pages/organization.tsx
@@ -83,6 +83,7 @@ const ProjectCard = (props: {
     <Card className="h-full self-start bg-gray-900/50 p-5 px-0 pt-4 hover:bg-gray-800/40 hover:shadow-md hover:shadow-gray-800/50">
       <Link
         to="/$organizationSlug/$projectSlug"
+        disabled={props.cleanOrganizationId == null || project?.slug == null}
         params={{
           organizationSlug: props.cleanOrganizationId ?? 'unknown-yet',
           projectSlug: project?.slug ?? 'unknown-yet',

--- a/packages/web/app/src/pages/project.tsx
+++ b/packages/web/app/src/pages/project.tsx
@@ -68,6 +68,9 @@ const TargetCard = (props: {
     >
       <Link
         to="/$organizationSlug/$projectSlug/$targetSlug"
+        disabled={
+          props.organizationSlug == null || props.projectSlug == null || target?.slug == null
+        }
         params={{
           organizationSlug: props.organizationSlug ?? 'unknown-yet',
           projectSlug: props.projectSlug ?? 'unknown-yet',


### PR DESCRIPTION
### Background

On the projects and targets page, if the list is not loaded yet then the card can still be clicked but you are taken to a bad url like `/my-org/unknown-yet/unknown-yet`. This only makes the issue of wait times even worse since the user then needs to go back a page before clicking through again.

### Description

This change improves the user experience by disabling the link when the necessary info isn't loaded in yet. This prevents accidentally clicking the card early and being taken to a bad domain.