### PR TITLE
Correct the public url for http callback in documentation

### DIFF
--- a/packages/web/docs/src/content/gateway/subscriptions.mdx
+++ b/packages/web/docs/src/content/gateway/subscriptions.mdx
@@ -138,7 +138,7 @@ export const gatewayConfig = defineConfig({
           kind: 'http-callback',
           options: {
             // The gateway's public URL, which your subgraphs access, must include the path configured on the gateway.
-            public_url: 'http://localhost:4000/callback',
+            public_url: 'http://localhost:4000',
             // The path of the router's callback endpoint
             path: '/callback',
             // Heartbeat interval to make sure the subgraph is still alive, and avoid hanging requests


### PR DESCRIPTION
HTTP callback config for Hive Gateway public_url should not also have callback path.
