### PR TITLE
Enhancement: New lab preflight prompt metadata

### DIFF
--- a/packages/web/app/src/laboratory/components/laboratory/context.tsx
+++ b/packages/web/app/src/laboratory/components/laboratory/context.tsx
@@ -73,7 +73,9 @@ type LaboratoryContextActions = LaboratoryCollectionsActions &
     openUpdateEndpointDialog?: () => void;
     openAddTestDialog?: () => void;
     openPreflightPromptModal?: (props: {
-      placeholder: string;
+      title?: string;
+      description?: string;
+      placeholder?: string;
       defaultValue?: string;
       onSubmit?: (value: string | null) => void;
     }) => void;
@@ -142,7 +144,9 @@ export interface LaboratoryApi {
   openUpdateEndpointDialog?: () => void;
   openAddTestDialog?: () => void;
   openPreflightPromptModal?: (props: {
-    placeholder: string;
+    title?: string;
+    description?: string;
+    placeholder?: string;
     defaultValue?: string;
     onSubmit?: (value: string | null) => void;
   }) => void;

--- a/packages/web/app/src/laboratory/components/laboratory/laboratory.tsx
+++ b/packages/web/app/src/laboratory/components/laboratory/laboratory.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { FileIcon, FoldersIcon, HistoryIcon, SettingsIcon } from 'lucide-react';
 import * as z from 'zod';
+import { Markdown } from '@/components/v2/markdown';
 import { Collections } from '@/laboratory/components/laboratory/collections';
 import { Command } from '@/laboratory/components/laboratory/command';
 import {
@@ -44,7 +45,13 @@ import {
   EmptyMedia,
   EmptyTitle,
 } from '@/laboratory/components/ui/empty';
-import { Field, FieldError, FieldGroup, FieldLabel } from '@/laboratory/components/ui/field';
+import {
+  Field,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLabel,
+} from '@/laboratory/components/ui/field';
 import { Input } from '@/laboratory/components/ui/input';
 import {
   ResizableHandle,
@@ -81,7 +88,9 @@ const addTestFormSchema = z.object({
 const PreflightPromptModal = (props: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  placeholder: string;
+  title?: string;
+  description?: string;
+  placeholder?: string;
   defaultValue?: string;
   onSubmit?: (value: string | null) => void;
 }) => {
@@ -116,7 +125,6 @@ const PreflightPromptModal = (props: {
         <DialogHeader>
           <DialogTitle>Preflight prompt</DialogTitle>
         </DialogHeader>
-        <DialogDescription>Enter values for the preflight script.</DialogDescription>
         <form
           id="preflight-prompt-form"
           onSubmit={e => {
@@ -128,8 +136,15 @@ const PreflightPromptModal = (props: {
             <form.Field name="value">
               {field => {
                 const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
+
                 return (
                   <Field data-invalid={isInvalid}>
+                    <FieldLabel htmlFor={field.name}>{props.title}</FieldLabel>
+                    {props.description && (
+                      <FieldDescription>
+                        <Markdown content={props.description} />
+                      </FieldDescription>
+                    )}
                     <Input
                       id={field.name}
                       name={field.name}
@@ -470,11 +485,51 @@ export const Laboratory = (
     [props.permissions],
   );
 
+  const [isPreflightPromptModalOpen, setIsPreflightPromptModalOpen] = useState(false);
+
+  const [preflightPromptModalProps, setPreflightPromptModalProps] = useState<{
+    title?: string;
+    description?: string;
+    placeholder?: string;
+    defaultValue?: string;
+    onSubmit?: (value: string | null) => void;
+  }>({
+    title: undefined,
+    description: undefined,
+    placeholder: undefined,
+    defaultValue: undefined,
+    onSubmit: undefined,
+  });
+
+  const openPreflightPromptModal = useCallback(
+    (props: {
+      title?: string;
+      description?: string;
+      placeholder?: string;
+      defaultValue?: string;
+      onSubmit?: (value: string | null) => void;
+    }) => {
+      setPreflightPromptModalProps({
+        title: props.title,
+        description: props.description,
+        placeholder: props.placeholder,
+        defaultValue: props.defaultValue,
+        onSubmit: props.onSubmit,
+      });
+
+      setTimeout(() => {
+        setIsPreflightPromptModalOpen(true);
+      }, 200);
+    },
+    [],
+  );
+
   const settingsApi = useSettings(props);
   const envApi = useEnv(props);
   const preflightApi = usePreflight({
     ...props,
     envApi,
+    openPreflightPromptModal,
   });
 
   const pluginsApi = usePlugins(props);
@@ -557,37 +612,6 @@ export const Laboratory = (
       setIsAddTestDialogOpen(false);
     },
   });
-
-  const [isPreflightPromptModalOpen, setIsPreflightPromptModalOpen] = useState(false);
-
-  const [preflightPromptModalProps, setPreflightPromptModalProps] = useState<{
-    placeholder: string;
-    defaultValue?: string;
-    onSubmit?: (value: string | null) => void;
-  }>({
-    placeholder: '',
-    defaultValue: undefined,
-    onSubmit: undefined,
-  });
-
-  const openPreflightPromptModal = useCallback(
-    (props: {
-      placeholder: string;
-      defaultValue?: string;
-      onSubmit?: (value: string | null) => void;
-    }) => {
-      setPreflightPromptModalProps({
-        placeholder: props.placeholder,
-        defaultValue: props.defaultValue,
-        onSubmit: props.onSubmit,
-      });
-
-      setTimeout(() => {
-        setIsPreflightPromptModalOpen(true);
-      }, 200);
-    },
-    [],
-  );
 
   const containerRef = useRef<HTMLDivElement>(null);
 

--- a/packages/web/app/src/laboratory/components/laboratory/preflight.tsx
+++ b/packages/web/app/src/laboratory/components/laboratory/preflight.tsx
@@ -41,10 +41,12 @@ export const Preflight = () => {
     const result = await runIsolatedLabScript(
       preflight?.script ?? '',
       env ?? { variables: {} },
-      (placeholder, defaultValue) => {
+      (title, defaultValue, options) => {
         return new Promise(resolve => {
           openPreflightPromptModal?.({
-            placeholder,
+            title,
+            description: options?.description,
+            placeholder: options?.placeholder,
             defaultValue,
             onSubmit: value => {
               resolve(value);
@@ -95,7 +97,7 @@ export const Preflight = () => {
                     request: {
                       headers: Headers;
                     };
-                    prompt: (placeholder: string, defaultValue: string) => Promise<string | null>;
+                    prompt: (title: string, defaultValue: string, options?: { placeholder?: string; description?: string }) => Promise<string | null>;
                     CryptoJS: typeof CryptoJS;
                     plugins: {
                       ${plugins


### PR DESCRIPTION
### Background

<!---
Please include a short note explaining the need for this PR / change.
If you are resolving/closing/fixing an issue, please mention it in this section.
--->

### Description

Ability to call prompt with: title, defaultValue, placeholder and markdown description

Example:

```
await lab.prompt('Email', '', {
  placeholder: 'example@example.com',
  description: 'Read more in [Docs](https://google.com)'
})
```
<img width="1840" height="1195" alt="Screenshot 2026-02-04 at 10 18 31" src="https://github.com/user-attachments/assets/9285155c-8103-4c6b-abe0-7567e9021789" />

### Checklist

<!---
We are following the OWASP Secure Coding Practices for developing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
