### PR TITLE
fix: schema contract composition applying `@inaccessible` on the federation types `ContextArgument` and `FieldValue` on the supergraph SDL

### DIFF
--- a/.changeset/deep-lies-happen.md
+++ b/.changeset/deep-lies-happen.md
@@ -1,0 +1,13 @@
+---
+'hive': patch
+---
+
+Fix schema contract composition applying `@inaccessible` on the federation types `ContextArgument` and `FieldValue` on the supergraph SDL.
+
+This mitigates the following error in apollo-router upon processing the supergraph:
+
+```
+could not create router: Api error(s): The supergraph schema failed to produce a valid API schema: The following errors occurred:
+  - Core feature type `join__ContextArgument` cannot use @inaccessible.
+  - Core feature type `join__FieldValue` cannot use @inaccessible.
+```

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -25,7 +25,7 @@
     "@hive/server": "workspace:*",
     "@hive/service-common": "workspace:*",
     "@hive/storage": "workspace:*",
-    "@theguild/federation-composition": "0.22.1",
+    "@theguild/federation-composition": "0.22.2",
     "@trpc/client": "10.45.3",
     "@trpc/server": "10.45.3",
     "@types/async-retry": "1.4.8",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@sentry/cli": "2.40.0",
     "@swc/core": "1.13.5",
     "@theguild/eslint-config": "0.12.1",
-    "@theguild/federation-composition": "0.22.1",
+    "@theguild/federation-composition": "0.22.2",
     "@theguild/prettier-config": "2.0.7",
     "@types/node": "24.12.2",
     "bob-the-bundler": "7.0.1",

--- a/packages/libraries/cli/package.json
+++ b/packages/libraries/cli/package.json
@@ -60,7 +60,7 @@
     "@oclif/core": "3.26.6",
     "@oclif/plugin-help": "6.2.36",
     "@oclif/plugin-update": "4.7.16",
-    "@theguild/federation-composition": "0.22.1",
+    "@theguild/federation-composition": "0.22.2",
     "cli-table3": "0.6.5",
     "colors": "1.4.0",
     "env-ci": "7.3.0",

--- a/packages/services/api/package.json
+++ b/packages/services/api/package.json
@@ -42,7 +42,7 @@
     "@sentry/node": "7.120.2",
     "@sentry/types": "7.120.2",
     "@slack/web-api": "7.10.0",
-    "@theguild/federation-composition": "0.22.1",
+    "@theguild/federation-composition": "0.22.2",
     "@trpc/client": "10.45.3",
     "@trpc/server": "10.45.3",
     "@types/bcryptjs": "2.4.6",

--- a/packages/services/demo/federation/package.json
+++ b/packages/services/demo/federation/package.json
@@ -7,7 +7,7 @@
   },
   "dependencies": {
     "@apollo/subgraph": "2.13.2",
-    "@theguild/federation-composition": "0.22.1",
+    "@theguild/federation-composition": "0.22.2",
     "graphql": "16.9.0",
     "graphql-yoga": "5.13.3"
   },

--- a/packages/services/schema/package.json
+++ b/packages/services/schema/package.json
@@ -15,7 +15,7 @@
     "@graphql-tools/stitching-directives": "3.1.38",
     "@hive/service-common": "workspace:*",
     "@sentry/node": "7.120.2",
-    "@theguild/federation-composition": "0.22.1",
+    "@theguild/federation-composition": "0.22.2",
     "@trpc/server": "10.45.3",
     "@types/async-retry": "1.4.8",
     "@types/ioredis-mock": "8.2.5",

--- a/packages/services/server/package.json
+++ b/packages/services/server/package.json
@@ -39,7 +39,7 @@
     "@hive/workflows": "workspace:*",
     "@sentry/node": "7.120.2",
     "@swc/core": "1.13.5",
-    "@theguild/federation-composition": "0.22.1",
+    "@theguild/federation-composition": "0.22.2",
     "@trpc/client": "10.45.3",
     "@trpc/server": "10.45.3",
     "@whatwg-node/server": "0.10.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,8 +169,8 @@ importers:
         specifier: 0.12.1
         version: 0.12.1(eslint@8.57.1(patch_hash=08d9d41d21638cb74d0f9f34877a8839601a4e5a8263066ff23e7032addbcba0))(typescript@5.7.3)
       '@theguild/federation-composition':
