### PR TITLE
Add created at, last used, and total docs to app deployment view

### DIFF
--- a/.changeset/dry-bats-pay.md
+++ b/.changeset/dry-bats-pay.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Add created at, last used, and total docs to app deployment view

--- a/scripts/seed-schemas/federated/users.graphql
+++ b/scripts/seed-schemas/federated/users.graphql
@@ -102,7 +102,7 @@ extend type Query {
     """
     id: ID!
   ): User
-  users: [User]
+  users(limit: Int! = 30): [User]
 }
 
 extend type Mutation {


### PR DESCRIPTION
### Background

https://linear.app/the-guild/issue/CONSOLE-1787/add-ui-to-check-age-of-app-deployments-for-approvals

App deployments dont have enough info shown to determine whether they are safe to ignore in the case of schema approvals or not.

### Description

This adds the vital info to the app deployment page. I used the schema check page as a reference for how this should look.

<img width="920" height="443" alt="Screenshot 2026-02-04 at 12 04 09 PM" src="https://github.com/user-attachments/assets/7ce3b684-7dcf-4102-88a5-14b2091b8113" />

