### PR TITLE
update manage filters ui

### DIFF
--- a/packages/web/app/src/pages/target-insights-manage-filters.tsx
+++ b/packages/web/app/src/pages/target-insights-manage-filters.tsx
@@ -259,7 +259,7 @@ function SavedFilterRow({
   return (
     <>
       <TableRow
-        className={canManage ? 'cursor-pointer' : undefined}
+        className={canManage ? 'cursor-pointer' : 'hover:bg-transparent'}
         onClick={canManage ? onToggleExpand : undefined}
       >
         <TableCell className="w-8">


### PR DESCRIPTION
This PR restricts the manage filters UI for non-privileged users viewing shared filters they don't have permission to modify. Rows for such filters no longer display the expand chevron or respond to clicks, preventing access to the filter editing panel. 

The action dropdown is now always visible but only shows "View in Insights" when the user lacks update/delete permissions. Private filters owned by the user remain fully manageable regardless of role.