### PR TITLE
Improve handling of "extend schema" in subgraphs for proposals

### DIFF
--- a/packages/services/api/src/modules/schema/providers/schema-helper.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-helper.ts
@@ -1,5 +1,13 @@
 import { createHash } from 'node:crypto';
-import { DocumentNode, print, visit } from 'graphql';
+import {
+  DefinitionNode,
+  DocumentNode,
+  isTypeDefinitionNode,
+  isTypeExtensionNode,
+  Kind,
+  print,
+  visit,
+} from 'graphql';
 import { Injectable, Scope } from 'graphql-modules';
 import objectHash from 'object-hash';
 import type {
@@ -101,6 +109,67 @@ export function removeDescriptions(documentNode: DocumentNode): DocumentNode {
       }
     },
   });
+}
+
+const extensionToDefinitionKindMap = {
+  [Kind.OBJECT_TYPE_EXTENSION]: Kind.OBJECT_TYPE_DEFINITION,
+  [Kind.INPUT_OBJECT_TYPE_EXTENSION]: Kind.INPUT_OBJECT_TYPE_DEFINITION,
+  [Kind.INTERFACE_TYPE_EXTENSION]: Kind.INTERFACE_TYPE_DEFINITION,
+  [Kind.UNION_TYPE_EXTENSION]: Kind.UNION_TYPE_DEFINITION,
+  [Kind.ENUM_TYPE_EXTENSION]: Kind.ENUM_TYPE_DEFINITION,
+  [Kind.SCALAR_TYPE_EXTENSION]: Kind.SCALAR_TYPE_DEFINITION,
+} as const;
+
+export function addTypeForExtensions(ast: DocumentNode) {
+  const trackTypeDefs = new Map<
+    string,
+    | {
+        state: 'TYPE_ONLY';
+      }
+    | {
+        state: 'EXTENSION_ONLY' | 'VALID_EXTENSION';
+        kind:
+          | Kind.OBJECT_TYPE_EXTENSION
+          | Kind.ENUM_TYPE_EXTENSION
+          | Kind.UNION_TYPE_EXTENSION
+          | Kind.SCALAR_TYPE_EXTENSION
+          | Kind.INTERFACE_TYPE_EXTENSION
+          | Kind.INPUT_OBJECT_TYPE_EXTENSION;
+      }
+  >();
+  for (const node of ast.definitions) {
+    if ('name' in node && node.name) {
+      const name = node.name.value;
+      const entry = trackTypeDefs.get(name);
+      if (isTypeExtensionNode(node)) {
+        if (!entry) {
+          trackTypeDefs.set(name, { state: 'EXTENSION_ONLY', kind: node.kind });
+        } else if (entry.state === 'TYPE_ONLY') {
+          trackTypeDefs.set(name, { kind: node.kind, state: 'VALID_EXTENSION' });
+        }
+      } else if (isTypeDefinitionNode(node)) {
+        if (!entry) {
+          trackTypeDefs.set(name, { state: 'TYPE_ONLY' });
+        } else if (entry.state === 'EXTENSION_ONLY') {
+          trackTypeDefs.set(name, { ...entry, state: 'VALID_EXTENSION' });
+        }
+      }
+    }
+  }
+
+  const astCopy = visit(ast, {});
+  for (const [name, entry] of trackTypeDefs) {
+    if (entry.state === 'EXTENSION_ONLY') {
+      (astCopy.definitions as DefinitionNode[]).push({
+        kind: extensionToDefinitionKindMap[entry.kind],
+        name: {
+          kind: Kind.NAME,
+          value: name,
+        },
+      });
+    }
+  }
+  return astCopy;
 }
 
 @Injectable({

--- a/packages/services/api/src/modules/schema/providers/schema-publisher.ts
+++ b/packages/services/api/src/modules/schema/providers/schema-publisher.ts
@@ -1047,6 +1047,7 @@ export class SchemaPublisher {
       return {
         __typename: 'SchemaCheckError',
         valid: false,
+        schemaProposalChanges: schemaCheck.schemaProposalChanges,
         changes: [
           ...(checkResult.state.schemaChanges?.all ?? []),
           ...(checkResult.state.contracts?.flatMap(contract => [
@@ -1096,6 +1097,7 @@ export class SchemaPublisher {
       return {
         __typename: 'SchemaCheckSuccess',
         valid: true,
+        schemaProposalChanges: schemaCheck.schemaProposalChanges,
         changes: [],
         warnings: [],
         initial: false,
@@ -1111,6 +1113,7 @@ export class SchemaPublisher {
     return {
       __typename: 'SchemaCheckError',
       valid: false,
+      schemaProposalChanges: schemaCheck.schemaProposalChanges,
       changes: [],
       warnings: [],
       errors: [

--- a/packages/web/app/src/components/target/proposals/schema-diff/core.tsx
+++ b/packages/web/app/src/components/target/proposals/schema-diff/core.tsx
@@ -288,9 +288,14 @@ function schemaDefinitionDiff({
   builder.newLine({ type: changeType });
   builder.write(keyword('schema'));
 
+  // Merge schema extensions into the schema definition to be sure to collect all directives applied to the schema definition.
   diffDirectiveUsages({
-    oldDirectives: oldSchema?.astNode?.directives ?? [],
-    newDirectives: newSchema?.astNode?.directives ?? [],
+    oldDirectives: (oldSchema?.astNode?.directives ?? []).concat(
+      ...(oldSchema?.extensionASTNodes.map(n => n.directives ?? []) ?? []),
+    ),
+    newDirectives: (newSchema?.astNode?.directives ?? []).concat(
+      ...(newSchema?.extensionASTNodes.map(n => n.directives ?? []) ?? []),
+    ),
     builder,
     path: ['.'],
   });

--- a/packages/web/app/src/lib/proposals/utils.ts
+++ b/packages/web/app/src/lib/proposals/utils.ts
@@ -1,0 +1,69 @@
+import {
+  DefinitionNode,
+  DocumentNode,
+  isTypeDefinitionNode,
+  isTypeExtensionNode,
+  Kind,
+  visit,
+} from 'graphql';
+
+const extensionToDefinitionKindMap = {
+  [Kind.OBJECT_TYPE_EXTENSION]: Kind.OBJECT_TYPE_DEFINITION,
+  [Kind.INPUT_OBJECT_TYPE_EXTENSION]: Kind.INPUT_OBJECT_TYPE_DEFINITION,
+  [Kind.INTERFACE_TYPE_EXTENSION]: Kind.INTERFACE_TYPE_DEFINITION,
+  [Kind.UNION_TYPE_EXTENSION]: Kind.UNION_TYPE_DEFINITION,
+  [Kind.ENUM_TYPE_EXTENSION]: Kind.ENUM_TYPE_DEFINITION,
+  [Kind.SCALAR_TYPE_EXTENSION]: Kind.SCALAR_TYPE_DEFINITION,
+} as const;
+
+export function addTypeForExtensions(ast: DocumentNode) {
+  const trackTypeDefs = new Map<
+    string,
+    | {
+        state: 'TYPE_ONLY';
+      }
+    | {
+        state: 'EXTENSION_ONLY' | 'VALID_EXTENSION';
+        kind:
+          | Kind.OBJECT_TYPE_EXTENSION
+          | Kind.ENUM_TYPE_EXTENSION
+          | Kind.UNION_TYPE_EXTENSION
+          | Kind.SCALAR_TYPE_EXTENSION
+          | Kind.INTERFACE_TYPE_EXTENSION
+          | Kind.INPUT_OBJECT_TYPE_EXTENSION;
+      }
+  >();
+  for (const node of ast.definitions) {
+    if ('name' in node && node.name) {
+      const name = node.name.value;
+      const entry = trackTypeDefs.get(name);
+      if (isTypeExtensionNode(node)) {
+        if (!entry) {
+          trackTypeDefs.set(name, { state: 'EXTENSION_ONLY', kind: node.kind });
+        } else if (entry.state === 'TYPE_ONLY') {
+          trackTypeDefs.set(name, { kind: node.kind, state: 'VALID_EXTENSION' });
+        }
+      } else if (isTypeDefinitionNode(node)) {
+        if (!entry) {
+          trackTypeDefs.set(name, { state: 'TYPE_ONLY' });
+        } else if (entry.state === 'EXTENSION_ONLY') {
+          trackTypeDefs.set(name, { ...entry, state: 'VALID_EXTENSION' });
+        }
+      }
+    }
+  }
+
+  const astCopy = visit(ast, {});
+  for (const [name, entry] of trackTypeDefs) {
+    if (entry.state === 'EXTENSION_ONLY') {
+      (astCopy.definitions as DefinitionNode[]).push({
+        kind: extensionToDefinitionKindMap[entry.kind],
+        name: {
+          kind: Kind.NAME,
+          value: name,
+        },
+      });
+    }
+  }
+  return astCopy;
+}


### PR DESCRIPTION
Patch schemas in diffSchemas for subgraphs using extend keyword; merge schema def and schema extensions directives in schema diff renderer

### Background

Schema extensions continue to be a problem for subgraph diffing.
SDL with only a type extension and not a type definition cannot be built, even though federation v1 uses this structure. And "extend schema ..." can define directives, but those directives remain on the extension in the AST and not in the main ASTNode, which caused issues with the rendering for proposals.

### Description

These changes address both issues by adding a definition to the AST before building. E.g.

This schema:
```
extend type Foo {
  bar: Boolean
}
```

Becomes:
```
type Foo

extend type Foo {
  bar: Boolean
}
```

And it merges the list of directives from the astNode and extension nodes in the diff renderer.