### PR TITLE
fix(app-deployments): auto-inject MCP directive definitions during operation validation

### DIFF
--- a/integration-tests/tests/api/app-deployments.spec.ts
+++ b/integration-tests/tests/api/app-deployments.spec.ts
@@ -958,7 +958,7 @@ test('add documents to app deployment fails if document does not pass validation
   });
 });
 
-test('add documents to app deployment succeeds with MCP directives even when schema does not define them', async () => {
+test('app deployment validates documents with MCP directives when schema does not define them', async () => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject, setFeatureFlag } = await createOrg();
   await setFeatureFlag('appDeployments', true);
@@ -977,7 +977,7 @@ test('add documents to app deployment succeeds with MCP directives even when sch
     `,
   });
 
-  const { createAppDeployment } = await execute({
+  await execute({
     document: CreateAppDeployment,
     variables: {
       input: {
@@ -988,18 +988,6 @@ test('add documents to app deployment succeeds with MCP directives even when sch
     authToken: token.secret,
   }).then(res => res.expectNoGraphQLErrors());
 
-  expect(createAppDeployment).toEqual({
-    error: null,
-    ok: {
-      createdAppDeployment: {
-        id: expect.any(String),
-        name: 'mcp-test',
-        version: '1.0.0',
-        status: 'pending',
-      },
-    },
-  });
-
   const { addDocumentsToAppDeployment } = await execute({
     document: AddDocumentsToAppDeployment,
     variables: {
@@ -1009,7 +997,23 @@ test('add documents to app deployment succeeds with MCP directives even when sch
         documents: [
           {
             hash: 'mcp-weather',
-            body: 'query GetWeather($location: String! @mcpDescription(provider: "langfuse:loc")) @mcpTool(name: "get_weather", description: "Get weather") { weather(location: $location) { temp conditions } }',
+            body: [
+              'query GetWeather(',
+              '  $location: String! @mcpDescription(provider: "langfuse:loc") @mcpHeader(name: "X-Location")',
+              ') @mcpTool(name: "get_weather", description: "Get weather") {',
+              '  weather(location: $location) { temp conditions }',
+              '}',
+            ].join('\n'),
+          },
+          {
+            hash: 'mcp-weather-title',
+            body: [
+              'query GetWeatherTitle(',
+              '  $location: String! @mcpDescription(provider: "langfuse:loc")',
+              ') @mcpTool(name: "get_weather_title", title: "Weather Tool", meta: "{}") {',
+              '  weather(location: $location) { temp conditions }',
+              '}',
+            ].join('\n'),
           },
         ],
       },
@@ -1017,20 +1021,10 @@ test('add documents to app deployment succeeds with MCP directives even when sch
     authToken: token.secret,
   }).then(res => res.expectNoGraphQLErrors());
 
-  expect(addDocumentsToAppDeployment).toEqual({
-    error: null,
-    ok: {
-      appDeployment: {
-        id: expect.any(String),
-        name: 'mcp-test',
-        version: '1.0.0',
-        status: 'pending',
-      },
-    },
-  });
+  expect(addDocumentsToAppDeployment.error).toBeNull();
 });
 
-test('add documents to app deployment succeeds with MCP directives when schema already defines them', async () => {
+test('app deployment validates documents with MCP directives when schema already defines them', async () => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject, setFeatureFlag } = await createOrg();
   await setFeatureFlag('appDeployments', true);
@@ -1039,6 +1033,7 @@ test('add documents to app deployment succeeds with MCP directives when schema a
 
   await token.publishSchema({
     sdl: /* GraphQL */ `
+      scalar JSON
       directive @mcpTool(name: String!, description: String) on QUERY | MUTATION
       directive @mcpDescription(provider: String!) on VARIABLE_DEFINITION | FIELD
       directive @mcpHeader(name: String!) on VARIABLE_DEFINITION
@@ -1052,7 +1047,7 @@ test('add documents to app deployment succeeds with MCP directives when schema a
     `,
   });
 
-  const { createAppDeployment } = await execute({
+  await execute({
     document: CreateAppDeployment,
     variables: {
       input: {
@@ -1063,19 +1058,7 @@ test('add documents to app deployment succeeds with MCP directives when schema a
     authToken: token.secret,
   }).then(res => res.expectNoGraphQLErrors());
 
-  expect(createAppDeployment).toEqual({
-    error: null,
-    ok: {
-      createdAppDeployment: {
-        id: expect.any(String),
-        name: 'mcp-existing',
-        version: '1.0.0',
-        status: 'pending',
-      },
-    },
-  });
-
-  const { addDocumentsToAppDeployment } = await execute({
+  const { addDocumentsToAppDeployment: successResult } = await execute({
     document: AddDocumentsToAppDeployment,
     variables: {
       input: {
@@ -1084,7 +1067,13 @@ test('add documents to app deployment succeeds with MCP directives when schema a
         documents: [
           {
             hash: 'mcp-weather-existing',
-            body: 'query GetWeather($location: String! @mcpDescription(provider: "langfuse:loc")) @mcpTool(name: "get_weather", description: "Get weather") { weather(location: $location) { temp conditions } }',
+            body: [
+              'query GetWeather(',
+              '  $location: String! @mcpDescription(provider: "langfuse:loc")',
+              ') @mcpTool(name: "get_weather", description: "Get weather") {',
+              '  weather(location: $location) { temp conditions }',
+              '}',
+            ].join('\n'),
           },
         ],
       },
@@ -1092,17 +1081,96 @@ test('add documents to app deployment succeeds with MCP directives when schema a
     authToken: token.secret,
   }).then(res => res.expectNoGraphQLErrors());
 
-  expect(addDocumentsToAppDeployment).toEqual({
-    error: null,
-    ok: {
-      appDeployment: {
-        id: expect.any(String),
-        name: 'mcp-existing',
-        version: '1.0.0',
-        status: 'pending',
+  expect(successResult.error).toBeNull();
+
+  const { addDocumentsToAppDeployment: failResult } = await execute({
+    document: AddDocumentsToAppDeployment,
+    variables: {
+      input: {
+        appName: 'mcp-existing',
+        appVersion: '1.0.0',
+        documents: [
+          {
+            hash: 'mcp-weather-title',
+            body: [
+              'query GetWeather(',
+              '  $location: String! @mcpDescription(provider: "langfuse:loc")',
+              ') @mcpTool(name: "get_weather", title: "Weather Tool") {',
+              '  weather(location: $location) { temp conditions }',
+              '}',
+            ].join('\n'),
+          },
+        ],
       },
     },
+    authToken: token.secret,
+  }).then(res => res.expectNoGraphQLErrors());
+
+  expect(failResult.error).toEqual(
+    expect.objectContaining({
+      message: expect.stringContaining('not valid'),
+      details: expect.objectContaining({
+        message: expect.stringContaining('title'),
+      }),
+    }),
+  );
+});
+
+test('app deployment injects only missing MCP directives when schema partially defines them', async () => {
+  const { createOrg } = await initSeed().createOwner();
+  const { createProject, setFeatureFlag } = await createOrg();
+  await setFeatureFlag('appDeployments', true);
+  const { createTargetAccessToken } = await createProject();
+  const token = await createTargetAccessToken({});
+
+  await token.publishSchema({
+    sdl: /* GraphQL */ `
+      directive @mcpTool(name: String!, description: String) on QUERY | MUTATION
+      type Query {
+        weather(location: String!): Weather
+      }
+      type Weather {
+        temp: Float
+        conditions: String
+      }
+    `,
   });
+
+  await execute({
+    document: CreateAppDeployment,
+    variables: {
+      input: {
+        appName: 'mcp-partial',
+        appVersion: '1.0.0',
+      },
+    },
+    authToken: token.secret,
+  }).then(res => res.expectNoGraphQLErrors());
+
+  const { addDocumentsToAppDeployment } = await execute({
+    document: AddDocumentsToAppDeployment,
+    variables: {
+      input: {
+        appName: 'mcp-partial',
+        appVersion: '1.0.0',
+        documents: [
+          {
+            hash: 'mcp-partial-weather',
+            body: [
+              'query GetWeather(',
+              '  $location: String! @mcpDescription(provider: "langfuse:loc")',
+              ') @mcpTool(name: "get_weather", description: "Get weather") {',
+              '  weather(location: $location) { temp conditions }',
+              '}',
+            ].join('\n'),
+          },
+        ],
+      },
+    },
+    authToken: token.secret,
+  }).then(res => res.expectNoGraphQLErrors());
+
+  expect(addDocumentsToAppDeployment.error).toBeNull();
 });
 
 test('add documents to app deployment fails if document contains multiple executable operation definitions', async () => {

--- a/integration-tests/tests/api/app-deployments.spec.ts
+++ b/integration-tests/tests/api/app-deployments.spec.ts
@@ -958,6 +958,153 @@ test('add documents to app deployment fails if document does not pass validation
   });
 });
 
+test('add documents to app deployment succeeds with MCP directives even when schema does not define them', async () => {
+  const { createOrg } = await initSeed().createOwner();
+  const { createProject, setFeatureFlag } = await createOrg();
+  await setFeatureFlag('appDeployments', true);
+  const { createTargetAccessToken } = await createProject();
+  const token = await createTargetAccessToken({});
+
+  await token.publishSchema({
+    sdl: /* GraphQL */ `
+      type Query {
+        weather(location: String!): Weather
+      }
+      type Weather {
+        temp: Float
+        conditions: String
+      }
+    `,
+  });
+
+  const { createAppDeployment } = await execute({
+    document: CreateAppDeployment,
+    variables: {
+      input: {
+        appName: 'mcp-test',
+        appVersion: '1.0.0',
+      },
+    },
+    authToken: token.secret,
+  }).then(res => res.expectNoGraphQLErrors());
+
+  expect(createAppDeployment).toEqual({
+    error: null,
+    ok: {
+      createdAppDeployment: {
+        id: expect.any(String),
+        name: 'mcp-test',
+        version: '1.0.0',
+        status: 'pending',
+      },
+    },
+  });
+
+  const { addDocumentsToAppDeployment } = await execute({
+    document: AddDocumentsToAppDeployment,
+    variables: {
+      input: {
+        appName: 'mcp-test',
+        appVersion: '1.0.0',
+        documents: [
+          {
+            hash: 'mcp-weather',
+            body: 'query GetWeather($location: String! @mcpDescription(provider: "langfuse:loc")) @mcpTool(name: "get_weather", description: "Get weather") { weather(location: $location) { temp conditions } }',
+          },
+        ],
+      },
+    },
+    authToken: token.secret,
+  }).then(res => res.expectNoGraphQLErrors());
+
+  expect(addDocumentsToAppDeployment).toEqual({
+    error: null,
+    ok: {
+      appDeployment: {
+        id: expect.any(String),
+        name: 'mcp-test',
+        version: '1.0.0',
+        status: 'pending',
+      },
+    },
+  });
+});
+
+test('add documents to app deployment succeeds with MCP directives when schema already defines them', async () => {
+  const { createOrg } = await initSeed().createOwner();
+  const { createProject, setFeatureFlag } = await createOrg();
+  await setFeatureFlag('appDeployments', true);
+  const { createTargetAccessToken } = await createProject();
+  const token = await createTargetAccessToken({});
+
+  await token.publishSchema({
+    sdl: /* GraphQL */ `
+      directive @mcpTool(name: String!, description: String) on QUERY | MUTATION
+      directive @mcpDescription(provider: String!) on VARIABLE_DEFINITION | FIELD
+      directive @mcpHeader(name: String!) on VARIABLE_DEFINITION
+      type Query {
+        weather(location: String!): Weather
+      }
+      type Weather {
+        temp: Float
+        conditions: String
+      }
+    `,
+  });
+
+  const { createAppDeployment } = await execute({
+    document: CreateAppDeployment,
+    variables: {
+      input: {
+        appName: 'mcp-existing',
+        appVersion: '1.0.0',
+      },
+    },
+    authToken: token.secret,
+  }).then(res => res.expectNoGraphQLErrors());
+
+  expect(createAppDeployment).toEqual({
+    error: null,
+    ok: {
+      createdAppDeployment: {
+        id: expect.any(String),
+        name: 'mcp-existing',
+        version: '1.0.0',
+        status: 'pending',
+      },
+    },
+  });
+
+  const { addDocumentsToAppDeployment } = await execute({
+    document: AddDocumentsToAppDeployment,
+    variables: {
+      input: {
+        appName: 'mcp-existing',
+        appVersion: '1.0.0',
+        documents: [
+          {
+            hash: 'mcp-weather-existing',
+            body: 'query GetWeather($location: String! @mcpDescription(provider: "langfuse:loc")) @mcpTool(name: "get_weather", description: "Get weather") { weather(location: $location) { temp conditions } }',
+          },
+        ],
+      },
+    },
+    authToken: token.secret,
+  }).then(res => res.expectNoGraphQLErrors());
+
+  expect(addDocumentsToAppDeployment).toEqual({
+    error: null,
+    ok: {
+      appDeployment: {
+        id: expect.any(String),
+        name: 'mcp-existing',
+        version: '1.0.0',
+        status: 'pending',
+      },
+    },
+  });
+});
+
 test('add documents to app deployment fails if document contains multiple executable operation definitions', async () => {
   const { createOrg } = await initSeed().createOwner();
   const { createProject, setFeatureFlag } = await createOrg();

--- a/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
@@ -47,11 +47,11 @@ const MCP_DIRECTIVES_DOC = parse(/* GraphQL */ `
     description: String
     title: String
     descriptionProvider: String
-    meta: JSON
+    meta: _HiveMCPJSON
   ) on QUERY | MUTATION
   directive @mcpDescription(provider: String!) on VARIABLE_DEFINITION | FIELD
   directive @mcpHeader(name: String!) on VARIABLE_DEFINITION
-  scalar JSON
+  scalar _HiveMCPJSON
 `);
 
 /**

--- a/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
@@ -30,6 +30,28 @@ const AppDeploymentOperationHashModel = z
 
 const AppDeploymentOperationBodyModel = z.string().min(3, 'Body must be at least 3 character long');
 
+const MCP_DIRECTIVES_SDL = /* GraphQL */ `
+  directive @mcpTool(name: String!, description: String, title: String, descriptionProvider: String, meta: JSON) on QUERY | MUTATION
+  directive @mcpDescription(provider: String!) on VARIABLE_DEFINITION | FIELD
+  directive @mcpHeader(name: String!) on VARIABLE_DEFINITION
+`;
+
+function appendMcpDirectives(schemaSdl: string): string {
+  // Strip any existing MCP directive definitions (they may have outdated arguments)
+  let result = schemaSdl
+    .replace(/^[ \t]*directive @mcpTool\b.*$/gm, '')
+    .replace(/^[ \t]*directive @mcpDescription\b.*$/gm, '')
+    .replace(/^[ \t]*directive @mcpHeader\b.*$/gm, '');
+
+  result += MCP_DIRECTIVES_SDL;
+
+  if (!/\bscalar JSON\b/.test(result)) {
+    result += '\nscalar JSON';
+  }
+
+  return result;
+}
+
 export type BatchProcessEvent = {
   event: 'PROCESS';
   id: string;
@@ -107,7 +129,8 @@ export class PersistedDocumentIngester {
       data.documents.length,
     );
 
-    const schema = buildSchema(data.schemaSdl);
+    const schemaSdl = appendMcpDirectives(data.schemaSdl);
+    const schema = buildSchema(schemaSdl);
     const typeInfo = new TypeInfo(schema);
     const documents: Array<DocumentRecord> = [];
 

--- a/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
@@ -45,7 +45,7 @@ function appendMcpDirectives(schemaSdl: string): string {
 
   result += MCP_DIRECTIVES_SDL;
 
-  if (!/\bscalar JSON\b/.test(result)) {
+  if (!/(^|\n)\s*scalar\s+JSON\b/.test(result)) {
     result += '\nscalar JSON';
   }
 

--- a/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
@@ -1,4 +1,13 @@
-import { buildSchema, DocumentNode, GraphQLError, Kind, parse, TypeInfo, validate } from 'graphql';
+import {
+  buildSchema,
+  DocumentNode,
+  GraphQLError,
+  Kind,
+  parse,
+  print,
+  TypeInfo,
+  validate,
+} from 'graphql';
 import PromiseQueue from 'p-queue';
 import { z } from 'zod';
 import { collectSchemaCoordinates, preprocessOperation } from '@graphql-hive/core';
@@ -30,7 +39,7 @@ const AppDeploymentOperationHashModel = z
 
 const AppDeploymentOperationBodyModel = z.string().min(3, 'Body must be at least 3 character long');
 
-const MCP_DIRECTIVES_SDL = /* GraphQL */ `
+const MCP_DIRECTIVES_DOC = parse(/* GraphQL */ `
   directive @mcpTool(
     name: String!
     description: String
@@ -40,22 +49,44 @@ const MCP_DIRECTIVES_SDL = /* GraphQL */ `
   ) on QUERY | MUTATION
   directive @mcpDescription(provider: String!) on VARIABLE_DEFINITION | FIELD
   directive @mcpHeader(name: String!) on VARIABLE_DEFINITION
-`;
+  scalar JSON
+`);
 
-function appendMcpDirectives(schemaSdl: string): string {
-  // Strip any existing MCP directive definitions (they may have outdated arguments)
-  let result = schemaSdl
-    .replace(/^[ \t]*directive @mcpTool\b.*$/gm, '')
-    .replace(/^[ \t]*directive @mcpDescription\b.*$/gm, '')
-    .replace(/^[ \t]*directive @mcpHeader\b.*$/gm, '');
+/**
+ * Persisted operation documents may use MCP directives (`@mcpTool`, `@mcpDescription`,
+ * `@mcpHeader`) and the `JSON` scalar (`@mcpTool`'s `meta` arg) that are not part of the
+ * user's schema. We inject any missing definitions so that `validate()` does not reject
+ * the documents for unknown directives or types.
+ *
+ * Only definitions absent from the SDL are added, when the user already defines an MCP
+ * directive (e.g. with a narrower arg set), their definition takes precedence.
+ */
+function injectMcpDirectives(schemaSdl: string): string {
+  const schemaDoc = parse(schemaSdl);
 
-  result += MCP_DIRECTIVES_SDL;
-
-  if (!/(^|\n)\s*scalar\s+JSON\b/.test(result)) {
-    result += '\nscalar JSON';
+  const existingNames = new Set<string>();
+  for (const def of schemaDoc.definitions) {
+    if (
+      def.kind === Kind.DIRECTIVE_DEFINITION ||
+      def.kind === Kind.SCALAR_TYPE_DEFINITION ||
+      def.kind === Kind.SCALAR_TYPE_EXTENSION
+    ) {
+      existingNames.add(def.name.value);
+    }
   }
 
-  return result;
+  const missing = MCP_DIRECTIVES_DOC.definitions.filter(def => {
+    if (def.kind === Kind.DIRECTIVE_DEFINITION || def.kind === Kind.SCALAR_TYPE_DEFINITION) {
+      return !existingNames.has(def.name.value);
+    }
+    return false;
+  });
+
+  if (missing.length === 0) {
+    return schemaSdl;
+  }
+
+  return schemaSdl + '\n' + print({ ...MCP_DIRECTIVES_DOC, definitions: missing });
 }
 
 export type BatchProcessEvent = {
@@ -135,7 +166,7 @@ export class PersistedDocumentIngester {
       data.documents.length,
     );
 
-    const schemaSdl = appendMcpDirectives(data.schemaSdl);
+    const schemaSdl = injectMcpDirectives(data.schemaSdl);
     const schema = buildSchema(schemaSdl);
     const typeInfo = new TypeInfo(schema);
     const documents: Array<DocumentRecord> = [];

--- a/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
@@ -31,7 +31,13 @@ const AppDeploymentOperationHashModel = z
 const AppDeploymentOperationBodyModel = z.string().min(3, 'Body must be at least 3 character long');
 
 const MCP_DIRECTIVES_SDL = /* GraphQL */ `
-  directive @mcpTool(name: String!, description: String, title: String, descriptionProvider: String, meta: JSON) on QUERY | MUTATION
+  directive @mcpTool(
+    name: String!
+    description: String
+    title: String
+    descriptionProvider: String
+    meta: JSON
+  ) on QUERY | MUTATION
   directive @mcpDescription(provider: String!) on VARIABLE_DEFINITION | FIELD
   directive @mcpHeader(name: String!) on VARIABLE_DEFINITION
 `;

--- a/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
+++ b/packages/services/api/src/modules/app-deployments/providers/persisted-document-ingester.ts
@@ -1,10 +1,12 @@
 import {
   buildSchema,
+  DirectiveDefinitionNode,
   DocumentNode,
   GraphQLError,
   Kind,
   parse,
   print,
+  ScalarTypeDefinitionNode,
   TypeInfo,
   validate,
 } from 'graphql';
@@ -54,30 +56,34 @@ const MCP_DIRECTIVES_DOC = parse(/* GraphQL */ `
 
 /**
  * Persisted operation documents may use MCP directives (`@mcpTool`, `@mcpDescription`,
- * `@mcpHeader`) and the `JSON` scalar (`@mcpTool`'s `meta` arg) that are not part of the
- * user's schema. We inject any missing definitions so that `validate()` does not reject
- * the documents for unknown directives or types.
+ * `@mcpHeader`) and the `JSON` scalar that may not be part of the user's schema.
+ * We inject any missing definitions so that `validate()` does not reject the documents
+ * for unknown directives or types.
  *
- * Only definitions absent from the SDL are added, when the user already defines an MCP
+ * Only definitions absent from the SDL are added. When the user already defines an MCP
  * directive (e.g. with a narrower arg set), their definition takes precedence.
  */
 function injectMcpDirectives(schemaSdl: string): string {
   const schemaDoc = parse(schemaSdl);
 
-  const existingNames = new Set<string>();
+  const mcpNames = new Set(
+    MCP_DIRECTIVES_DOC.definitions
+      .filter(
+        (def): def is DirectiveDefinitionNode | ScalarTypeDefinitionNode =>
+          def.kind === Kind.DIRECTIVE_DEFINITION || def.kind === Kind.SCALAR_TYPE_DEFINITION,
+      )
+      .map(def => def.name.value),
+  );
+
   for (const def of schemaDoc.definitions) {
-    if (
-      def.kind === Kind.DIRECTIVE_DEFINITION ||
-      def.kind === Kind.SCALAR_TYPE_DEFINITION ||
-      def.kind === Kind.SCALAR_TYPE_EXTENSION
-    ) {
-      existingNames.add(def.name.value);
+    if ('name' in def && def.name && mcpNames.has(def.name.value)) {
+      mcpNames.delete(def.name.value);
     }
   }
 
   const missing = MCP_DIRECTIVES_DOC.definitions.filter(def => {
     if (def.kind === Kind.DIRECTIVE_DEFINITION || def.kind === Kind.SCALAR_TYPE_DEFINITION) {
-      return !existingNames.has(def.name.value);
+      return mcpNames.has(def.name.value);
     }
     return false;
   });
@@ -86,7 +92,7 @@ function injectMcpDirectives(schemaSdl: string): string {
     return schemaSdl;
   }
 
-  return schemaSdl + '\n' + print({ ...MCP_DIRECTIVES_DOC, definitions: missing });
+  return schemaSdl + '\n' + print({ kind: Kind.DOCUMENT, definitions: missing });
 }
 
 export type BatchProcessEvent = {


### PR DESCRIPTION
### Summary

When pushing persisted operations that use MCP directives (`@mcpTool`, `@mcpDescription`, `@mcpHeader`) via app deployments, validation fails because the target schema doesn't define these directives. Users shouldn't need to manually add MCP directive definitions to their schema just to use them in operations, the gateway plugin handles them at runtime.

This fix auto-injects the canonical MCP directive definitions into the schema used for validation in the persisted document ingester. It strips any existing (potentially outdated) definitions first, then appends the current ones.


### Changes made
- Purely additive: collects existing directive and scalar names from the AST, then only injects definitions that are missing. User-defined `@mcpTool` (via `@composeDirective`, `@link`, etc.) is left untouched.
- No-op fast path: if all directives already exist, returns the original SDL string unchanged (no parse-print round-trip on the schema).
- `MCP_DIRECTIVES_DOC` parsed once at module load, avoids re-parsing the constant SDL on every batch.

### Tests added
- add documents to app deployment succeeds with MCP directives even when schema does not define them
- add documents to app deployment succeeds with MCP directives when schema already defines them