-        specifier: 0.22.1
-        version: 0.22.1(graphql@16.9.0)
+        specifier: 0.22.2
+        version: 0.22.2(graphql@16.9.0)
       '@theguild/prettier-config':
         specifier: 2.0.7
         version: 2.0.7(prettier@3.4.2)
@@ -362,8 +362,8 @@ importers:
         specifier: workspace:*
         version: link:../packages/services/storage
       '@theguild/federation-composition':
-        specifier: 0.22.1
-        version: 0.22.1(graphql@16.9.0)
+        specifier: 0.22.2
+        version: 0.22.2(graphql@16.9.0)
       '@trpc/client':
         specifier: 10.45.3
         version: 10.45.3(@trpc/server@10.45.3)
@@ -539,8 +539,8 @@ importers:
         specifier: 4.7.16
         version: 4.7.16
       '@theguild/federation-composition':
-        specifier: 0.22.1
-        version: 0.22.1(graphql@16.9.0)
+        specifier: 0.22.2
+        version: 0.22.2(graphql@16.9.0)
       cli-table3:
         specifier: 0.6.5
         version: 0.6.5
@@ -1159,8 +1159,8 @@ importers:
         specifier: 7.10.0
         version: 7.10.0
       '@theguild/federation-composition':
-        specifier: 0.22.1
-        version: 0.22.1(graphql@16.9.0)
+        specifier: 0.22.2
+        version: 0.22.2(graphql@16.9.0)
       '@trpc/client':
         specifier: 10.45.3
         version: 10.45.3(@trpc/server@10.45.3)
@@ -1402,8 +1402,8 @@ importers:
         specifier: 2.13.2
         version: 2.13.2(graphql@16.9.0)
       '@theguild/federation-composition':
-        specifier: 0.22.1
-        version: 0.22.1(graphql@16.9.0)
+        specifier: 0.22.2
+        version: 0.22.2(graphql@16.9.0)
       graphql:
         specifier: 16.9.0
         version: 16.9.0
@@ -1508,8 +1508,8 @@ importers:
         specifier: 7.120.2
         version: 7.120.2
       '@theguild/federation-composition':
-        specifier: 0.22.1
-        version: 0.22.1(graphql@16.9.0)
+        specifier: 0.22.2
+        version: 0.22.2(graphql@16.9.0)
       '@trpc/server':
         specifier: 10.45.3
         version: 10.45.3
@@ -1640,8 +1640,8 @@ importers:
         specifier: 1.13.5
         version: 1.13.5
       '@theguild/federation-composition':
-        specifier: 0.22.1
-        version: 0.22.1(graphql@16.9.0)
+        specifier: 0.22.2
+        version: 0.22.2(graphql@16.9.0)
       '@trpc/client':
         specifier: 10.45.3
         version: 10.45.3(@trpc/server@10.45.3)
@@ -9831,8 +9831,8 @@ packages:
     peerDependencies:
       graphql: ^16.0.0
 
-  '@theguild/federation-composition@0.22.1':
-    resolution: {integrity: sha512-etGvmHP0nJk4vu9Y6Sw8Tfihaj78VLrk3UbinknjOi4DwzUhfhCPmQPZvOcvIIgUMdTOIDXkY+LAoKn7Fw6nBQ==}
+  '@theguild/federation-composition@0.22.2':
+    resolution: {integrity: sha512-V2xIRp4kAwKMEF5Ay2R6w2N/kwTe2BetOzfF19N0j6Cg/z7IlwUqEBbSEe6yIeFhVM5dOMor3TpamcMfHXIX7w==}
     engines: {node: '>=18'}
     peerDependencies:
       graphql: ^16.0.0
@@ -30776,7 +30776,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@theguild/federation-composition@0.22.1(graphql@16.9.0)':
+  '@theguild/federation-composition@0.22.2(graphql@16.9.0)':
     dependencies:
       constant-case: 3.0.4
       debug: 4.4.3(supports-color@8.1.1)


### PR DESCRIPTION
### Background

- https://github.com/graphql-hive/federation-composition/pull/295

### Description

Fix schema contract composition applying `@inaccessible` on the federation types `ContextArgument` and `FieldValue` on the supergraph SDL.

This mitigates the following error in apollo-router upon processing the supergraph:

```
could not create router: Api error(s): The supergraph schema failed to produce a valid API schema: The following errors occurred:
  - Core feature type `join__ContextArgument` cannot use @inaccessible.
  - Core feature type `join__FieldValue` cannot use @inaccessible.
```