### PR TITLE
fix: add targetAccessToken:modify to organization access token permissions

### DIFF
--- a/packages/services/api/src/modules/organization/lib/organization-access-token-permissions.ts
+++ b/packages/services/api/src/modules/organization/lib/organization-access-token-permissions.ts
@@ -94,6 +94,11 @@ export const permissionGroups: Array<PermissionGroup> = [
         title: 'Manage CDN access tokens',
         description: 'Allow managing access tokens for the CDN.',
       },
+      {
+        id: 'targetAccessToken:modify',
+        title: 'Manage registry access tokens',
+        description: 'Create and delete registry access tokens for targets.',
+      },
     ],
   },
   {


### PR DESCRIPTION
## Summary

- Adds the missing `targetAccessToken:modify` permission to the organization access token permissions list

## Problem

The `targetAccessToken:modify` permission is required by the `createToken` mutation but was missing from the list of assignable permissions for organization access tokens. This prevented programmatic token creation via the API.

The permission was already:
1. Defined in `authz.ts` under `permissionsByLevel.target`
2. Required by `TokenManager.createToken()` in `token-manager.ts`
3. Available for organization members in `organization-member-permissions.ts`

But it was not exposed for organization access tokens, making it impossible to grant this permission to API tokens.

## Solution

Added `targetAccessToken:modify` to the `target` permission group in `organization-access-token-permissions.ts`.

Fixes #7657

## Test plan

- [ ] Create an organization access token with the new "Manage registry access tokens" permission
- [ ] Verify the token can call the `createToken` mutation successfully