### PR TITLE
fix: drop unique zendesk constraint

### DIFF
--- a/packages/migrations/src/actions/2026.02.06T00-00-00.zendesk-unique.ts
+++ b/packages/migrations/src/actions/2026.02.06T00-00-00.zendesk-unique.ts
@@ -1,0 +1,10 @@
+import { type MigrationExecutor } from '../pg-migrator';
+
+export default {
+  name: '2026.02.06T00-00-00.zendesk-unique.ts',
+  run: ({ sql }) => sql`
+    ALTER TABLE "users"
+    DROP CONSTRAINT IF EXISTS "users_zendesk_user_id_key"
+    ;
+  `,
+} satisfies MigrationExecutor;

--- a/packages/migrations/src/run-pg-migrations.ts
+++ b/packages/migrations/src/run-pg-migrations.ts
@@ -181,5 +181,6 @@ export const runPGMigrations = async (args: { slonik: DatabasePool; runTo?: stri
       await import('./actions/2026.01.27T00-00-00.app-deployment-protection'),
       await import('./actions/2026.01.09T00-00-00.email-verifications'),
       await import('./actions/2026.01.30T00-00-00.account-linking'),
+      await import('./actions/2026.02.06T00-00-00.zendesk-unique'),
     ],
   });


### PR DESCRIPTION
### Description

We can have multiple users with the same email currently, so this index causes runtime exceptions. If at a later stage we deduplicated existing users we can consider reintroducing this index.

I checked the code for any usages of this, but there is no real usage aside from registering the user on our zendesk organization.

https://linear.app/the-guild/issue/CONSOLE-1841/internal-server-error-when-opening-support-ticket-in-hive

### Checklist

<!---
We are following the OWASP Secure Coding Practices for developing Hive. You can find the complete guide here:
https://owasp.org/www-pdf-archive/OWASP_SCP_Quick_Reference_Guide_v2.pdf

Please use this checklist to ensure your PR quality before proceeding.
You may remove unnecessary checks from this list, if it's not relevant to your changes.
--->

- [ ] Input validation
- [ ] Output encoding
- [ ] Authentication management
- [ ] Session management
- [ ] Access control
- [ ] Cryptographic practices
- [ ] Error handling and logging
- [ ] Data protection
- [ ] Communication security
- [ ] System configuration
- [ ] Database security
- [ ] File management
- [ ] Memory management
- [ ] Testing
