### PR TITLE
fix/figure out permissions after clone

### DIFF
--- a/packages/libraries/router/package.json
+++ b/packages/libraries/router/package.json
@@ -3,6 +3,6 @@
   "version": "3.0.1",
   "private": true,
   "scripts": {
-    "sync-cargo-file": "ls -l sync-cargo-file.sh && sh ./sync-cargo-file.sh"
+    "sync-cargo-file": "ls -l sync-cargo-file.sh && bash ./sync-cargo-file.sh"
   }
 }


### PR DESCRIPTION
### Background

Build started failing because the file is not executable. But when checking it has the correct permissions.

```
➜  graphql-hive-3 git:(fix-script-run) ✗ ls -l  packages/libraries/router/sync-cargo-file.sh
-rwxr-xr-x  1 laurinquast  staff  713 Nov 20  2024 packages/libraries/router/sync-cargo-file.sh
```

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->

### Checklist

<!---
We are following the OWASP Secure Coding Practices for developing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
