### PR TITLE
Change link text color from neutral to accent

### DIFF
--- a/packages/web/app/src/components/target/history/errors-and-changes.tsx
+++ b/packages/web/app/src/components/target/history/errors-and-changes.tsx
@@ -487,7 +487,7 @@ function ChangeItem(
                                       appVersion: deployment.version,
                                     }}
                                     search={{ coordinates: change.path?.join('.') }}
-                                    className="text-neutral-2 block pt-2 text-sm hover:underline"
+                                    className="text-accent block pt-2 text-sm hover:underline"
                                   >
                                     Show all ({deployment.totalAffectedOperations}) affected
                                     operations
@@ -583,7 +583,7 @@ function ChangeItem(
                                   appVersion: deployment.version,
                                 }}
                                 search={{ coordinates: change.path?.join('.') }}
-                                className="text-neutral-2 block pt-2 text-sm hover:underline"
+                                className="text-accent block pt-2 text-sm hover:underline"
                               >
                                 Show all ({deployment.totalAffectedOperations}) affected operations
                               </Link>


### PR DESCRIPTION
This PR updates another missed link color in the `errors-and-changes.tsx` file.