### PR TITLE
Add referrerPolicy back to YouTube iframes

### DIFF
--- a/packages/web/docs/src/components/youtube-iframe.tsx
+++ b/packages/web/docs/src/components/youtube-iframe.tsx
@@ -22,6 +22,8 @@ export function YoutubeIframe({
       allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
       allowFullScreen
       sandbox="allow-scripts allow-presentation allow-same-origin allow-popups"
+      // this is required for the iframe to work in prod, doesn't matter on localhost
+      referrerPolicy="strict-origin-when-cross-origin"
     />
   );
 }


### PR DESCRIPTION
### Background

I wanna link to the new laboratory product update in Weekly and the YT embed is broken.

### Description

We used to have this line, it seems it was removed by accident.
