### PR TITLE
fix(ci): use `tag_name` instead of release `name` in `apollo-router` updater workflow

### DIFF
--- a/scripts/apollo-router-action.ts
+++ b/scripts/apollo-router-action.ts
@@ -51,7 +51,7 @@ async function fetchLatestVersion() {
   }
 
   const latest = await latestResponse.json();
-  const latestStableVersion = latest.name.replace('v', '');
+  const latestStableVersion = latest.tag_name.replace('v', '');
 
   if (!latestStableVersion) {
     throw new Error('Failed to find latest stable version');


### PR DESCRIPTION
Fix https://github.com/graphql-hive/console/actions/runs/21364625840/job/61500590730 