### PR TITLE
fix: ensure vars as passed through turbo

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -13,7 +13,8 @@
   "tasks": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**"]
+      "outputs": ["dist/**"],
+      "passThroughEnv": ["SENTRY_AUTH_TOKEN", "SENTRY_ORG", "SENTRY_PROJECT", "RELEASE"]
     },
     "check:build": {
       "outputs": [""]

--- a/turbo.json
+++ b/turbo.json
@@ -14,7 +14,8 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**"],
-      "passThroughEnv": ["SENTRY_AUTH_TOKEN", "SENTRY_ORG", "SENTRY_PROJECT", "RELEASE"]
+      "env": ["SENTRY_ORG", "SENTRY_PROJECT", "RELEASE"],
+      "passThroughEnv": ["SENTRY_AUTH_TOKEN"]
     },
     "check:build": {
       "outputs": [""]


### PR DESCRIPTION
This PR fixes the Sentry Vite plugin silently skipping sourcemap uploads by adding `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`, and `RELEASE` to the build task's passThroughEnv in `turbo.json`. Even though these env vars are set in the CI workflow, Turborepo sanitizes subprocess environments by default for cache determinism — so the Vite plugin never saw the auth token and skipped upload. With this change, the plugin can actually upload client sourcemaps tagged with `dist: webapp`.