### PR TITLE
fix: chema sdl resolver to ignore auto fix composite schema execution…

### DIFF
--- a/.changeset/afraid-pans-thank.md
+++ b/.changeset/afraid-pans-thank.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Fix for schema sdl resolver to ignore auto fix composite schema execution in case of monolith

--- a/integration-tests/testkit/flow.ts
+++ b/integration-tests/testkit/flow.ts
@@ -1242,6 +1242,7 @@ export function fetchLatestValidSchema(token: string) {
             }
           }
           tags
+          sdl
           schemas {
             nodes {
               ... on SingleSchema {

--- a/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-version-helper.ts
@@ -105,12 +105,17 @@ export class SchemaVersionHelper {
 
   async getCompositeSchemaSdl(schemaVersion: SchemaVersion) {
     if (schemaVersion.hasPersistedSchemaChanges) {
+      if (!schemaVersion.supergraphSDL) {
+        return schemaVersion.compositeSchemaSDL;
+      }
+
       return schemaVersion.compositeSchemaSDL
         ? this.autoFixCompositeSchemaSdl(schemaVersion.compositeSchemaSDL, schemaVersion.id)
         : null;
     }
 
     const composition = await this.composeSchemaVersion(schemaVersion);
+
     if (composition === null) {
       return null;
     }
@@ -134,6 +139,7 @@ export class SchemaVersionHelper {
   @cache<SchemaVersion>(version => version.id)
   async getCompositeSchemaAst(schemaVersion: SchemaVersion) {
     const compositeSchemaSdl = await this.getCompositeSchemaSdl(schemaVersion);
+
     if (compositeSchemaSdl === null) {
       return null;
     }

--- a/packages/web/app/src/pages/target-laboratory-new.tsx
+++ b/packages/web/app/src/pages/target-laboratory-new.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo } from 'react';
 import clsx from 'clsx';
 import { buildSchema, introspectionFromSchema } from 'graphql';
 import { throttle } from 'lodash';
+import { toast } from 'sonner';
 import { useMutation, useQuery } from 'urql';
 import { Page, TargetLayout } from '@/components/layouts/target';
 import { ConnectLabModal } from '@/components/target/laboratory/connect-lab-modal';
@@ -605,10 +606,21 @@ function LaboratoryPageContent(props: {
   });
 
   const sdl = query.data?.target?.latestSchemaVersion?.sdl;
-  const introspection = useMemo(
-    () => (sdl ? introspectionFromSchema(buildSchema(sdl)) : null),
-    [sdl],
-  );
+
+  const introspection = useMemo(() => {
+    if (!sdl) {
+      return null;
+    }
+
+    try {
+      return introspectionFromSchema(buildSchema(sdl));
+    } catch (err) {
+      toast.error('Failed to fetch schema', {
+        description: err instanceof Error ? err.message : 'Unknown error',
+      });
+      return null;
+    }
+  }, [sdl]);
 
   if (laboratoryState.fetching) {
     return null;


### PR DESCRIPTION
… in case of monolith

### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

Schema sdl resolver to ignore auto fix composite schema execution in case of monolith

### Checklist

<!---
We are following the OWASP Secure Coding Practices for developing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
