### PR TITLE
Explorer page unions now link to the contained types

### DIFF
--- a/.changeset/strong-women-bake.md
+++ b/.changeset/strong-women-bake.md
@@ -1,0 +1,5 @@
+---
+'hive': patch
+---
+
+Explorer page unions now link to the contained types

--- a/packages/web/app/src/components/target/explorer/union-type.tsx
+++ b/packages/web/app/src/components/target/explorer/union-type.tsx
@@ -1,5 +1,10 @@
 import { FragmentType, graphql, useFragment } from '@/gql';
-import { GraphQLTypeCard, GraphQLTypeCardListItem, SchemaExplorerUsageStats } from './common';
+import {
+  GraphQLTypeAsLink,
+  GraphQLTypeCard,
+  GraphQLTypeCardListItem,
+  SchemaExplorerUsageStats,
+} from './common';
 import { SupergraphMetadataList } from './super-graph-metadata';
 
 const GraphQLUnionTypeComponent_TypeFragment = graphql(`
@@ -46,7 +51,21 @@ export function GraphQLUnionTypeComponent(props: {
       <div className="flex flex-col">
         {ttype.members.map((member, i) => (
           <GraphQLTypeCardListItem key={member.name} index={i}>
-            <div>{member.name}</div>
+            <GraphQLTypeAsLink
+              organizationSlug={props.organizationSlug}
+              projectSlug={props.projectSlug}
+              targetSlug={props.targetSlug}
+              className="text-neutral-11 font-semibold"
+              type={member.name}
+            />
+            {member.supergraphMetadata && (
+              <SupergraphMetadataList
+                targetSlug={props.targetSlug}
+                projectSlug={props.projectSlug}
+                organizationSlug={props.organizationSlug}
+                supergraphMetadata={member.supergraphMetadata}
+              />
+            )}
             {typeof props.totalRequests === 'number' && (
               <SchemaExplorerUsageStats
                 totalRequests={props.totalRequests}
@@ -54,14 +73,6 @@ export function GraphQLUnionTypeComponent(props: {
                 targetSlug={props.targetSlug}
                 projectSlug={props.projectSlug}
                 organizationSlug={props.organizationSlug}
-              />
-            )}
-            {member.supergraphMetadata && (
-              <SupergraphMetadataList
-                targetSlug={props.targetSlug}
-                projectSlug={props.projectSlug}
-                organizationSlug={props.organizationSlug}
-                supergraphMetadata={member.supergraphMetadata}
               />
             )}
           </GraphQLTypeCardListItem>


### PR DESCRIPTION
### Background

When testing something unrelated, I noticed unions are not displayed quite in the same way as the rest of our schema in the explorer pages.

### Description

This adds a link to the contained types and fixes the ordering of the columns for unions.

Before:

<img width="814" height="536" alt="Screenshot 2026-03-09 at 10 38 08 AM" src="https://github.com/user-attachments/assets/1045603e-ffc0-4ed3-ae67-4ae49874b5a5" />


After:
<img width="1219" height="516" alt="Screenshot 2026-03-09 at 10 23 38 AM" src="https://github.com/user-attachments/assets/3ee1536e-5b5b-45ea-beb6-6e6007da9b1f" />
