### PR TITLE
Improve performance of ClickHouse queries in Traces

### DIFF
--- a/packages/services/api/src/modules/operations/providers/traces.ts
+++ b/packages/services/api/src/modules/operations/providers/traces.ts
@@ -45,7 +45,7 @@ export class Traces {
           SELECT
             min("Start") AS start_ts,
             max("End") AS end_ts
-          FROM otel_traces_trace_id_ts
+          FROM "otel_traces_trace_id_ts"
           WHERE "TraceId" IN (${sql.array(traceIds, 'String')})
         )
         SELECT


### PR DESCRIPTION
Elapsed: 4.582s vs 0.114s
Read: 214,312 rows (30.75 MB) vs 32,768 rows (13.51 MB)

and

Elapsed: 0.914s vs 0.105s
Read: 14,335,288 rows (577.67 MB) vs 24,576 rows (3.25 MB)