### PR TITLE
fix width-jumping in virtual lists

### DIFF
--- a/packages/web/app/src/components/base/menu/menu.tsx
+++ b/packages/web/app/src/components/base/menu/menu.tsx
@@ -180,9 +180,9 @@ type MenuProps = {
    */
   lockScroll?: boolean;
   /**
-   * Prevent the popup from shrinking while open. The width ratchets upward
-   * as wider content scrolls into view (e.g. virtualized lists) but never
-   * jumps narrower. Resets each time the popup reopens.
+   * Lock the popup width after the first layout so it never changes while open.
+   * Useful for virtualized lists where items scroll in/out of view.
+   * Resets each time the popup reopens.
    */
   stableWidth?: boolean;
 };


### PR DESCRIPTION
This PR updates the `useStableWidth` function in our `Menu` component to prevent a virtualized list from changing widths as items of differing widths scroll into view.

Rather than ratcheting over the lifetime of the popup, we set the initial width to the natural width of the initial visible items and rely on `title` attributes for visibility of longer item names.