### PR TITLE
restore GraphQL syntax highlighting across Monaco editors

### DIFF
--- a/packages/web/app/src/components/schema-editor.ts
+++ b/packages/web/app/src/components/schema-editor.ts
@@ -9,6 +9,10 @@ import 'monaco-editor/esm/vs/editor/contrib/readOnlyMessage/browser/contribution
 // Registers the basic GraphQL Monarch tokenizer so `language="graphql"` models
 // get syntax highlighting. Without this, `editor.api` ships no languages.
 import 'monaco-editor/esm/vs/basic-languages/graphql/graphql.contribution.js';
+// Registers the JSON language service (`monaco.languages.json`) — required by
+// the policy naming-convention rule editor, which configures JSON schema
+// diagnostics in `beforeMount`.
+import 'monaco-editor/esm/vs/language/json/monaco.contribution.js';
 import {
   loader,
   DiffEditor as MonacoDiffEditor,

--- a/packages/web/app/src/components/schema-editor.ts
+++ b/packages/web/app/src/components/schema-editor.ts
@@ -8,7 +8,7 @@ import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import 'monaco-editor/esm/vs/editor/contrib/readOnlyMessage/browser/contribution.js';
 // Registers the basic GraphQL Monarch tokenizer so `language="graphql"` models
 // get syntax highlighting. Without this, `editor.api` ships no languages.
-import 'monaco-editor/esm/vs/basic-languages/graphql/graphql.contribution';
+import 'monaco-editor/esm/vs/basic-languages/graphql/graphql.contribution.js';
 import {
   loader,
   DiffEditor as MonacoDiffEditor,

--- a/packages/web/app/src/components/schema-editor.ts
+++ b/packages/web/app/src/components/schema-editor.ts
@@ -1,6 +1,14 @@
 import { lazy } from 'react';
+// Import from `editor.api` rather than the `monaco-editor` main entry to keep
+// the bundle lean — the main entry auto-registers every basic language, which
+// bloats our client sourcemaps. We opt in to the contributions we actually use
+// via the side-effect imports below.
 import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
+// Enables the read-only tooltip shown when users type into a read-only model.
 import 'monaco-editor/esm/vs/editor/contrib/readOnlyMessage/browser/contribution.js';
+// Registers the basic GraphQL Monarch tokenizer so `language="graphql"` models
+// get syntax highlighting. Without this, `editor.api` ships no languages.
+import 'monaco-editor/esm/vs/basic-languages/graphql/graphql.contribution';
 import {
   loader,
   DiffEditor as MonacoDiffEditor,

--- a/packages/web/app/src/lib/preflight/graphiql-plugin.tsx
+++ b/packages/web/app/src/lib/preflight/graphiql-plugin.tsx
@@ -660,7 +660,11 @@ function PreflightModal({
   }, []);
 
   const handleMonacoEditorBeforeMount = useCallback(async (monaco: Monaco) => {
-    if (monaco.languages.typescript) {
+    // Lazy-load the TS language service on first preflight mount if it hasn't
+    // already been registered. `schema-editor.ts` configures Monaco with the
+    // lean `editor.api` entry (no languages bundled), so `monaco.languages
+    // .typescript` is only defined after this side-effect import has run.
+    if (!monaco.languages.typescript) {
       await import('monaco-editor/esm/vs/language/typescript/monaco.contribution');
     }
 


### PR DESCRIPTION
This PR restores necessary language services across Monaco editors (Schema page, schema diff, proposals), which regressed after #7952 switched Monaco imports to the leaner `monaco-editor/esm/vs/editor/editor.api` entry to trim our client sourcemaps.

The `editor.api` entry ships the editor runtime only, it does not auto-register any basic languages, so `language="graphql"` models rendered as plaintext. Rather than revert to the full main entry (and pull every basic language back into the bundle), this keeps the lean import and opts in explicitly to just the GraphQL Monarch tokenizer via a side-effect import of `monaco-editor/esm/vs/basic-languages/graphql/graphql.contribution` in `schema-editor.ts`, which is where the shared Monaco instance is wired into `@monaco-editor/react`.

Comments were added to `schema-editor.ts` documenting why we import from `editor.api` and what each contribution side-effect import is responsible for.