### PR TITLE
fix(app): dev graphiql page height using viewport instead of relative

### DIFF
--- a/packages/web/app/src/pages/dev.tsx
+++ b/packages/web/app/src/pages/dev.tsx
@@ -7,7 +7,7 @@ import 'graphiql/style.css';
 
 export function DevPage() {
   return (
-    <div className="size-full">
+    <div className="h-screen w-full">
       <Helmet>
         <style key="dev">
           {`


### PR DESCRIPTION
before:
<img width="1147" height="872" alt="Screenshot 2026-02-04 at 19 02 14" src="https://github.com/user-attachments/assets/b893adfc-c6b4-4b08-9a66-812701a577ef" />

after:
<img width="1147" height="872" alt="Screenshot 2026-02-04 at 19 03 43" src="https://github.com/user-attachments/assets/a07c947a-f5ba-42a5-8a8f-d3385c9e234b" />
