### PR TITLE
fix(yoga): handle malformed persisted document IDs with proper error instead of 500

### DIFF
--- a/.changeset/calm-doors-shake.md
+++ b/.changeset/calm-doors-shake.md
@@ -1,0 +1,5 @@
+---
+'@graphql-hive/yoga': patch
+---
+
+Fix 500 error when malformed document IDs are passed to persisted documents. Now returns a proper GraphQL error with `INVALID_DOCUMENT_ID` code.


### PR DESCRIPTION
### Background

Malformed `document_id` values cause 500 errors instead of helpful validation errors. The core library throws `PersistedDocumentValidationError` but the yoga plugin wasn't catching it.

### Description
  Added error handling in `@graphql-hive/yoga` to catch validation errors and return a proper GraphQL error with `INVALID_DOCUMENT_ID` code.