### PR TITLE
Wrap side effect in organization join page with useEffect

### DIFF
--- a/packages/web/app/src/pages/organization-join.tsx
+++ b/packages/web/app/src/pages/organization-join.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import { LogOutIcon } from 'lucide-react';
 import { SessionAuth, useSessionContext } from 'supertokens-auth-react/recipe/session';
 import { useMutation, useQuery } from 'urql';
@@ -92,24 +92,29 @@ export function JoinOrganizationPage(props: { inviteCode: string }) {
       ? query.data.organizationByInviteCode.name
       : null;
 
+  useEffect(() => {
+    if (!session.loading && !session.doesSessionExist) {
+      toast({
+        title: 'Account Required',
+        description:
+          'To accept an organization invite, you must first have an account, log in, and then use the invitation.',
+        variant: 'default',
+        duration: 10_000,
+      });
+      void router.navigate({
+        to: '/auth/sign-in',
+        search: {
+          redirectToPath: router.latestLocation.pathname,
+        },
+      });
+    }
+  }, [!session.loading && !session.doesSessionExist, toast, router]);
+
   if (session.loading) {
     return <Spinner className="m-auto mt-6" />;
   }
 
-  if (!session.loading && !session.doesSessionExist) {
-    toast({
-      title: 'Account Required',
-      description:
-        'To accept an organization invite, you must first have an account, log in, and then use the invitation.',
-      variant: 'default',
-      duration: 10_000,
-    });
-    void router.navigate({
-      to: '/auth/sign-in',
-      search: {
-        redirectToPath: router.latestLocation.pathname,
-      },
-    });
+  if (!session.doesSessionExist) {
     return <></>;
   }
 


### PR DESCRIPTION
### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->
While looking into the invitation flow, I spotted a side effect placed directly inside the render function of the organization-join page, which made the redirected `/auth/sign-in` page to have a `redirectToPath` value of `/auth/sign-in`. :facepalm:

### Description

<!---
Please share here a technical description of your changes. This should include what packages/components are effects: CLI, client/agent, services, APIs.
--->
Isolates the side effects into the useEffect hook.

### Checklist

<!---
We are following the OWASP Secure Coding Practices for developing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
